### PR TITLE
fix: grant pull-requests:read to the DCO check

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   DCO:


### PR DESCRIPTION
The DCO workflow declared `permissions: contents: read`, which (because explicit permissions zero out all unlisted scopes) left the GITHUB_TOKEN without `pull-requests: read` — so `pulls.listCommits` failed with `Resource not accessible by integration`. This grants the missing scope.

Also serves as end-to-end verification that the required checks (DCO, Quality Checks, Tests) fire on a PR.