### PR TITLE
ci: swap non-functional Playwright E2E for headless unit suite

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -11,26 +11,26 @@ jobs:
   quality-checks:
     name: Quality Checks
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
+
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
-      
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: '22.15.1'
         cache: 'pnpm'
-        
+
     - name: Install dependencies
       run: pnpm install
-      
+
     - name: Run type checking
       run: pnpm typecheck
-      
+
     - name: Run linting
       run: pnpm lint
 
@@ -38,98 +38,37 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     needs: quality-checks
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
+
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
-      
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: '22.15.1'
         cache: 'pnpm'
-        
+
     - name: Install dependencies
       run: pnpm install
 
-    # Cache native modules to speed up rebuilds
-    - name: Cache native modules
-      uses: actions/cache@v4
-      with:
-        path: |
-          main/node_modules/.bin
-          main/build
-          ~/.electron
-          ~/.electron-gyp
-        key: ${{ runner.os }}-native-modules-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-native-modules-
-      
-    - name: Cache Electron binaries
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cache/electron
-          ~/.cache/electron-builder
-        key: ${{ runner.os }}-electron-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-electron-
-      
-    # Build frontend and main process in parallel for faster builds
-    - name: Build application components
-      run: |
-        # Build both frontend and main process concurrently
-        pnpm run build:frontend &
-        pnpm run build:main &
-        wait
-        
-    - name: Rebuild native modules
-      run: pnpm run electron:rebuild
-      
-    - name: Setup display for Electron
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get install -y --no-install-recommends xvfb
-        export DISPLAY=:99
-        sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
-      
-    - name: Cache Playwright browsers
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-playwright-
-      
-    - name: Install Playwright browsers
-      run: pnpm exec playwright install --with-deps chromium
-      
-    - name: Configure git for tests
-      run: |
-        git config --global init.defaultBranch main
-        git config --global user.email "test@example.com"
-        git config --global user.name "Test User"
-      
-    - name: Run tests
-      run: |
-        export DISPLAY=:99
-        # Using minimal test suite until permission tests are fixed
-        # See: https://github.com/stravu/crystal/issues/XXX
-        pnpm test:ci:minimal
+    # The root `postinstall` (electron-builder install-app-deps) rebuilds
+    # better-sqlite3 against the Electron ABI. The unit suite runs under host
+    # Node (vitest), so restore the host-Node ABI or main DB tests throw
+    # NODE_MODULE_VERSION mismatches. See CLAUDE.md.
+    - name: Rebuild better-sqlite3 for host Node ABI
+      run: pnpm rebuild better-sqlite3
+
+    # Headless unit chain (main + frontend vitest, schema parity, build scripts).
+    # The Playwright E2E suite is intentionally excluded: the renderer cannot
+    # bootstrap in CI without the Electron preload-injected electronTRPC bridge,
+    # so it fails on every run regardless of the change. See CLAUDE.md; re-add an
+    # E2E job once the Playwright config uses _electron.launch().
+    - name: Run unit tests
+      run: pnpm test:unit
       env:
         CI: true
-        ELECTRON_DISABLE_SANDBOX: 1
-      timeout-minutes: 5
-      
-    - name: Upload test artifacts
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: playwright-report
-        path: |
-          playwright-report/
-          test-results/
-        retention-days: 7
+      timeout-minutes: 10


### PR DESCRIPTION
## Problem

The **Tests** job in `quality.yml` runs `pnpm test:ci:minimal`, which drives the renderer in a plain **Chromium tab** at `localhost:4521`. The renderer cannot bootstrap there without the Electron `preload`-injected `electronTRPC` bridge, so all 4 smoke/health-check specs time out:

```
✘ Health Check › Electron app should start          — waitForSelector timeout
✘ Smoke › Application should start successfully      — waitForSelector timeout
✘ Smoke › Main UI elements should be visible         — sidebar never visible
✘ Smoke › Settings button is clickable               — [data-testid="settings-button"] never visible
```

This job has failed on **every push to main regardless of the change** — a known environmental issue already documented in `CLAUDE.md`. Result: the red ❌ on every push is noise, not a real signal, and it masks genuine regressions.

## Change

Replace the Electron/Playwright machinery in the **Tests** job with `pnpm test:unit` — the documented headless AC gate:
- `main` vitest (912 tests) + `frontend` vitest (619 tests)
- schema parity (`verify:schema` + `verify-schema-parity.test.js`)
- build-script tests (`test:build`)

**1531 tests total, passes clean locally (exit 0).**

Also adds a `pnpm rebuild better-sqlite3` step so main DB tests run against the **host-Node ABI** (NMV 127) instead of the Electron ABI left by the `postinstall` (`electron-builder install-app-deps`) — per the CLAUDE.md note.

## Preserved

- Job id/name (`test` / **Tests**) and the `needs: quality-checks` gate are unchanged, so any required-status-check / branch-protection config still matches.
- **Quality Checks** job (typecheck + lint) is untouched — it was already passing.

## Follow-up (out of scope)

Re-introduce a real E2E job once the Playwright config is reworked to use `_electron.launch()` instead of a Chromium tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)