### PR TITLE
perf: cut idle main-process CPU ~6x and streaming CPU ~5x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ shared/*.d.ts
 shared/*.d.ts.map
 .cyboflow/worktrees/
 frontend/dist-harness/
+
+# Perf profiling artifacts (scripts/profile-electron.mjs)
+.perf/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Agents in this repo usually run *inside* a cyboflow session while editing cybofl
 - `docs/cyboflow_system_design.md` — product spec and scope decisions.
 - `docs/RELEASE-RUNBOOK.md` + `docs/signing/APPLE_DEVELOPER_SETUP.md` — load before any build, packaging, or release task.
 - `docs/VISUAL-VERIFICATION-SETUP.md` — how to see/drive the UI (CDP attach on :9223 is the primary path; Peekaboo is the fallback, with TCC diagnostics).
+- `docs/PERFORMANCE.md` — the CPU/memory harness (`pnpm dev:perf`, `scripts/profile-electron.mjs`), baselines, and the measurement traps (main-process timer wakeups cost more than their callbacks; dev-mode renderer profiles are inflated by `jsxDEV`).
 - `docs/PROVENANCE.md` — fork lineage; standing rule: never merge or cherry-pick from Nimbalyst.
 - `docs/crystal-legacy/` and `docs/workflows-future/` — historical reference, not current truth.
 
@@ -33,6 +34,7 @@ Agents in this repo usually run *inside* a cyboflow session while editing cybofl
 
 ```bash
 pnpm dev               # Electron dev (run `pnpm build:main` at least once first)
+pnpm dev:perf          # dev + main-process perf tracer/timer census + --inspect (docs/PERFORMANCE.md)
 pnpm typecheck && pnpm lint
 pnpm test:unit         # THE headless AC gate — for a SETTLED tree, not per-change (see below)
 pnpm test:integration  # Mocked-SDK itest suite (required for panels/claude changes)

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,247 @@
+# Performance: measuring cyboflow
+
+How to measure cyboflow's CPU and memory, what the numbers mean, and the traps
+that make naive measurements wrong. Load this before doing perf work.
+
+## The one thing to know first
+
+**In the Electron MAIN process, a timer wakeup costs far more than the work it
+does.** Electron drives libuv from Chromium's CFRunLoop, so each fire is a
+`__CFRunLoopDoSources0 → uv_run → uv__run_timers → RunTimers` round trip, and
+re-arming a repeating timer adds a `uv__loop_interrupt` → `kevent` syscall.
+
+The consequence is counter-intuitive and it has already bitten this codebase
+once: V8's CPU profiler can report the main process at **0.1% busy** while the
+OS reports the process at **2%**, because the cost is in the wakeup machinery,
+not in the JS. So:
+
+- A steady `setInterval` in main is expensive **even when its callback does
+  nothing**. Prefer on-demand timers armed only while work is actually pending.
+- Never conclude "main is idle" from a V8 profile alone. Cross-check with the
+  OS (`ps -o cputime`) — see "Measuring honestly" below.
+
+## The harness
+
+```bash
+pnpm dev:perf        # dev + CYBOFLOW_PERF_TRACE=1 + --inspect=9229 (main-process V8 inspector)
+pnpm dev             # normal dev; renderer CDP on 9223 only
+```
+
+`pnpm dev:perf` turns on three things at once via one env var:
+
+| Instrument | Where | Output |
+|---|---|---|
+| `PerfTracer` (`main/src/services/perfTracer.ts`) | main | `[perf]` — event-loop utilization, process CPU%, event-loop delay, RSS/heap, seam counters |
+| `TimerCensus` (`main/src/services/timerCensus.ts`) | main | `[perf-timers]` — wakeups/sec attributed to the code that scheduled each timer |
+| `perfProbe` (`frontend/src/utils/perfProbe.ts`) | renderer | `[perf-r]` — long tasks + React commits per `<PerfProfiler id>` area |
+
+`[perf]` / `[perf-timers]` are `logger.info`, which goes to the dev server's
+**stdout**, not `cyboflow-backend-debug.log` (only WARN/ERROR are persisted to
+file). Redirect when launching: `pnpm dev:perf > /tmp/dev.log 2>&1`.
+
+Add a seam counter with `perfBump('name')` — free when tracing is off.
+
+### scripts/profile-electron.mjs
+
+Dependency-free CDP/inspector client. Needs a running dev app.
+
+```bash
+node scripts/profile-electron.mjs sample  --label idle --duration-ms 20000   # per-process CPU + DOM/heap counters
+node scripts/profile-electron.mjs cpu     --label idle --duration-ms 30000   # main-process V8 profile + self-time leaderboard
+node scripts/profile-electron.mjs cpu     --target renderer --click Insights # renderer profile while driving the UI
+node scripts/profile-electron.mjs heap    --label idle --duration-ms 40000   # allocation-site sampling (churn, not retention)
+node scripts/profile-electron.mjs handles --label idle                       # live libuv handle census
+node scripts/profile-electron.mjs inspect                                    # dump visible text + clickable controls
+```
+
+`cpu` writes the raw `.cpuprofile` to `.perf/` (git-ignored) — open it in Chrome
+DevTools → Performance for the flame graph.
+
+`cpu`, `heap`, and `handles` need `--inspect`, i.e. `pnpm dev:perf`.
+
+## Measuring honestly
+
+**Use a throwaway data dir.** `CYBOFLOW_DIR=/tmp/cyboflow-perf-profile pnpm dev`
+keeps measurements off your real backlog and gives a reproducible starting state.
+
+**The instrumentation is not free.** `--inspect` adds an inspector thread doing
+its own `uv__io_poll`, and the tracer/census add a 5s interval plus a captured
+stack per scheduled timer. Measured cost: roughly **+1% main-process CPU**. Use
+`pnpm dev:perf` to *find* a problem; quote final numbers from plain `pnpm dev`.
+
+**Always A/B against a control.** Absolute numbers mean little alone. Two
+controls worth keeping:
+
+- *Bare Electron* — a ~10-line `main.js` opening one window, run with the same
+  Electron binary. Idles at **~0.03%** main-process CPU. That is the floor.
+- *The previous build* — revert the change, `pnpm build:main`, re-measure under
+  identical conditions.
+
+**Ground truth for process CPU is the OS**, sampled over a long window:
+
+```bash
+PID=$(ps aux | grep "[E]lectron.app/Contents/MacOS/Electron \." | awk '{print $2}' | head -1)
+t0=$(ps -o cputime= -p $PID); sleep 90; t1=$(ps -o cputime= -p $PID)   # diff / 90s
+top -l 3 -s 5 -pid $PID -stats pid,cpu,idlew,mem                       # IDLEW = idle wakeups
+```
+
+Idle wakeups track battery drain better than CPU% does; they are the metric the
+timer census is designed to move.
+
+**Renderer numbers under `pnpm dev` are inflated.** Vite serves React's
+development JSX runtime, and `jsxDEV` dominates any renderer profile taken this
+way — a navigation profile showed it at ~50% of renderer busy time. Dev-mode
+renderer CPU is useful for *relative* comparison and for spotting structural
+problems (re-render storms, leaks); it is not a valid absolute figure. Main-process
+numbers do NOT have this problem — `main/dist` is the same `tsc` output in dev
+and prod.
+
+## Measuring with ACTIVE sessions
+
+Idle numbers miss the parsing/streaming hot paths entirely. To load the app for
+real, drive it from outside over the renderer's own bridges — no UI clicking
+needed, and it works headlessly:
+
+```bash
+# 1. anything the preload exposes, via CDP (window.electronAPI)
+node scripts/eval-cdp.mjs "window.electronAPI.sessions.createQuick({ prompt:'', projectId:1,
+  worktreeMode:'worktree', agentProvider:'codex', agentRuntime:'codex-sdk', agentModel:'gpt-5.6-luna' })"
+
+# 2. any tRPC procedure, via window.electronTRPC (superjson-wrapped: input is { json: <value> })
+node scripts/trpc-call.mjs cyboflow.runs.start mutation \
+  '{"workflowId":"wf-global-sprint","projectId":1,"sessionId":"<id>",
+    "agentProvider":"claude","agentRuntime":"claude-sdk","substrate":"sdk",
+    "taskIds":["<taskId>"],"permissionMode":"dontAsk"}'
+```
+
+Point the project at a THROWAWAY git repo — a sprint agent really does commit.
+`agentModel` is the unified, provider-normalized field for both providers
+(`sonnet` for Claude; a catalog id like `gpt-5.6-luna` for Codex — get the live
+list from `window.electronAPI.models.getCodexCatalog()`, it is discovered
+dynamically and is NOT in the source).
+
+Two gotchas that will silently give you a useless measurement:
+
+- **Starting a run programmatically does not open its subscriptions.** The
+  `throttleAsyncIterator` subscriptions (`events`, `agentThread`) only exist
+  while the renderer is watching. If `throttle.js` is absent from
+  `[perf-timers]`, nothing is subscribed.
+- **The run view streams over the raw `cyboflow:stream:<runId>` IPC channel,
+  not the throttled tRPC path.** Opening a run exercises the parser and the raw
+  channel; it does not exercise the throttle.
+
+`[perf]`'s seam counters (`raw.claude` / `raw.codex`) are the load level. Always
+normalize CPU **per raw event** when comparing two runs — agent pacing varies a
+lot between runs, so raw busy-ms comparisons are misleading.
+
+### Baselines with two concurrent sprints (Claude sonnet + Codex Luna)
+
+| Metric | Value |
+|---|---|
+| Main-process CPU | 0.65–3% (bursty, tracks event rate) |
+| Main-process JS busy per raw event | ~0.65ms |
+| Event-loop utilization | ~0.0% (never the bottleneck) |
+| Main-process heap | ~47MB, flat; ~1.4 MB/min allocated |
+| Main-process RSS | 160–280MB, trending DOWN as runs settle |
+
+## Known-good baselines (empty workspace, idle, plain `pnpm dev`)
+
+Recorded 2026-08-13 on macOS/arm64, Electron 37.6.0. Regressions against these
+are worth investigating.
+
+| Metric | Value |
+|---|---|
+| Main-process CPU, idle | ~0.30% (bare-Electron floor: 0.03%) |
+| Main-process idle wakeups | ~2 per 3s |
+| Main-process timer wakeups | ~0/s (only the tracer's own, when enabled) |
+| Main-process heap | ~44MB, **0 bytes/min allocated at idle** |
+| Main-process RSS | ~180MB |
+| Renderer JS heap, idle | ~25MB |
+| Renderer script time, idle | ~0ms per 15s |
+| Main-process CPU during UI navigation | ~0.5% |
+
+Renderer DOM growth across repeated navigation converges (node delta per round
+253 → 44 → 0), i.e. views mount once and stay — not a leak.
+
+## Fixed: the 60Hz subscription tick (2026-08-13)
+
+`throttleAsyncIterator` (`main/src/orchestrator/trpc/throttle.ts`) used to arm a
+`setInterval(1000/hz)` for the entire life of every tRPC subscription. At
+`hz=60`, two live subscriptions fired **~98 times/second** between them while
+doing **0.8ms of real work per 5000ms** — ~99.98% pure wakeup overhead, burning
+~1.5% of a core on a completely idle app.
+
+It now arms a single `setTimeout` only while a value is actually pending, so an
+idle subscription holds **no timer at all**. Emission semantics are unchanged
+(`lastEmitAt` is seeded at construction, so the first value is still held for a
+full `intervalMs` rather than emitted on the leading edge).
+
+Measured, plain `pnpm dev`, identical conditions:
+
+| | idle main CPU | idle wakeups |
+|---|---|---|
+| Before | 1.76% | 20 / 3s |
+| After | **0.30%** | **2 / 3s** |
+
+`throttle.test.ts` pins the invariant ("holds no timer while the source is
+idle") so the steady-interval shape cannot come back unnoticed.
+
+## Fixed: ZodError construction per streamed event (2026-08-13)
+
+Profiling the main process under two concurrent sprints put **`ZodError`
+construction at 59% of all main-process JS**, with GC (churning those errors)
+next at 10%.
+
+`claudeStreamEventSchema` is a 7-branch `z.union` (a plain union, not a
+`discriminatedUnion` — Zod 3 rejects nested discriminated unions as branches).
+Zod has no fast path for that: it tries each branch in order and **constructs a
+full ZodError for every one that does not match**, including the branches it
+discards before reaching the one that does. Each ZodError captures a stack
+trace. So every streamed event — and a Codex run emits hundreds, none of which
+match the Claude schema at all — paid for up to 7 of them.
+
+Every branch pins a distinct top-level `type` literal, so the matching branch is
+fully determined by `type` alone. `claudeStreamEventSchemaByType` now dispatches
+on it and parses exactly ONE branch. This is semantically identical (a value
+whose `type` is X cannot match a branch pinning a different literal; a
+missing/non-string `type` matches nothing either way) and is guarded in both
+directions by compile-time coverage bridges plus a test asserting the map agrees
+with the full union on accepted AND rejected values.
+
+Microbenchmark, realistic mixed corpus: **21.3µs → 1.4µs per event (14.8×)**.
+
+Measured live, two concurrent sprints, same instrumented build:
+
+| | busy JS | ZodError | GC | raw events | JS per event |
+|---|---|---|---|---|---|
+| Before | 737.6ms | 433.9ms (58.8%) | 72.2ms | 210 | 3.51ms |
+| After | 293.5ms | 25.7ms (8.8%) | 15.6ms | 453 | **0.65ms** |
+
+**5.4× less main-process CPU per streamed event** — and the "after" window
+carried 2.2× the event volume, so the comparison understates the win.
+
+### Follow-up: the INNER unions (same day)
+
+Re-profiling attributed the 8.8% residual back to `narrow` itself, not to some
+other subsystem: the branches carry their own plain unions, and
+`contentBlockSchema` is parsed once **per content block** of every assistant
+message. `z.union([text, tool_use, thinking])` therefore rebuilt a ZodError per
+non-matching block type, per block.
+
+All the block schemas are plain objects pinning a distinct `type`, so these are
+exactly what Zod 3's `discriminatedUnion` is for (the nesting constraint that
+forced the top-level union does not apply here). Converted:
+
+- `contentBlockSchema` → `z.discriminatedUnion('type', …)`
+- user `content: z.array(z.union([tool_result, text]))` → `z.array(z.discriminatedUnion('type', …))`
+
+Accept/reject behaviour is identical; only the error SHAPE on failure changes,
+and the sole consumer discards the error. Benchmarked on assistant events with
+1/4/12 content blocks: **8.3µs → 4.3µs per event (1.9×)**.
+
+`tool_use_result` is deliberately left as a `z.union` — its arms are an object
+and an array with no shared discriminant, so it cannot be converted, and it is
+optional + low-volume.
+
+Cumulative for the parser: **21.3µs → ~1.4µs** on the mixed corpus, and
+assistant-heavy traffic gets the extra 1.9× on top.

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -1,3 +1,9 @@
+// FIRST import, deliberately: the timer census can only attribute timers
+// scheduled AFTER it patches the globals, and several services schedule one at
+// module-import time. A no-op unless CYBOFLOW_PERF_TRACE=1.
+import { installTimerCensus } from './services/timerCensus';
+installTimerCensus();
+
 import {
   app,
   BrowserWindow,

--- a/main/src/orchestrator/trpc/__tests__/throttle.test.ts
+++ b/main/src/orchestrator/trpc/__tests__/throttle.test.ts
@@ -245,6 +245,50 @@ describe('throttleAsyncIterator', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Test 5: teardown completes even against an uncooperative source.
+  //
+  // The consumer loop is suspended in `iterator.next()` and only re-reads `done`
+  // once a value arrives, so a source that never produces again cannot be woken
+  // from inside. Teardown must therefore not block on it — otherwise .return()
+  // (a client disconnect) stays pending forever and the subscription leaks.
+  // -------------------------------------------------------------------------
+  it('returns promptly when the source is parked in next() and ignores cancellation', async () => {
+    let returnCalled = false;
+    // Never yields, never completes, and its return() never settles either —
+    // the worst-behaved source the throttle could be handed.
+    const hostileSource: AsyncIterable<number> = {
+      [Symbol.asyncIterator]: () => ({
+        next: () => new Promise<IteratorResult<number>>(() => undefined),
+        return: () => {
+          returnCalled = true;
+          return new Promise<IteratorResult<number>>(() => undefined);
+        },
+      }),
+    };
+
+    const controller = new AbortController();
+    const throttled = throttleAsyncIterator(hostileSource, 60, controller.signal);
+
+    // Start consuming so the generator is live and parked between emissions.
+    const drained: number[] = [];
+    const drainPromise = (async () => {
+      for await (const v of throttled) drained.push(v);
+    })();
+    await drainMicrotasks(50);
+
+    // The disconnect. Before the signal existed this could not be observed at
+    // all: the generator was suspended at an internal await, so `.return()` was
+    // merely QUEUED and its teardown never ran — here that is a test timeout.
+    controller.abort();
+    await drainMicrotasks(50);
+    await drainPromise;
+
+    expect(drained).toEqual([]);
+    expect(returnCalled).toBe(true); // the source WAS asked to cancel
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
   // Test 4: the cap holds across a system clock jump.
   //
   // An earlier version computed each delay from a `Date.now()` delta, which is

--- a/main/src/orchestrator/trpc/__tests__/throttle.test.ts
+++ b/main/src/orchestrator/trpc/__tests__/throttle.test.ts
@@ -225,6 +225,14 @@ describe('throttleAsyncIterator', () => {
     await drainMicrotasks(50);
     expect(vi.getTimerCount()).toBe(1);
 
+    // A post-idle value must still be HELD for a full interval and coalesced —
+    // not emitted on the leading edge. (Deriving the delay from a wall-clock
+    // delta got this wrong: after an idle gap the computed delay collapsed to
+    // zero, so value 1 escaped immediately and 2 followed separately.)
+    await vi.advanceTimersByTimeAsync(5);
+    await drainMicrotasks(20);
+    expect(results).toEqual([]);
+
     // Once the burst has drained, the subscription goes back to costing nothing.
     await vi.advanceTimersByTimeAsync(100);
     await drainMicrotasks(50);
@@ -234,5 +242,56 @@ describe('throttleAsyncIterator', () => {
     done();
     await drainMicrotasks(50);
     await drainPromise;
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 4: the cap holds across a system clock jump.
+  //
+  // An earlier version computed each delay from a `Date.now()` delta, which is
+  // wrong in BOTH directions: a forward jump made the delay collapse to zero
+  // (emitting faster than hz), and a backward jump inflated it by the size of
+  // the jump (stalling a pending final value). The cadence must come from
+  // relative timer delays only, so moving the wall clock must change nothing.
+  // -------------------------------------------------------------------------
+  it('is unaffected by system clock jumps in either direction', async () => {
+    const { push, done, iterable } = makeManualIterator<number>();
+    const throttled = throttleAsyncIterator(iterable, 60);
+
+    const results: number[] = [];
+    const drainPromise = (async () => {
+      for await (const v of throttled) results.push(v);
+    })();
+
+    const realNow = Date.now;
+    try {
+      push(1);
+      await drainMicrotasks(30);
+
+      // Jump the wall clock forward an hour without advancing timers.
+      Date.now = () => realNow() + 3_600_000;
+      await drainMicrotasks(30);
+      // The value is still held: only the timer decides, not the clock.
+      expect(results).toEqual([]);
+
+      // And it still lands on the normal cadence, not instantly.
+      await vi.advanceTimersByTimeAsync(17);
+      await drainMicrotasks(30);
+      expect(results).toEqual([1]);
+
+      // Now jump backward an hour and send a final value + completion. It must
+      // not be stalled by the (negative) apparent elapsed time.
+      Date.now = () => realNow() - 3_600_000;
+      push(2);
+      done();
+      await drainMicrotasks(30);
+      await vi.advanceTimersByTimeAsync(17);
+      await drainMicrotasks(30);
+      expect(results).toEqual([1, 2]);
+    } finally {
+      Date.now = realNow;
+    }
+
+    await drainPromise;
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/main/src/orchestrator/trpc/__tests__/throttle.test.ts
+++ b/main/src/orchestrator/trpc/__tests__/throttle.test.ts
@@ -2,11 +2,13 @@
  * Unit tests for throttleAsyncIterator.
  *
  * Uses vi.useFakeTimers() for deterministic rate measurement — no wall-clock
- * dependence. Two test cases:
+ * dependence. Test cases:
  *   1. Rate cap: source produces events continuously for 1 simulated second →
  *      throttle emits ≈ hz ± 10 times.
  *   2. Coalescing-latest: multiple source events within one tick window →
  *      only the latest event is emitted.
+ *   3. Idle costs nothing: a subscription whose source is quiet holds NO timer,
+ *      and returns to holding none after a burst settles.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { throttleAsyncIterator } from '../throttle';
@@ -189,5 +191,48 @@ describe('throttleAsyncIterator', () => {
     // Exactly one event should have been emitted — and it must be 10 (latest wins).
     expect(results).toHaveLength(1);
     expect(results[0]).toBe(10);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 3: An idle subscription arms no timer.
+  //
+  // This is the property that matters for main-process CPU. The throttle used
+  // to hold a setInterval for its whole life, so N live subscriptions cost
+  // N * hz wakeups/second whether or not anything was streaming. Assert the
+  // timer only exists while a value is actually pending.
+  // -------------------------------------------------------------------------
+  it('holds no timer while the source is idle', async () => {
+    const { push, done, iterable } = makeManualIterator<number>();
+    const throttled = throttleAsyncIterator(iterable, 60);
+
+    const results: number[] = [];
+    const drainPromise = (async () => {
+      for await (const v of throttled) {
+        results.push(v);
+      }
+    })();
+
+    // A live subscription that has never seen a value must be timer-free.
+    await drainMicrotasks(50);
+    await vi.advanceTimersByTimeAsync(1000);
+    await drainMicrotasks(50);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(results).toHaveLength(0);
+
+    // A burst arms exactly one timer, no matter how many values it carries.
+    push(1);
+    push(2);
+    await drainMicrotasks(50);
+    expect(vi.getTimerCount()).toBe(1);
+
+    // Once the burst has drained, the subscription goes back to costing nothing.
+    await vi.advanceTimersByTimeAsync(100);
+    await drainMicrotasks(50);
+    expect(results).toEqual([2]);
+    expect(vi.getTimerCount()).toBe(0);
+
+    done();
+    await drainMicrotasks(50);
+    await drainPromise;
   });
 });

--- a/main/src/orchestrator/trpc/routers/agentThread.ts
+++ b/main/src/orchestrator/trpc/routers/agentThread.ts
@@ -308,7 +308,13 @@ export const agentThreadRouter = router({
         'message',
         abortSignal,
       );
-      for await (const ev of throttleAsyncIterator(filterThread(all, input.threadId), 60)) {
+      // Signal threaded through: between emissions the throttle parks at an
+      // internal await, where `.return()` alone cannot run its teardown.
+      for await (const ev of throttleAsyncIterator(
+        filterThread(all, input.threadId),
+        60,
+        abortSignal,
+      )) {
         yield ev.envelope;
       }
     }),

--- a/main/src/orchestrator/trpc/routers/events.ts
+++ b/main/src/orchestrator/trpc/routers/events.ts
@@ -246,7 +246,9 @@ export const eventsRouter = router({
       // SSE transport always provides it, but the type allows undefined).
       const abortSignal = signal ?? new AbortController().signal;
       const source = makePlaceholderAsyncIterator<StreamEvent>(abortSignal);
-      for await (const ev of throttleAsyncIterator(source, 60)) {
+      // Signal threaded through: between emissions the throttle parks at an
+      // internal await, where `.return()` alone cannot run its teardown.
+      for await (const ev of throttleAsyncIterator(source, 60, abortSignal)) {
         yield ev;
       }
     }),

--- a/main/src/orchestrator/trpc/throttle.ts
+++ b/main/src/orchestrator/trpc/throttle.ts
@@ -62,8 +62,28 @@
  * ## Lifecycle / cleanup
  *
  * When the outer generator is returned or thrown (client disconnect, error),
- * the `finally` block sets `done = true`, clears any pending cooldown timer, and
- * awaits the consumer promise so the background loop exits cleanly.
+ * the `finally` block sets `done = true`, clears any pending cooldown timer,
+ * and cancels the source via `iterator.return()`.
+ *
+ * It deliberately does NOT wait for the background consumer. Teardown here must
+ * always complete promptly: a source parked in `next()` cannot see `done`, so
+ * blocking on it would leave a client disconnect pending indefinitely. A source
+ * is therefore expected to end on cancellation, but is not TRUSTED to — the
+ * throttle stays correct either way.
+ *
+ * ## Why `signal` is needed for that to be true
+ *
+ * Cleanup code alone is not enough, because between emissions this generator is
+ * suspended at an internal `await` (not at a `yield`). Calling `.return()` on an
+ * async generator in that state does NOT run its `finally` — the request is
+ * QUEUED until the generator next resumes. With an idle source there is nothing
+ * to resume it, so a client disconnect would hang and the subscription would be
+ * retained, with none of the teardown below ever executing.
+ *
+ * Passing the subscription's `AbortSignal` gives the generator an external wake:
+ * on abort it resumes, breaks the loop, and runs teardown deterministically.
+ * Callers that own a signal (every tRPC subscription does) SHOULD pass it.
+ * Omitting it preserves the old behaviour exactly, including that hazard.
  */
 
 /**
@@ -73,11 +93,14 @@
  *
  * @param source - Any async iterable (EventEmitter-backed iterator, etc.).
  * @param hz     - Target emission rate in events per second (e.g. 60).
+ * @param signal - The subscription's AbortSignal. Strongly recommended: without
+ *                 it, teardown cannot interrupt an idle generator (see above).
  * @returns      An async generator suitable for use in a tRPC subscription.
  */
 export async function* throttleAsyncIterator<T>(
   source: AsyncIterable<T>,
   hz: number,
+  signal?: AbortSignal,
 ): AsyncGenerator<T> {
   const intervalMs = 1000 / hz;
 
@@ -131,14 +154,21 @@ export async function* throttleAsyncIterator<T>(
     }, intervalMs);
   }
 
+  // An EXPLICIT iterator rather than `for await`, so teardown can reach in and
+  // cancel a source that is currently parked inside `next()`. `for await` only
+  // calls `.return()` when its loop exits, which is exactly what cannot happen
+  // in that state.
+  const iterator = source[Symbol.asyncIterator]();
+
   // Background consumer: reads source, updates latest+dirty, and arms the
-  // flush. Deliberately does NOT enqueue directly — only `flush` does, so the
+  // cooldown. Deliberately does NOT enqueue directly — only `flush` does, so the
   // rate cap and coalescing stay in one place.
   const consumerPromise = (async () => {
     try {
-      for await (const event of source) {
-        if (done) break;
-        latest = event;
+      while (!done) {
+        const next = await iterator.next();
+        if (next.done === true || done) break;
+        latest = next.value;
         dirty = true;
         armCooldown();
       }
@@ -148,11 +178,22 @@ export async function* throttleAsyncIterator<T>(
     }
   })();
 
+  // The external wake described in the header: an abort resolves whatever the
+  // generator is parked on, so teardown can actually run.
+  const onAbort = (): void => wake();
+  signal?.addEventListener('abort', onAbort);
+
   try {
     while (!done) {
       // Drain the queue first.
       while (queue.length > 0) {
         yield queue.shift() as T;
+      }
+
+      // Cancelled — stop, even mid-burst. Checked after the drain so anything
+      // already flushed still reaches the client.
+      if (signal?.aborted === true) {
+        break;
       }
 
       // If source is done and queue is empty and nothing dirty remains,
@@ -167,8 +208,10 @@ export async function* throttleAsyncIterator<T>(
       // Wait for next wake() call (tick enqueue or source-done).
       await new Promise<void>((resolve) => {
         // Re-check inside the constructor to avoid a race between the
-        // `while(queue.length)` check above and registering the callback.
-        if (queue.length > 0 || (sourceDone && !dirty)) {
+        // `while(queue.length)` check above and registering the callback —
+        // including an abort that landed in that window, which would otherwise
+        // park us with the listener already spent.
+        if (queue.length > 0 || (sourceDone && !dirty) || signal?.aborted === true) {
           resolve();
         } else {
           waitResolve = resolve;
@@ -177,11 +220,27 @@ export async function* throttleAsyncIterator<T>(
     }
   } finally {
     done = true;
+    signal?.removeEventListener('abort', onAbort);
     if (cooldownTimer !== null) {
       clearTimeout(cooldownTimer);
       cooldownTimer = null;
     }
     wake(); // unblock consumer if waiting
-    await consumerPromise;
+
+    // Cancel the source, then let the consumer wind down on its own.
+    //
+    // Teardown must NOT block on the consumer. It used to `await consumerPromise`,
+    // but `wake()` cannot reach that loop — it is suspended in `iterator.next()`,
+    // and `done` is only re-read once a value arrives. A source that never
+    // produces again (nor honours cancellation) therefore left `.return()` on
+    // this generator pending FOREVER, so a client disconnect never completed and
+    // the subscription's state stayed retained. Awaiting bought nothing in
+    // return: all the consumer does on exit is set `sourceDone` and `wake()`,
+    // neither of which is observable once the generator has returned.
+    //
+    // `.catch` on both: after teardown a source error has no consumer, and an
+    // unhandled rejection must not escape into the process.
+    void Promise.resolve(iterator.return?.()).catch(() => undefined);
+    void consumerPromise.catch(() => undefined);
   }
 }

--- a/main/src/orchestrator/trpc/throttle.ts
+++ b/main/src/orchestrator/trpc/throttle.ts
@@ -23,17 +23,38 @@
  * ## Algorithm
  *
  * 1. A background consumer loop reads from `source`, always overwriting
- *    `latest` and setting `dirty = true`.
- * 2. A `setInterval(1000/hz)` tick checks: if `dirty`, push `latest` into
- *    an internal queue and clear `dirty`.
+ *    `latest`, setting `dirty = true`, and asking for a flush to be scheduled.
+ * 2. `scheduleFlush` arms a SINGLE `setTimeout` for the earliest instant the
+ *    rate cap allows (`intervalMs` after the last emission). When it fires it
+ *    moves `latest` into the queue and clears `dirty`.
  * 3. The outer generator dequeues and yields, blocking between dequeues
- *    until the next tick signal or source completion.
+ *    until the next flush signal or source completion.
+ *
+ * ## Why on-demand timers, not a steady interval
+ *
+ * This used to arm `setInterval(1000/hz)` for the whole life of the
+ * subscription, which ticked whether or not the source had produced anything.
+ * In the Electron MAIN process that is expensive in a way it is not in plain
+ * Node: libuv is driven by Chromium's CFRunLoop, so each fire costs a
+ * `__CFRunLoopDoSources0 → uv_run → uv__run_timers` round trip plus a
+ * `uv__loop_interrupt`/`kevent` to re-arm. Measured on an IDLE app, two live
+ * subscriptions at `hz=60` fired ~98 times/second between them and did 0.8ms of
+ * real work per 5000ms — ~2% of a core spent almost entirely on wakeup
+ * overhead. Arming the timer only while a value is actually pending drops that
+ * to ZERO timers when nothing is streaming, with identical emission semantics.
+ *
+ * ## Emission-timing equivalence
+ *
+ * `lastEmitAt` starts at construction time, so the first value is still held
+ * for a full `intervalMs` rather than emitted on the leading edge — matching
+ * the old fixed-grid behaviour (a value is never forwarded faster than the cap
+ * would have allowed) and keeping coalescing observable to callers.
  *
  * ## Lifecycle / cleanup
  *
  * When the outer generator is returned or thrown (client disconnect, error),
- * the `finally` block sets `done = true`, clears the interval, and awaits
- * the consumer promise so the background loop exits cleanly.
+ * the `finally` block sets `done = true`, clears any pending flush timer, and
+ * awaits the consumer promise so the background loop exits cleanly.
  */
 
 /**
@@ -62,6 +83,14 @@ export async function* throttleAsyncIterator<T>(
   // Pending resolve callback: the outer generator awaits this between yields.
   let waitResolve: (() => void) | null = null;
 
+  // The single in-flight flush timer, or null when nothing is pending. At most
+  // one exists at a time, and none at all while the source is quiet.
+  let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Wall-clock of the last emission, seeded at construction so the first value
+  // is rate-limited exactly as the old fixed-grid interval limited it.
+  let lastEmitAt = Date.now();
+
   /** Wake up the outer generator loop (new value enqueued or source done). */
   function wake(): void {
     if (waitResolve) {
@@ -71,25 +100,41 @@ export async function* throttleAsyncIterator<T>(
     }
   }
 
-  // Tick interval: if dirty, snapshot latest and enqueue for yield.
-  const interval = setInterval(() => {
-    if (dirty) {
-      const toEmit = latest as T;
-      dirty = false;
-      latest = undefined;
-      queue.push(toEmit);
-      wake();
-    }
-  }, intervalMs);
+  /** Move `latest` into the queue and wake the generator. */
+  function flush(): void {
+    if (!dirty) return;
+    const toEmit = latest as T;
+    dirty = false;
+    latest = undefined;
+    lastEmitAt = Date.now();
+    queue.push(toEmit);
+    wake();
+  }
 
-  // Background consumer: reads source, updates latest+dirty only.
-  // Deliberately does NOT enqueue directly — only the interval tick does.
+  /**
+   * Arm the flush timer for the earliest instant the rate cap allows. A no-op
+   * when one is already pending (so a burst of source events shares a single
+   * timer) or when the generator has been torn down.
+   */
+  function scheduleFlush(): void {
+    if (flushTimer !== null || done) return;
+    const delay = Math.max(0, intervalMs - (Date.now() - lastEmitAt));
+    flushTimer = setTimeout(() => {
+      flushTimer = null;
+      flush();
+    }, delay);
+  }
+
+  // Background consumer: reads source, updates latest+dirty, and arms the
+  // flush. Deliberately does NOT enqueue directly — only `flush` does, so the
+  // rate cap and coalescing stay in one place.
   const consumerPromise = (async () => {
     try {
       for await (const event of source) {
         if (done) break;
         latest = event;
         dirty = true;
+        scheduleFlush();
       }
     } finally {
       sourceDone = true;
@@ -105,9 +150,10 @@ export async function* throttleAsyncIterator<T>(
       }
 
       // If source is done and queue is empty and nothing dirty remains,
-      // we are finished. (Dirty will be caught by the next interval tick if
-      // the interval fires before this check — that's intentional to ensure
-      // the very last event is not lost when the source exhausts quickly.)
+      // we are finished. (A still-dirty value keeps us here: its flush timer
+      // was armed when it was set, so it will fire and wake us — that's what
+      // ensures the very last event is not lost when the source exhausts
+      // quickly.)
       if (sourceDone && queue.length === 0 && !dirty) {
         break;
       }
@@ -125,7 +171,10 @@ export async function* throttleAsyncIterator<T>(
     }
   } finally {
     done = true;
-    clearInterval(interval);
+    if (flushTimer !== null) {
+      clearTimeout(flushTimer);
+      flushTimer = null;
+    }
     wake(); // unblock consumer if waiting
     await consumerPromise;
   }

--- a/main/src/orchestrator/trpc/throttle.ts
+++ b/main/src/orchestrator/trpc/throttle.ts
@@ -23,10 +23,10 @@
  * ## Algorithm
  *
  * 1. A background consumer loop reads from `source`, always overwriting
- *    `latest`, setting `dirty = true`, and asking for a flush to be scheduled.
- * 2. `scheduleFlush` arms a SINGLE `setTimeout` for the earliest instant the
- *    rate cap allows (`intervalMs` after the last emission). When it fires it
- *    moves `latest` into the queue and clears `dirty`.
+ *    `latest`, setting `dirty = true`, and arming the cooldown.
+ * 2. `armCooldown` runs a SINGLE `setTimeout(intervalMs)`. When it fires it
+ *    moves `latest` into the queue, clears `dirty`, and re-arms; an expiry
+ *    with nothing pending stops the chain instead.
  * 3. The outer generator dequeues and yields, blocking between dequeues
  *    until the next flush signal or source completion.
  *
@@ -45,15 +45,24 @@
  *
  * ## Emission-timing equivalence
  *
- * `lastEmitAt` starts at construction time, so the first value is still held
- * for a full `intervalMs` rather than emitted on the leading edge — matching
- * the old fixed-grid behaviour (a value is never forwarded faster than the cap
- * would have allowed) and keeping coalescing observable to callers.
+ * The cadence is driven by a COOLDOWN chain, never by comparing wall-clock
+ * timestamps. A value arriving while idle arms a timer for `intervalMs` and is
+ * held until it fires — so, exactly as under the old fixed grid, the first
+ * value of a burst is coalesced with everything else that lands in that window
+ * rather than escaping on the leading edge. Each emission re-arms the cooldown;
+ * when it expires with nothing pending, the chain stops and the subscription
+ * goes back to holding no timer.
+ *
+ * Deliberately NO `Date.now()` arithmetic. Deriving the delay from a wall-clock
+ * delta makes the throttle wrong across a system clock adjustment in both
+ * directions: a backward jump would stall a pending final value for the size of
+ * the jump, and a forward jump would compute a zero delay and let emissions
+ * exceed `hz`. Relative timer delays are immune to both.
  *
  * ## Lifecycle / cleanup
  *
  * When the outer generator is returned or thrown (client disconnect, error),
- * the `finally` block sets `done = true`, clears any pending flush timer, and
+ * the `finally` block sets `done = true`, clears any pending cooldown timer, and
  * awaits the consumer promise so the background loop exits cleanly.
  */
 
@@ -83,13 +92,9 @@ export async function* throttleAsyncIterator<T>(
   // Pending resolve callback: the outer generator awaits this between yields.
   let waitResolve: (() => void) | null = null;
 
-  // The single in-flight flush timer, or null when nothing is pending. At most
-  // one exists at a time, and none at all while the source is quiet.
-  let flushTimer: ReturnType<typeof setTimeout> | null = null;
-
-  // Wall-clock of the last emission, seeded at construction so the first value
-  // is rate-limited exactly as the old fixed-grid interval limited it.
-  let lastEmitAt = Date.now();
+  // The single in-flight cooldown timer, or null when the chain is stopped. At
+  // most one exists at a time, and none at all while the source is quiet.
+  let cooldownTimer: ReturnType<typeof setTimeout> | null = null;
 
   /** Wake up the outer generator loop (new value enqueued or source done). */
   function wake(): void {
@@ -106,23 +111,24 @@ export async function* throttleAsyncIterator<T>(
     const toEmit = latest as T;
     dirty = false;
     latest = undefined;
-    lastEmitAt = Date.now();
     queue.push(toEmit);
     wake();
   }
 
   /**
-   * Arm the flush timer for the earliest instant the rate cap allows. A no-op
-   * when one is already pending (so a burst of source events shares a single
-   * timer) or when the generator has been torn down.
+   * Start one `intervalMs` cooldown. When it expires, anything that arrived
+   * during the window is emitted (coalesced to the latest) and the cooldown
+   * re-arms; if nothing arrived, the chain stops and we hold no timer until the
+   * next value. A no-op when a cooldown is already running or after teardown.
    */
-  function scheduleFlush(): void {
-    if (flushTimer !== null || done) return;
-    const delay = Math.max(0, intervalMs - (Date.now() - lastEmitAt));
-    flushTimer = setTimeout(() => {
-      flushTimer = null;
+  function armCooldown(): void {
+    if (cooldownTimer !== null || done) return;
+    cooldownTimer = setTimeout(() => {
+      cooldownTimer = null;
+      if (!dirty) return; // quiet window — stop the chain, go back to zero timers
       flush();
-    }, delay);
+      armCooldown();
+    }, intervalMs);
   }
 
   // Background consumer: reads source, updates latest+dirty, and arms the
@@ -134,7 +140,7 @@ export async function* throttleAsyncIterator<T>(
         if (done) break;
         latest = event;
         dirty = true;
-        scheduleFlush();
+        armCooldown();
       }
     } finally {
       sourceDone = true;
@@ -150,8 +156,8 @@ export async function* throttleAsyncIterator<T>(
       }
 
       // If source is done and queue is empty and nothing dirty remains,
-      // we are finished. (A still-dirty value keeps us here: its flush timer
-      // was armed when it was set, so it will fire and wake us — that's what
+      // we are finished. (A still-dirty value keeps us here: its cooldown was
+      // armed when it was set, so it will fire and wake us — that's what
       // ensures the very last event is not lost when the source exhausts
       // quickly.)
       if (sourceDone && queue.length === 0 && !dirty) {
@@ -171,9 +177,9 @@ export async function* throttleAsyncIterator<T>(
     }
   } finally {
     done = true;
-    if (flushTimer !== null) {
-      clearTimeout(flushTimer);
-      flushTimer = null;
+    if (cooldownTimer !== null) {
+      clearTimeout(cooldownTimer);
+      cooldownTimer = null;
     }
     wake(); // unblock consumer if waiting
     await consumerPromise;

--- a/main/src/services/__tests__/timerCensus.test.ts
+++ b/main/src/services/__tests__/timerCensus.test.ts
@@ -1,0 +1,132 @@
+/**
+ * TimerCensus tests — the opt-in timer-wakeup attribution instrument.
+ *
+ * The census patches global timer functions, so its overriding constraint is
+ * that it must not CHANGE the behaviour of the code it measures. These cases
+ * pin the observer-effect properties that a naive wrapper silently breaks.
+ *
+ * TRACE_ENABLED is read from the env at module load, so each scenario resets
+ * the module registry and re-imports with the env pre-set.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { promisify } from 'node:util';
+
+const OLD_TRACE = process.env.CYBOFLOW_PERF_TRACE;
+
+const realSetTimeout = globalThis.setTimeout;
+const realSetInterval = globalThis.setInterval;
+const realSetImmediate = globalThis.setImmediate;
+
+afterEach(() => {
+  process.env.CYBOFLOW_PERF_TRACE = OLD_TRACE;
+  globalThis.setTimeout = realSetTimeout;
+  globalThis.setInterval = realSetInterval;
+  globalThis.setImmediate = realSetImmediate;
+  vi.resetModules();
+});
+
+async function installEnabled() {
+  process.env.CYBOFLOW_PERF_TRACE = '1';
+  vi.resetModules();
+  const mod = await import('../timerCensus');
+  mod.installTimerCensus();
+  return mod;
+}
+
+describe('timerCensus (disabled)', () => {
+  it('leaves the global timer functions untouched', async () => {
+    process.env.CYBOFLOW_PERF_TRACE = '0';
+    vi.resetModules();
+    const mod = await import('../timerCensus');
+    mod.installTimerCensus();
+
+    expect(globalThis.setTimeout).toBe(realSetTimeout);
+    expect(globalThis.setInterval).toBe(realSetInterval);
+    expect(globalThis.setImmediate).toBe(realSetImmediate);
+    expect(mod.drainTimerCensus()).toEqual([]);
+  });
+});
+
+describe('timerCensus (enabled)', () => {
+  it('preserves util.promisify(setTimeout) semantics', async () => {
+    // setTimeout carries Symbol(nodejs.util.promisify.custom); a bare wrapper
+    // drops it, and promisify then falls back to callback-last — calling
+    // setTimeout(ms, value, cb), so the delay lands in the callback slot and the
+    // promise REJECTS with ERR_INVALID_ARG_TYPE instead of resolving with the
+    // value. Anything doing `await promisify(setTimeout)(…)` would break, but
+    // only while profiling: the exact observer effect this must not have.
+    await installEnabled();
+
+    const delay = promisify(globalThis.setTimeout);
+    await expect(delay(1, 'sentinel')).resolves.toBe('sentinel');
+  });
+
+  it('preserves clearTimeout, handle identity and unref()', async () => {
+    await installEnabled();
+
+    const handle = globalThis.setTimeout(() => {
+      throw new Error('cleared timer must never fire');
+    }, 5);
+    // The real Timeout handle is returned untouched, so its whole API works.
+    expect(typeof handle.unref).toBe('function');
+    expect(handle.unref()).toBe(handle);
+    clearTimeout(handle);
+
+    await new Promise((resolve) => realSetTimeout(resolve, 20));
+  });
+
+  it('forwards extra arguments and counts the fire against its site', async () => {
+    const mod = await installEnabled();
+
+    const seen: unknown[] = [];
+    await new Promise<void>((resolve) => {
+      globalThis.setTimeout(
+        (...args: unknown[]) => {
+          seen.push(...args);
+          resolve();
+        },
+        1,
+        'a',
+        'b',
+      );
+    });
+
+    expect(seen).toEqual(['a', 'b']);
+    const rows = mod.drainTimerCensus();
+    expect(rows.reduce((sum, row) => sum + row.fires, 0)).toBe(1);
+    // Draining resets the counters.
+    expect(mod.drainTimerCensus().reduce((sum, row) => sum + row.fires, 0)).toBe(0);
+  });
+
+  it('does not throw when a timer global is absent on this host', async () => {
+    // setImmediate does not exist in every environment. Installing the census
+    // must never be the thing that takes the process down.
+    process.env.CYBOFLOW_PERF_TRACE = '1';
+    vi.resetModules();
+    (globalThis as { setImmediate?: unknown }).setImmediate = undefined;
+    const mod = await import('../timerCensus');
+
+    expect(() => mod.installTimerCensus()).not.toThrow();
+    expect(globalThis.setTimeout).not.toBe(realSetTimeout); // still installed what it could
+  });
+
+  it('reports every site so the headline wakeup total cannot under-count', async () => {
+    // drainTimerCensus resets ALL sites, so if it also truncated its return the
+    // dropped fires would be unrecoverable and the reported rate would be
+    // systematically low exactly when the process is busiest.
+    const mod = await installEnabled();
+    const rows = mod.drainTimerCensus();
+    expect(Array.isArray(rows)).toBe(true);
+    // Truncation belongs to the formatter, which says what it elided.
+    const many = Array.from({ length: 10 }, (_, i) => ({
+      site: `site${i}`,
+      kind: 'interval' as const,
+      created: 1,
+      fires: 100,
+      callbackMs: 1,
+      minDelayMs: 16,
+    }));
+    const line = mod.formatTimerCensus(many);
+    expect(line).toContain('+2 more sites');
+  });
+});

--- a/main/src/services/perfTracer.ts
+++ b/main/src/services/perfTracer.ts
@@ -30,6 +30,7 @@ import {
   type EventLoopUtilization,
   type IntervalHistogram,
 } from 'node:perf_hooks';
+import { drainTimerCensus, formatTimerCensus, installTimerCensus } from './timerCensus';
 
 /** Minimal logger surface — kept local so this module imports nothing heavy. */
 interface PerfLogger {
@@ -138,6 +139,15 @@ export class PerfTracer {
       `[perf] elu=${eluPct}% cpu=${cpuPct}% eld(mean/p99/max)=${eldMean}/${eldP99}/${eldMax}ms ` +
         `rss=${rssMb}mb heap=${heapMb}mb | ${seamStr}`,
     );
+
+    // Timer wakeups are the dominant main-process idle cost (see timerCensus's
+    // header), so they get their own line rather than competing with the seam
+    // counters for space.
+    const census = drainTimerCensus();
+    const wakeups = census.reduce((sum, row) => sum + row.fires, 0);
+    this.logger.info(
+      `[perf-timers] ${(wakeups / (wallMs / 1000)).toFixed(1)}/s | ${formatTimerCensus(census)}`,
+    );
   }
 }
 
@@ -148,6 +158,7 @@ export class PerfTracer {
  */
 export function startPerfTracer(logger: PerfLogger): PerfTracer | null {
   if (!TRACE_ENABLED) return null;
+  installTimerCensus();
   const tracer = new PerfTracer(logger);
   tracer.start();
   return tracer;

--- a/main/src/services/streamParser/__tests__/typedEventNarrowing.test.ts
+++ b/main/src/services/streamParser/__tests__/typedEventNarrowing.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { TypedEventNarrowing } from '../typedEventNarrowing';
+import { claudeStreamEventSchema, claudeStreamEventSchemaByType } from '../schemas';
 import {
   systemInit,
   assistant,
@@ -244,5 +245,87 @@ describe('TypedEventNarrowing', () => {
       session_id: '9ac69ae6-7b4a-4007-b470-b6c9628dfb71',
     });
     expect('kind' in updated).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Union equivalence
+  //
+  // narrow() dispatches on the top-level `type` and parses ONE branch instead
+  // of walking the whole z.union, because Zod builds a ZodError for every
+  // non-matching branch and that dominated main-process CPU while runs streamed.
+  // These pin the two properties that make the swap safe: the dispatch map
+  // covers exactly the union's branches, and it accepts/rejects the same values.
+  // -------------------------------------------------------------------------
+
+  it('dispatch map covers exactly the top-level types the union accepts', () => {
+    expect(Object.keys(claudeStreamEventSchemaByType).sort()).toEqual([
+      'assistant',
+      'rate_limit_event',
+      'result',
+      'session_info',
+      'stream_event',
+      'system',
+      'user',
+    ]);
+  });
+
+  it('narrows every content-block kind, and rejects an unknown or malformed one', () => {
+    // contentBlockSchema is a discriminatedUnion parsed once PER BLOCK, so this
+    // pins that all three arms still narrow and that a bad block still sinks the
+    // whole event to __unknown__ (rather than being silently dropped or kept).
+    const withBlocks = (content: unknown[]) => ({
+      type: 'assistant',
+      message: {
+        id: 'm1', type: 'message', role: 'assistant', model: 'claude',
+        content, stop_reason: null, stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+      session_id: 'sess', uuid: 'u1',
+    });
+
+    const ok = narrower.narrow(withBlocks([
+      { type: 'text', text: 'hi' },
+      { type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } },
+      { type: 'thinking', thinking: 'hmm' },
+    ]));
+    expect('kind' in ok).toBe(false);
+
+    // Unknown discriminant.
+    const unknownBlock = narrower.narrow(withBlocks([{ type: 'image', source: {} }]));
+    expect('kind' in unknownBlock && unknownBlock.kind).toBe('__unknown__');
+
+    // Known discriminant, wrong payload — must NOT slip through.
+    const malformed = narrower.narrow(withBlocks([{ type: 'text', text: 42 }]));
+    expect('kind' in malformed && malformed.kind).toBe('__unknown__');
+  });
+
+  it('agrees with the full union on both accepted and rejected values', () => {
+    const corpus: unknown[] = [
+      systemInit(),
+      assistant(),
+      resultSuccess(),
+      streamEventSignatureDelta(),
+      streamEventThinkingDelta(),
+      // Rejected: unknown discriminant, missing discriminant, wrong shape for a
+      // KNOWN type, non-object, and a null/absent type.
+      { type: 'totally_unknown', foo: 1 },
+      { subtype: 'init' },
+      { type: 'assistant' },
+      { type: 'result', subtype: 'success' },
+      'not-an-object',
+      42,
+      null,
+      { type: null },
+    ];
+
+    for (const value of corpus) {
+      const viaUnion = claudeStreamEventSchema.safeParse(value);
+      const viaNarrow = narrower.narrow(value);
+      const narrowRejected = 'kind' in viaNarrow && viaNarrow.kind === '__unknown__';
+      expect(narrowRejected).toBe(!viaUnion.success);
+      if (viaUnion.success) {
+        expect(viaNarrow).toEqual(viaUnion.data);
+      }
+    }
   });
 });

--- a/main/src/services/streamParser/__tests__/typedEventNarrowing.test.ts
+++ b/main/src/services/streamParser/__tests__/typedEventNarrowing.test.ts
@@ -269,6 +269,45 @@ describe('TypedEventNarrowing', () => {
     ]);
   });
 
+  it('maps each key to the branch that actually pins that literal', () => {
+    // Key coverage alone is not enough: swapping two map values would keep both
+    // the key list and the compile-time output-union bridges satisfied while
+    // silently routing every event of those two types to the wrong schema.
+    // Read each branch's DECLARED `type` literal and require it to equal its key.
+    interface LiteralLike { value: unknown }
+    interface ObjectLike { shape: { type: LiteralLike } }
+    interface UnionLike { options: ObjectLike[] }
+
+    const declaredTypes = (branch: unknown): unknown[] => {
+      if (typeof branch !== 'object' || branch === null) return [];
+      if ('options' in branch) {
+        return (branch as UnionLike).options.map((option) => option.shape.type.value);
+      }
+      if ('shape' in branch) return [(branch as ObjectLike).shape.type.value];
+      return [];
+    };
+
+    for (const [key, branch] of Object.entries(claudeStreamEventSchemaByType)) {
+      const literals = declaredTypes(branch);
+      expect(literals.length).toBeGreaterThan(0);
+      // Every arm of a branch (a subtype-discriminated union has several) must
+      // pin the same top-level `type`, and it must be the key it is filed under.
+      for (const literal of literals) expect(literal).toBe(key);
+    }
+  });
+
+  it('returns __unknown__ (never throws) for prototype-named event types', () => {
+    // `'constructor' in obj` is true via Object.prototype, so an object-index
+    // guard would pass and then call `.safeParse` on Object itself — a TypeError
+    // out of a function documented to NEVER throw. Ordinary JSON can carry these.
+    for (const type of ['constructor', 'toString', 'valueOf', 'hasOwnProperty', '__proto__']) {
+      const event = JSON.parse(JSON.stringify({ type, anything: 1 })) as unknown;
+      let result: ReturnType<TypedEventNarrowing['narrow']> | undefined;
+      expect(() => { result = narrower.narrow(event); }).not.toThrow();
+      expect(result && 'kind' in result && result.kind).toBe('__unknown__');
+    }
+  });
+
   it('narrows every content-block kind, and rejects an unknown or malformed one', () => {
     // contentBlockSchema is a discriminatedUnion parsed once PER BLOCK, so this
     // pins that all three arms still narrow and that a bad block still sinks the
@@ -316,6 +355,16 @@ describe('TypedEventNarrowing', () => {
       42,
       null,
       { type: null },
+      // Prototype-reachable names: the old union rejected these, and so must the
+      // dispatch path (rather than resolving to Object.prototype members).
+      { type: 'constructor' },
+      { type: 'toString' },
+      { type: 'valueOf' },
+      { type: 'hasOwnProperty' },
+      // Non-string discriminants.
+      { type: 1 },
+      { type: { toString: () => 'assistant' } },
+      [],
     ];
 
     for (const value of corpus) {

--- a/main/src/services/streamParser/schemas.ts
+++ b/main/src/services/streamParser/schemas.ts
@@ -225,7 +225,16 @@ const systemUnionSchema = z.discriminatedUnion('subtype', [
 // Assistant variant schema
 // ---------------------------------------------------------------------------
 
-const contentBlockSchema = z.union([
+// discriminatedUnion, not union: this parses once PER CONTENT BLOCK of every
+// assistant message, so a plain union would build a ZodError for each
+// non-matching block type on every block (see the dispatch-map comment at the
+// bottom of this file for why that is expensive). All three arms are plain
+// objects pinning a distinct `type`, which is exactly what Zod 3's
+// discriminatedUnion requires. Accept/reject behaviour is unchanged — only the
+// error SHAPE on failure differs, and the sole consumer
+// (TypedEventNarrowing.narrow) discards the error and falls back to
+// `__unknown__`.
+const contentBlockSchema = z.discriminatedUnion('type', [
   textBlockSchema,
   toolUseBlockSchema,
   thinkingBlockSchema,
@@ -264,7 +273,8 @@ const userEventSchema = z.object({
     // Primarily tool_result blocks (SDK user turns); may also carry text blocks for
     // genuine user-text turns (the on-demand monitor's injected conversation turns).
     // Mirrors the additive widening of UserEvent.message.content in claudeStream.ts.
-    content: z.array(z.union([toolResultBlockSchema, textBlockSchema])),
+    // discriminatedUnion for the same per-block reason as contentBlockSchema.
+    content: z.array(z.discriminatedUnion('type', [toolResultBlockSchema, textBlockSchema])),
   }).passthrough(),
   // Two wire shapes observed: the file-tool metadata OBJECT (SamSaffron gist), and
   // an ARRAY of content blocks — what an MCP tool result carries (confirmed in the
@@ -458,6 +468,48 @@ export const claudeStreamEventSchema = z.union([
   resultUnionSchema,
   streamEventSchema,
 ]);
+
+// ---------------------------------------------------------------------------
+// Top-level branch dispatch (performance)
+//
+// `z.union` has no fast path: Zod 3 tries each branch in order and CONSTRUCTS A
+// FULL ZodError for every one that does not match — including the branches it
+// discards before reaching the one that does. Since each ZodError captures a
+// stack trace, the cost lands on every single streamed event. Profiling the
+// main process under two concurrent sprint runs put `ZodError` construction at
+// ~39% of ALL main-process CPU, with GC (churning those errors) next at ~10%.
+//
+// Every branch above pins a distinct top-level `type` literal, so the branch a
+// value can possibly match is fully determined by `type` alone. This map makes
+// that dispatch O(1) and parses exactly ONE branch, which is semantically
+// identical to the union — a value whose `type` is X cannot match any branch
+// that pins a different literal, and a value with a missing/non-string `type`
+// matches nothing either way (both routes yield the `__unknown__` fallback).
+//
+// The union above is retained as the source of truth for the drift bridges;
+// {@link TypedEventNarrowing} is the only runtime consumer and it uses this map.
+// ---------------------------------------------------------------------------
+
+export const claudeStreamEventSchemaByType = {
+  system: systemUnionSchema,
+  session_info: sessionInfoSchema,
+  rate_limit_event: rateLimitEventSchema,
+  assistant: assistantEventSchema,
+  user: userEventSchema,
+  result: resultUnionSchema,
+  stream_event: streamEventSchema,
+} as const;
+
+// Compile-time coverage bridges — the reason a forgotten map entry cannot
+// silently demote a whole event variant to `__unknown__` at runtime. Adding a
+// branch to the union without adding it here (or vice versa) fails `tsc`.
+type MapBranchOutput = z.infer<
+  (typeof claudeStreamEventSchemaByType)[keyof typeof claudeStreamEventSchemaByType]
+>;
+const _mapCoversUnion: MapBranchOutput = {} as z.infer<typeof claudeStreamEventSchema>;
+void _mapCoversUnion;
+const _unionCoversMap: z.infer<typeof claudeStreamEventSchema> = {} as MapBranchOutput;
+void _unionCoversMap;
 
 // ---------------------------------------------------------------------------
 // Compile-time drift bridges

--- a/main/src/services/streamParser/typedEventNarrowing.ts
+++ b/main/src/services/streamParser/typedEventNarrowing.ts
@@ -6,9 +6,12 @@
  * to the { kind: '__unknown__', raw } catch-all — never throws, never drops.
  */
 
-import { claudeStreamEventSchema } from './schemas';
+import { claudeStreamEventSchemaByType } from './schemas';
 import type { ClaudeStreamEvent } from '../../../../shared/types/claudeStream';
 import type { ILogger } from './types';
+
+/** The `type` values that have a schema branch. */
+type KnownEventType = keyof typeof claudeStreamEventSchemaByType;
 
 export class TypedEventNarrowing {
   private readonly logger: Pick<ILogger, 'verbose'> | undefined;
@@ -20,28 +23,38 @@ export class TypedEventNarrowing {
   /**
    * Narrow a parsed JSON value to a typed ClaudeStreamEvent.
    *
-   * Runs `claudeStreamEventSchema.safeParse(parsed)`. On success, returns the
-   * validated, narrowed event. On failure (unknown variant, missing field, bad
-   * type), returns `{ kind: '__unknown__', raw: parsed }`.
+   * Dispatches on the top-level `type` discriminant via
+   * `claudeStreamEventSchemaByType` and `safeParse`s that ONE branch. On
+   * success, returns the validated, narrowed event. On failure (unknown
+   * variant, missing field, bad type), returns `{ kind: '__unknown__', raw }`.
+   *
+   * Equivalent to parsing the full `claudeStreamEventSchema` union, because
+   * every branch pins a distinct `type` literal — but without constructing a
+   * ZodError for each non-matching branch, which profiling showed dominated
+   * main-process CPU while runs were streaming (see the map's header comment).
    *
    * Contract: NEVER throws. NEVER drops (unknown events become the catch-all
    * variant, not null).
    */
   narrow(parsed: unknown): ClaudeStreamEvent {
-    const result = claudeStreamEventSchema.safeParse(parsed);
-    if (result.success) {
-      return result.data;
-    }
-
-    // Log at debug/verbose level — informative but not noisy.
     const rawObj =
       typeof parsed === 'object' && parsed !== null
         ? (parsed as Record<string, unknown>)
         : {};
-    const wireType =
-      typeof rawObj['type'] === 'string' ? rawObj['type'] : '<missing>';
+    const rawType = rawObj['type'];
+    const wireType = typeof rawType === 'string' ? rawType : undefined;
+
+    if (wireType !== undefined && wireType in claudeStreamEventSchemaByType) {
+      const branch = claudeStreamEventSchemaByType[wireType as KnownEventType];
+      const result = branch.safeParse(parsed);
+      if (result.success) {
+        return result.data;
+      }
+    }
+
+    // Log at debug/verbose level — informative but not noisy.
     this.logger?.verbose?.(
-      `[streamParser] unknown ClaudeStreamEvent variant type=${wireType}`,
+      `[streamParser] unknown ClaudeStreamEvent variant type=${wireType ?? '<missing>'}`,
     );
 
     return { kind: '__unknown__', raw: rawObj };

--- a/main/src/services/streamParser/typedEventNarrowing.ts
+++ b/main/src/services/streamParser/typedEventNarrowing.ts
@@ -9,9 +9,23 @@
 import { claudeStreamEventSchemaByType } from './schemas';
 import type { ClaudeStreamEvent } from '../../../../shared/types/claudeStream';
 import type { ILogger } from './types';
+import type { ZodTypeAny } from 'zod';
 
-/** The `type` values that have a schema branch. */
-type KnownEventType = keyof typeof claudeStreamEventSchemaByType;
+/**
+ * Runtime branch lookup, as a Map rather than a plain-object index.
+ *
+ * This MUST NOT be an object property lookup. `'constructor' in obj` — and
+ * likewise `toString`, `valueOf`, `__proto__`, `hasOwnProperty` — is true for
+ * any object literal via Object.prototype, so a wire event of
+ * `{ type: 'constructor' }` would pass the guard and then resolve to
+ * `Object`, whose `.safeParse` does not exist: a TypeError thrown straight
+ * out of `narrow()`, breaking its documented NEVER-throws contract and taking
+ * the streaming pipeline with it. A Map has no prototype chain to fall
+ * through, so an unknown `type` is simply a miss.
+ */
+const BRANCH_BY_TYPE: ReadonlyMap<string, ZodTypeAny> = new Map(
+  Object.entries(claudeStreamEventSchemaByType),
+);
 
 export class TypedEventNarrowing {
   private readonly logger: Pick<ILogger, 'verbose'> | undefined;
@@ -44,11 +58,11 @@ export class TypedEventNarrowing {
     const rawType = rawObj['type'];
     const wireType = typeof rawType === 'string' ? rawType : undefined;
 
-    if (wireType !== undefined && wireType in claudeStreamEventSchemaByType) {
-      const branch = claudeStreamEventSchemaByType[wireType as KnownEventType];
+    const branch = wireType === undefined ? undefined : BRANCH_BY_TYPE.get(wireType);
+    if (branch !== undefined) {
       const result = branch.safeParse(parsed);
       if (result.success) {
-        return result.data;
+        return result.data as ClaudeStreamEvent;
       }
     }
 

--- a/main/src/services/timerCensus.ts
+++ b/main/src/services/timerCensus.ts
@@ -1,0 +1,225 @@
+/**
+ * TimerCensus — attributes main-process timer WAKEUPS to the code that scheduled
+ * them.
+ *
+ * Why this exists (measured, not theoretical): in the Electron main process a
+ * libuv timer is not cheap the way it is in plain Node. Electron drives libuv
+ * from Chromium's CFRunLoop, so every timer fire costs a full
+ * `__CFRunLoopDoSources0 → uv_run → uv__run_timers → RunTimers` round trip, and
+ * re-arming a repeating timer adds a `uv__loop_interrupt` → `kevent` syscall. A
+ * native `sample` of an IDLE cyboflow main process attributes ~all of its
+ * on-CPU main-thread samples to exactly that path, while V8's own profiler
+ * reports the JS inside those callbacks at ~0.1% — i.e. the cost is the WAKEUP
+ * RATE, not the work per callback.
+ *
+ * That makes "how many times per second does each site fire, and does it do
+ * anything when it does" the question that matters, and no stock tool answers
+ * it. `process.getActiveResourcesInfo()` counts live handles but not their rate
+ * or origin, and an unref'd timer does not even show up there.
+ *
+ * This module wraps `setTimeout` / `setInterval` / `setImmediate`, records the
+ * app-code frame that created each one, and counts fires + callback time per
+ * site. {@link drainTimerCensus} returns a per-interval snapshot that
+ * {@link PerfTracer} prints alongside event-loop utilization.
+ *
+ * Gating: fully OFF unless `CYBOFLOW_PERF_TRACE=1`. When off, `installTimerCensus`
+ * returns without touching the globals, so normal runs keep the untouched
+ * built-ins and pay nothing. Capturing a creation stack per scheduled timer is
+ * far too expensive to leave on in production — that cost is the reason this is
+ * opt-in rather than always-on.
+ *
+ * Install as early as possible: sites that schedule a timer at module-import
+ * time are only attributed if the census is installed before that import runs.
+ */
+
+/** Minimal logger surface — kept local so this module imports nothing heavy. */
+interface CensusLogger {
+  info(message: string): void;
+}
+
+const TRACE_ENABLED = process.env.CYBOFLOW_PERF_TRACE === '1';
+
+/** Per-creation-site totals for the current interval. */
+interface SiteStats {
+  /** Timers created from this site during the interval. */
+  created: number;
+  /** Callback invocations from this site during the interval. */
+  fires: number;
+  /** Total wall time spent inside those callbacks, ms. */
+  callbackMs: number;
+  /** Shortest delay requested from this site, ms — the wakeup cadence. */
+  minDelayMs: number;
+  /** Kind of timer, for reading the report. */
+  kind: 'interval' | 'timeout' | 'immediate';
+}
+
+const sites = new Map<string, SiteStats>();
+let installed = false;
+
+function statsFor(site: string, kind: SiteStats['kind']): SiteStats {
+  let stats = sites.get(site);
+  if (!stats) {
+    stats = { created: 0, fires: 0, callbackMs: 0, minDelayMs: Number.POSITIVE_INFINITY, kind };
+    sites.set(site, stats);
+  }
+  return stats;
+}
+
+/**
+ * Resolve the first app-code frame that scheduled this timer.
+ *
+ * Skips this module and node internals so the reported site is the caller that
+ * can actually be changed. Falls back to the raw first frame rather than
+ * dropping the sample, so nothing goes unattributed.
+ */
+function callSite(): string {
+  const stack = new Error().stack;
+  if (!stack) return '(no stack)';
+  const lines = stack.split('\n').slice(1);
+  let firstFrame: string | null = null;
+  for (const line of lines) {
+    const match = line.match(/\(?((?:\/|[A-Za-z]:)[^():\s]+):(\d+):\d+\)?\s*$/);
+    if (!match) continue;
+    const [, file, lineNo] = match;
+    if (firstFrame === null) firstFrame = `${file.split('/').slice(-2).join('/')}:${lineNo}`;
+    if (file.includes('timerCensus')) continue;
+    if (file.includes('node:')) continue;
+    if (file.includes('/node_modules/')) {
+      // Keep node_modules frames, but label them so app code is easy to spot.
+      return `[dep] ${file.split('/node_modules/')[1]?.split('/').slice(0, 2).join('/') ?? file}:${lineNo}`;
+    }
+    return `${file.split('/').slice(-2).join('/')}:${lineNo}`;
+  }
+  return firstFrame ?? '(unresolved)';
+}
+
+/** A timer callback as node types it. */
+type TimerCallback = (...args: unknown[]) => void;
+
+/**
+ * Wrap a callback so each invocation is counted against the `stats` bucket its
+ * creation site owns.
+ */
+function countingWrapper(stats: SiteStats, callback: TimerCallback): TimerCallback {
+  return function wrapped(this: unknown, ...args: unknown[]): void {
+    const startedAt = performance.now();
+    try {
+      callback.apply(this, args);
+    } finally {
+      stats.fires += 1;
+      stats.callbackMs += performance.now() - startedAt;
+    }
+  };
+}
+
+/**
+ * Wrap `setTimeout` / `setInterval` / `setImmediate` on globalThis so every
+ * scheduled timer is attributed to its creation site. Idempotent, and a no-op
+ * unless `CYBOFLOW_PERF_TRACE=1`.
+ */
+export function installTimerCensus(): void {
+  if (!TRACE_ENABLED || installed) return;
+  installed = true;
+
+  const globals = globalThis as unknown as {
+    setTimeout: typeof setTimeout;
+    setInterval: typeof setInterval;
+    setImmediate: typeof setImmediate;
+  };
+
+  const realSetTimeout = globals.setTimeout;
+  const realSetInterval = globals.setInterval;
+  const realSetImmediate = globals.setImmediate;
+
+  // The wrappers deliberately forward to the real builtin and return its handle
+  // untouched, so `unref()` / `clearInterval()` / Timeout identity all keep
+  // working exactly as before — the census only observes.
+  const wrapScheduler = (
+    real: typeof setTimeout | typeof setInterval,
+    kind: 'timeout' | 'interval',
+  ) =>
+    function scheduled(callback: TimerCallback, ms?: number, ...args: unknown[]) {
+      const site = callSite();
+      const stats = statsFor(site, kind);
+      stats.created += 1;
+      stats.minDelayMs = Math.min(stats.minDelayMs, ms ?? 0);
+      return (real as (cb: TimerCallback, ms?: number, ...rest: unknown[]) => NodeJS.Timeout)(
+        countingWrapper(stats, callback),
+        ms,
+        ...args,
+      );
+    };
+
+  globals.setTimeout = wrapScheduler(realSetTimeout, 'timeout') as typeof setTimeout;
+  globals.setInterval = wrapScheduler(realSetInterval, 'interval') as typeof setInterval;
+  globals.setImmediate = function scheduledImmediate(callback: TimerCallback, ...args: unknown[]) {
+    const site = callSite();
+    const stats = statsFor(site, 'immediate');
+    stats.created += 1;
+    stats.minDelayMs = 0;
+    return realSetImmediate(
+      countingWrapper(stats, callback) as unknown as (...a: unknown[]) => void,
+      ...args,
+    );
+  } as unknown as typeof setImmediate;
+}
+
+/** One reported row, richest-first by fire count. */
+export interface TimerCensusRow {
+  site: string;
+  kind: SiteStats['kind'];
+  created: number;
+  fires: number;
+  callbackMs: number;
+  minDelayMs: number;
+}
+
+/**
+ * Drain the census into a sorted snapshot and reset the per-interval counters.
+ * Sites are kept (not deleted) so a long-lived interval keeps its identity
+ * across reports; only the counters reset.
+ */
+export function drainTimerCensus(limit = 8): TimerCensusRow[] {
+  const rows: TimerCensusRow[] = [];
+  for (const [site, stats] of sites) {
+    if (stats.fires === 0 && stats.created === 0) continue;
+    rows.push({
+      site,
+      kind: stats.kind,
+      created: stats.created,
+      fires: stats.fires,
+      callbackMs: Number(stats.callbackMs.toFixed(1)),
+      minDelayMs: Number.isFinite(stats.minDelayMs) ? stats.minDelayMs : 0,
+    });
+    stats.created = 0;
+    stats.fires = 0;
+    stats.callbackMs = 0;
+  }
+  rows.sort((a, b) => b.fires - a.fires);
+  return rows.slice(0, limit);
+}
+
+/** Format a census snapshot as a single log-friendly line. */
+export function formatTimerCensus(rows: TimerCensusRow[]): string {
+  if (rows.length === 0) return '(no timers)';
+  return rows
+    .map(
+      (row) =>
+        `${row.site}[${row.kind === 'interval' ? 'iv' : row.kind === 'timeout' ? 'to' : 'im'}@${row.minDelayMs}ms]=` +
+        `${row.fires}x/${row.callbackMs}ms`,
+    )
+    .join(' ');
+}
+
+/** Test-only: drop all recorded sites so cases do not leak into each other. */
+export function _resetTimerCensusForTesting(): void {
+  sites.clear();
+}
+
+/** Whether the census is active this process. */
+export function timerCensusEnabled(): boolean {
+  return TRACE_ENABLED;
+}
+
+/** Expose the logger type for the tracer's use. */
+export type { CensusLogger };

--- a/main/src/services/timerCensus.ts
+++ b/main/src/services/timerCensus.ts
@@ -97,6 +97,31 @@ function callSite(): string {
 type TimerCallback = (...args: unknown[]) => void;
 
 /**
+ * Copy the real timer's own SYMBOL properties onto the wrapper.
+ *
+ * `setTimeout` and `setImmediate` carry `Symbol(nodejs.util.promisify.custom)`,
+ * which is what makes `util.promisify(setTimeout)(ms, value)` resolve after
+ * `ms`. A bare wrapper function does not have it, so promisify silently falls
+ * back to callback-style and calls `setTimeout(ms, value, cb)` — the delay
+ * lands in the callback slot and the promise REJECTS with ERR_INVALID_ARG_TYPE.
+ * An instrument that changes the behaviour of the code it measures is worse
+ * than no instrument, so the hook is carried across.
+ *
+ * Deliberately symbols only: copying every own descriptor would drag in
+ * `length` / `name` / `prototype`, where a non-configurable mismatch can throw.
+ */
+function carryOwnSymbols(target: object, source: unknown): void {
+  // `source` is a global that a host may simply not provide (`setImmediate` is
+  // absent under some test environments and in browsers). Installing the census
+  // must never be what takes the process down, so a missing global is skipped.
+  if (typeof source !== 'function') return;
+  for (const symbol of Object.getOwnPropertySymbols(source)) {
+    const descriptor = Object.getOwnPropertyDescriptor(source, symbol);
+    if (descriptor) Object.defineProperty(target, symbol, descriptor);
+  }
+}
+
+/**
  * Wrap a callback so each invocation is counted against the `stats` bucket its
  * creation site owns.
  */
@@ -150,9 +175,18 @@ export function installTimerCensus(): void {
       );
     };
 
-  globals.setTimeout = wrapScheduler(realSetTimeout, 'timeout') as typeof setTimeout;
-  globals.setInterval = wrapScheduler(realSetInterval, 'interval') as typeof setInterval;
-  globals.setImmediate = function scheduledImmediate(callback: TimerCallback, ...args: unknown[]) {
+  const wrappedTimeout = wrapScheduler(realSetTimeout, 'timeout');
+  const wrappedInterval = wrapScheduler(realSetInterval, 'interval');
+  carryOwnSymbols(wrappedTimeout, realSetTimeout);
+  carryOwnSymbols(wrappedInterval, realSetInterval);
+  globals.setTimeout = wrappedTimeout as typeof setTimeout;
+  globals.setInterval = wrappedInterval as typeof setInterval;
+
+  // Same reason as carryOwnSymbols' guard: no setImmediate on this host, so
+  // there is nothing to wrap and nothing to attribute.
+  if (typeof realSetImmediate !== 'function') return;
+
+  const wrappedImmediate = function scheduledImmediate(callback: TimerCallback, ...args: unknown[]) {
     const site = callSite();
     const stats = statsFor(site, 'immediate');
     stats.created += 1;
@@ -161,7 +195,9 @@ export function installTimerCensus(): void {
       countingWrapper(stats, callback) as unknown as (...a: unknown[]) => void,
       ...args,
     );
-  } as unknown as typeof setImmediate;
+  };
+  carryOwnSymbols(wrappedImmediate, realSetImmediate);
+  globals.setImmediate = wrappedImmediate as unknown as typeof setImmediate;
 }
 
 /** One reported row, richest-first by fire count. */
@@ -178,8 +214,14 @@ export interface TimerCensusRow {
  * Drain the census into a sorted snapshot and reset the per-interval counters.
  * Sites are kept (not deleted) so a long-lived interval keeps its identity
  * across reports; only the counters reset.
+ *
+ * Returns EVERY site, deliberately. Truncating here would corrupt the headline
+ * wakeup rate: the counters are reset for all sites but only the returned rows
+ * are summable, so a slice would silently under-report exactly when the process
+ * is busiest (many sites firing) — i.e. it would bias the measurement in the
+ * flattering direction. {@link formatTimerCensus} truncates for DISPLAY only.
  */
-export function drainTimerCensus(limit = 8): TimerCensusRow[] {
+export function drainTimerCensus(): TimerCensusRow[] {
   const rows: TimerCensusRow[] = [];
   for (const [site, stats] of sites) {
     if (stats.fires === 0 && stats.created === 0) continue;
@@ -196,19 +238,25 @@ export function drainTimerCensus(limit = 8): TimerCensusRow[] {
     stats.callbackMs = 0;
   }
   rows.sort((a, b) => b.fires - a.fires);
-  return rows.slice(0, limit);
+  return rows;
 }
 
-/** Format a census snapshot as a single log-friendly line. */
-export function formatTimerCensus(rows: TimerCensusRow[]): string {
+/**
+ * Format a census snapshot as a single log-friendly line, showing only the
+ * busiest `limit` sites (the tail is noise) plus a count of what was elided —
+ * silent truncation would read as "these are all the timers" when they are not.
+ */
+export function formatTimerCensus(rows: TimerCensusRow[], limit = 8): string {
   if (rows.length === 0) return '(no timers)';
-  return rows
+  const shown = rows.slice(0, limit);
+  const elided = rows.length - shown.length;
+  return shown
     .map(
       (row) =>
         `${row.site}[${row.kind === 'interval' ? 'iv' : row.kind === 'timeout' ? 'to' : 'im'}@${row.minDelayMs}ms]=` +
         `${row.fires}x/${row.callbackMs}ms`,
     )
-    .join(' ');
+    .join(' ') + (elided > 0 ? ` (+${elided} more sites)` : '');
 }
 
 /** Test-only: drop all recorded sites so cases do not leak into each other. */

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dev": "pnpm run electron-dev",
     "electron-dev": "node scripts/ensure-sqlite-abi.mjs electron && concurrently \"pnpm run --filter frontend dev\" \"wait-on http://localhost:${CYBOFLOW_VITE_PORT:-4521} && electron . --remote-debugging-port=${CYBOFLOW_CDP_PORT:-9223}\"",
     "electron-dev:custom": "node scripts/ensure-sqlite-abi.mjs electron && concurrently \"pnpm run --filter frontend dev\" \"wait-on http://localhost:${CYBOFLOW_VITE_PORT:-4521} && electron .\"",
+    "dev:perf": "node scripts/ensure-sqlite-abi.mjs electron && concurrently \"pnpm run --filter frontend dev\" \"wait-on http://localhost:${CYBOFLOW_VITE_PORT:-4521} && CYBOFLOW_PERF_TRACE=1 electron . --inspect=${CYBOFLOW_INSPECT_PORT:-9229} --remote-debugging-port=${CYBOFLOW_CDP_PORT:-9223}\"",
     "build": "pnpm run build:frontend && pnpm run build:main && pnpm run build:electron",
     "build:frontend": "pnpm run --filter frontend build",
     "build:main": "pnpm run --filter main build && node scripts/bundle-mcp-server.mjs",

--- a/scripts/eval-cdp.mjs
+++ b/scripts/eval-cdp.mjs
@@ -1,0 +1,17 @@
+// Evaluate an expression in the Cyboflow renderer over CDP and print the result.
+const port = process.env.CDP_PORT ?? '9223';
+const expr = process.argv[2];
+const list = await (await fetch(`http://127.0.0.1:${port}/json/list`)).json();
+const page = list.find((t) => t.type === 'page' && /^https?:/.test(t.url));
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((r, j) => { ws.addEventListener('open', r, {once:true}); ws.addEventListener('error', j, {once:true}); });
+const send = (method, params) => new Promise((resolve, reject) => {
+  const id = Math.floor(Math.random() * 1e9);
+  const on = (e) => { const m = JSON.parse(String(e.data)); if (m.id !== id) return; ws.removeEventListener('message', on);
+    m.error ? reject(new Error(m.error.message)) : resolve(m.result); };
+  ws.addEventListener('message', on);
+  ws.send(JSON.stringify({ id, method, params }));
+});
+const res = await send('Runtime.evaluate', { expression: expr, returnByValue: true, awaitPromise: true });
+console.log(JSON.stringify(res.result?.value ?? res.exceptionDetails ?? res, null, 2));
+ws.close();

--- a/scripts/profile-electron.mjs
+++ b/scripts/profile-electron.mjs
@@ -1,0 +1,583 @@
+#!/usr/bin/env node
+/**
+ * Profile the real Cyboflow renderer and main process through their CDP /
+ * inspector endpoints.
+ *
+ * Renderer (needs `--remote-debugging-port`, default 9223 — `pnpm dev` sets it):
+ *   node scripts/profile-electron.mjs inspect
+ *   node scripts/profile-electron.mjs sample --label baseline-idle --duration-ms 10000
+ *   node scripts/profile-electron.mjs sample --label nav --duration-ms 10000 \
+ *     --click Backlog --click Reviews --click Home
+ *
+ * Main process (needs `--inspect`, default 9229 — use `pnpm dev:perf`):
+ *   node scripts/profile-electron.mjs cpu --label idle --duration-ms 20000
+ *   node scripts/profile-electron.mjs heap --label idle --duration-ms 30000
+ *
+ * `cpu` records a real V8 sampling profile and prints the self-time leaderboard,
+ * which is the only way to attribute main-process CPU to a specific function.
+ * `heap` runs V8's sampling allocation profiler, which attributes bytes ALLOCATED
+ * over the window to allocation sites — the churn that drives GC cost, distinct
+ * from retained heap.
+ *
+ * The script is dependency-free so it remains usable before Playwright has
+ * been built.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const argv = process.argv.slice(2);
+const command = argv.shift() ?? 'sample';
+
+function option(name, fallback) {
+  const index = argv.indexOf(name);
+  return index === -1 ? fallback : argv[index + 1];
+}
+
+function options(name) {
+  const values = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === name && argv[i + 1]) values.push(argv[i + 1]);
+  }
+  return values;
+}
+
+const host = option('--host', '127.0.0.1');
+const port = Number(option('--port', '9223'));
+const inspectPort = Number(option('--inspect-port', '9229'));
+const topN = Number(option('--top', '30'));
+const durationMs = Number(option('--duration-ms', '10000'));
+const label = option('--label', 'sample');
+const outputPath = option('--output', null);
+const clickLabels = options('--click');
+
+if (!Number.isFinite(port) || !Number.isFinite(durationMs) || durationMs < 250) {
+  throw new Error('Invalid --port or --duration-ms value');
+}
+
+const endpoint = `http://${host}:${port}`;
+
+async function readJson(url) {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`${url} returned HTTP ${response.status}`);
+  return response.json();
+}
+
+class CdpClient {
+  constructor(url) {
+    this.nextId = 1;
+    this.pending = new Map();
+    this.socket = new WebSocket(url);
+    this.ready = new Promise((resolve, reject) => {
+      this.socket.addEventListener('open', resolve, { once: true });
+      this.socket.addEventListener('error', reject, { once: true });
+    });
+    this.socket.addEventListener('message', (event) => {
+      const message = JSON.parse(String(event.data));
+      if (typeof message.id !== 'number') return;
+      const waiter = this.pending.get(message.id);
+      if (!waiter) return;
+      this.pending.delete(message.id);
+      if (message.error) waiter.reject(new Error(message.error.message));
+      else waiter.resolve(message.result);
+    });
+  }
+
+  async send(method, params = {}) {
+    await this.ready;
+    const id = this.nextId;
+    this.nextId += 1;
+    const result = new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+    });
+    this.socket.send(JSON.stringify({ id, method, params }));
+    return result;
+  }
+
+  close() {
+    this.socket.close();
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function targets() {
+  const list = await readJson(`${endpoint}/json/list`);
+  const page = list.find((target) => target.type === 'page' && /^https?:\/\//.test(target.url));
+  if (!page) throw new Error(`No Electron renderer target found at ${endpoint}`);
+  return { list, page };
+}
+
+function metricsMap(result) {
+  return Object.fromEntries(result.metrics.map(({ name, value }) => [name, value]));
+}
+
+function round(value, digits = 2) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  return Number(value.toFixed(digits));
+}
+
+function mb(bytes) {
+  return round(bytes / 1024 / 1024, 1);
+}
+
+function metricDelta(before, after, name, scale = 1) {
+  return round(((after[name] ?? 0) - (before[name] ?? 0)) * scale, 2);
+}
+
+function processSnapshot(result) {
+  return Object.fromEntries(result.processInfo.map((entry) => [String(entry.id), entry]));
+}
+
+function processDeltas(before, after) {
+  const rows = [];
+  for (const [pid, current] of Object.entries(after)) {
+    const previous = before[pid];
+    if (!previous) continue;
+    rows.push({
+      pid: Number(pid),
+      type: current.type,
+      cpuSeconds: round(current.cpuTime - previous.cpuTime, 3),
+    });
+  }
+  return rows.sort((a, b) => b.cpuSeconds - a.cpuSeconds);
+}
+
+async function inspect() {
+  const { list, page } = await targets();
+  const client = new CdpClient(page.webSocketDebuggerUrl);
+  try {
+    const { result } = await client.send('Runtime.evaluate', {
+      expression: `({
+        title: document.title,
+        url: location.href,
+        text: document.body.innerText.slice(0, 12000),
+        controls: [...document.querySelectorAll('button, a, [role="button"]')]
+          .map((node) => ({
+            tag: node.tagName,
+            text: (node.innerText || node.getAttribute('aria-label') || '').trim(),
+            ariaLabel: node.getAttribute('aria-label'),
+            title: node.getAttribute('title')
+          }))
+          .filter((item) => item.text || item.ariaLabel || item.title)
+          .slice(0, 300)
+      })`,
+      returnByValue: true,
+    });
+    console.log(JSON.stringify({ targets: list.map(({ id, title, type, url }) => ({ id, title, type, url })), page: result.value }, null, 2));
+  } finally {
+    client.close();
+  }
+}
+
+async function clickByLabel(client, text) {
+  const expression = `(() => {
+    const wanted = ${JSON.stringify(text)}.toLowerCase();
+    const nodes = [...document.querySelectorAll('button, a, [role="button"]')];
+    const node = nodes.find((candidate) => {
+      const label = (candidate.innerText || candidate.getAttribute('aria-label') || candidate.getAttribute('title') || '').trim().toLowerCase();
+      return label === wanted || label.includes(wanted);
+    });
+    if (!node) return { clicked: false, available: nodes.map((item) => (item.innerText || item.getAttribute('aria-label') || '').trim()).filter(Boolean).slice(0, 100) };
+    node.click();
+    return { clicked: true, label: (node.innerText || node.getAttribute('aria-label') || '').trim() };
+  })()`;
+  const { result } = await client.send('Runtime.evaluate', { expression, returnByValue: true });
+  if (!result.value?.clicked) throw new Error(`Could not click ${JSON.stringify(text)}: ${JSON.stringify(result.value?.available)}`);
+  return result.value.label;
+}
+
+async function sample() {
+  const [{ page }, browserVersion] = await Promise.all([
+    targets(),
+    readJson(`${endpoint}/json/version`),
+  ]);
+  const pageClient = new CdpClient(page.webSocketDebuggerUrl);
+  const browserClient = new CdpClient(browserVersion.webSocketDebuggerUrl);
+
+  try {
+    await Promise.all([
+      pageClient.send('Performance.enable'),
+      pageClient.send('Runtime.enable'),
+    ]);
+
+    const [beforeMetricsResult, beforeDom, beforeProcessesResult] = await Promise.all([
+      pageClient.send('Performance.getMetrics'),
+      pageClient.send('Memory.getDOMCounters'),
+      browserClient.send('SystemInfo.getProcessInfo'),
+    ]);
+    const beforeMetrics = metricsMap(beforeMetricsResult);
+    const beforeProcesses = processSnapshot(beforeProcessesResult);
+
+    const clicked = [];
+    const startedAt = Date.now();
+    let clickIndex = 0;
+    while (Date.now() - startedAt < durationMs) {
+      if (clickLabels.length > 0) {
+        clicked.push(await clickByLabel(pageClient, clickLabels[clickIndex % clickLabels.length]));
+        clickIndex += 1;
+      }
+      await sleep(Math.min(1000, Math.max(0, durationMs - (Date.now() - startedAt))));
+    }
+
+    const [afterMetricsResult, afterDom, afterProcessesResult] = await Promise.all([
+      pageClient.send('Performance.getMetrics'),
+      pageClient.send('Memory.getDOMCounters'),
+      browserClient.send('SystemInfo.getProcessInfo'),
+    ]);
+    const afterMetrics = metricsMap(afterMetricsResult);
+    const afterProcesses = processSnapshot(afterProcessesResult);
+    const actualDurationMs = Date.now() - startedAt;
+
+    const report = {
+      label,
+      capturedAt: new Date().toISOString(),
+      endpoint,
+      page: { title: page.title, url: page.url },
+      durationMs: actualDurationMs,
+      workload: { requestedClicks: clickLabels, completedClicks: clicked },
+      renderer: {
+        jsHeapUsedMb: mb(afterMetrics.JSHeapUsedSize ?? 0),
+        jsHeapTotalMb: mb(afterMetrics.JSHeapTotalSize ?? 0),
+        documents: afterDom.documents,
+        nodes: afterDom.nodes,
+        listeners: afterDom.jsEventListeners,
+        nodeDelta: afterDom.nodes - beforeDom.nodes,
+        listenerDelta: afterDom.jsEventListeners - beforeDom.jsEventListeners,
+        taskDurationMs: metricDelta(beforeMetrics, afterMetrics, 'TaskDuration', 1000),
+        scriptDurationMs: metricDelta(beforeMetrics, afterMetrics, 'ScriptDuration', 1000),
+        layoutDurationMs: metricDelta(beforeMetrics, afterMetrics, 'LayoutDuration', 1000),
+        recalcStyleDurationMs: metricDelta(beforeMetrics, afterMetrics, 'RecalcStyleDuration', 1000),
+        layoutCount: metricDelta(beforeMetrics, afterMetrics, 'LayoutCount'),
+        recalcStyleCount: metricDelta(beforeMetrics, afterMetrics, 'RecalcStyleCount'),
+      },
+      processes: processDeltas(beforeProcesses, afterProcesses),
+    };
+
+    const json = JSON.stringify(report, null, 2);
+    console.log(json);
+    if (outputPath) {
+      await fs.mkdir(path.dirname(outputPath), { recursive: true });
+      await fs.writeFile(outputPath, `${json}\n`);
+    }
+  } finally {
+    pageClient.close();
+    browserClient.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main-process profiling (V8 inspector on --inspect-port)
+// ---------------------------------------------------------------------------
+
+const inspectEndpoint = `http://${host}:${inspectPort}`;
+
+/**
+ * Resolve the main-process inspector target. Electron's `--inspect` exposes a
+ * single `node` target; we accept the first entry either way so this keeps
+ * working if the shape changes.
+ */
+async function mainTarget() {
+  let list;
+  try {
+    list = await readJson(`${inspectEndpoint}/json/list`);
+  } catch (error) {
+    throw new Error(
+      `No main-process inspector at ${inspectEndpoint} (${error.message}). ` +
+        'Launch the app with `pnpm dev:perf`, which adds --inspect.',
+    );
+  }
+  const target = list.find((entry) => entry.webSocketDebuggerUrl);
+  if (!target) throw new Error(`No debuggable target at ${inspectEndpoint}`);
+  return target;
+}
+
+function frameLabel(callFrame) {
+  const name = callFrame.functionName || '(anonymous)';
+  const url = (callFrame.url || '').replace(/^file:\/\//, '');
+  // Keep the tail of the path — enough to identify the module, short enough to read.
+  const shortUrl = url ? url.split('/').slice(-2).join('/') : '(native)';
+  return `${name} @ ${shortUrl}:${(callFrame.lineNumber ?? 0) + 1}`;
+}
+
+/**
+ * Fold a .cpuprofile into self-time per function plus per-file totals.
+ *
+ * V8 reports `samples` (node ids) and `timeDeltas` (µs since the previous
+ * sample), so self time for a node is the sum of the deltas of the samples that
+ * landed on it — the honest "which function was actually on-CPU" measure.
+ */
+function foldCpuProfile(profile) {
+  const byId = new Map(profile.nodes.map((node) => [node.id, node]));
+  const selfMicros = new Map();
+  const samples = profile.samples ?? [];
+  const deltas = profile.timeDeltas ?? [];
+
+  let totalMicros = 0;
+  for (let i = 0; i < samples.length; i += 1) {
+    const delta = Math.max(0, deltas[i] ?? 0);
+    totalMicros += delta;
+    selfMicros.set(samples[i], (selfMicros.get(samples[i]) ?? 0) + delta);
+  }
+
+  const functions = [];
+  const byFile = new Map();
+  let idleMicros = 0;
+
+  for (const [id, micros] of selfMicros) {
+    const node = byId.get(id);
+    if (!node) continue;
+    const name = node.callFrame.functionName;
+    if (name === '(idle)' || name === '(program)') {
+      idleMicros += micros;
+      continue;
+    }
+    functions.push({ label: frameLabel(node.callFrame), ms: micros / 1000, hits: node.hitCount ?? 0 });
+
+    const url = (node.callFrame.url || '').replace(/^file:\/\//, '');
+    const file = url ? url.split('/').slice(-2).join('/') : '(native)';
+    byFile.set(file, (byFile.get(file) ?? 0) + micros);
+  }
+
+  functions.sort((a, b) => b.ms - a.ms);
+  const files = [...byFile.entries()]
+    .map(([file, micros]) => ({ file, ms: micros / 1000 }))
+    .sort((a, b) => b.ms - a.ms);
+
+  return {
+    totalMs: totalMicros / 1000,
+    idleMs: idleMicros / 1000,
+    busyMs: (totalMicros - idleMicros) / 1000,
+    functions,
+    files,
+  };
+}
+
+async function cpu() {
+  // `--target renderer` profiles the React renderer over the normal CDP port
+  // instead of the main process over the inspector port; everything downstream
+  // (folding, reporting) is identical because both speak the same Profiler
+  // domain.
+  const useRenderer = option('--target', 'main') === 'renderer';
+  const target = useRenderer ? (await targets()).page : await mainTarget();
+  const client = new CdpClient(target.webSocketDebuggerUrl);
+  try {
+    await client.send('Profiler.enable');
+    // 200µs — ~5x finer than the 1ms default, which matters when total busy time
+    // over the window is only a few hundred ms.
+    await client.send('Profiler.setSamplingInterval', { interval: 200 });
+    await client.send('Profiler.start');
+    if (useRenderer && clickLabels.length > 0) {
+      // Drive the same workload the `sample` command drives, so the profile
+      // explains a measured number rather than an idle window.
+      const startedAt = Date.now();
+      let index = 0;
+      while (Date.now() - startedAt < durationMs) {
+        await clickByLabel(client, clickLabels[index % clickLabels.length]);
+        index += 1;
+        await sleep(1000);
+      }
+    } else {
+      await sleep(durationMs);
+    }
+    const { profile } = await client.send('Profiler.stop');
+    await client.send('Profiler.disable');
+
+    const folded = foldCpuProfile(profile);
+    const wallMs = (profile.endTime - profile.startTime) / 1000;
+
+    const report = {
+      label,
+      capturedAt: new Date().toISOString(),
+      endpoint: inspectEndpoint,
+      target: target.title ?? target.url,
+      wallMs: round(wallMs),
+      busyMs: round(folded.busyMs),
+      idleMs: round(folded.idleMs),
+      cpuPercent: round((folded.busyMs / wallMs) * 100),
+      topFunctions: folded.functions.slice(0, topN).map((fn) => ({
+        ms: round(fn.ms),
+        percentOfBusy: round((fn.ms / Math.max(folded.busyMs, 0.001)) * 100),
+        fn: fn.label,
+      })),
+      topFiles: folded.files.slice(0, topN).map((entry) => ({
+        ms: round(entry.ms),
+        percentOfBusy: round((entry.ms / Math.max(folded.busyMs, 0.001)) * 100),
+        file: entry.file,
+      })),
+    };
+
+    console.log(JSON.stringify(report, null, 2));
+
+    const targetPath = outputPath ?? `.perf/${label}.cpuprofile`;
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    await fs.writeFile(targetPath, JSON.stringify(profile));
+    console.error(`\n[raw profile written to ${targetPath} — open in Chrome DevTools > Performance]`);
+  } finally {
+    client.close();
+  }
+}
+
+/**
+ * Fold a V8 sampling heap profile into bytes-allocated per allocation site.
+ * The tree carries `selfSize` per node; children accumulate separately.
+ */
+function foldHeapProfile(node, out = new Map()) {
+  if (node.selfSize > 0) {
+    const key = frameLabel(node.callFrame);
+    out.set(key, (out.get(key) ?? 0) + node.selfSize);
+  }
+  for (const child of node.children ?? []) foldHeapProfile(child, out);
+  return out;
+}
+
+async function heap() {
+  const target = await mainTarget();
+  const client = new CdpClient(target.webSocketDebuggerUrl);
+  try {
+    await client.send('HeapProfiler.enable');
+    const before = await client.send('Runtime.getHeapUsage').catch(() => null);
+    // 16KB sampling interval — fine enough to catch steady per-tick churn.
+    await client.send('HeapProfiler.startSampling', { samplingInterval: 16384 });
+    await sleep(durationMs);
+    const { profile } = await client.send('HeapProfiler.stopSampling');
+    const after = await client.send('Runtime.getHeapUsage').catch(() => null);
+    await client.send('HeapProfiler.disable');
+
+    const folded = [...foldHeapProfile(profile.head).entries()]
+      .map(([site, bytes]) => ({ site, bytes }))
+      .sort((a, b) => b.bytes - a.bytes);
+    const totalBytes = folded.reduce((sum, entry) => sum + entry.bytes, 0);
+
+    const report = {
+      label,
+      capturedAt: new Date().toISOString(),
+      endpoint: inspectEndpoint,
+      durationMs,
+      heapUsedMbBefore: before ? mb(before.usedSize) : null,
+      heapUsedMbAfter: after ? mb(after.usedSize) : null,
+      totalAllocatedMb: mb(totalBytes),
+      allocatedMbPerMinute: round((totalBytes / 1024 / 1024) * (60000 / durationMs), 2),
+      topAllocationSites: folded.slice(0, topN).map((entry) => ({
+        mb: mb(entry.bytes),
+        percent: round((entry.bytes / Math.max(totalBytes, 1)) * 100),
+        site: entry.site,
+      })),
+    };
+
+    console.log(JSON.stringify(report, null, 2));
+    if (outputPath) {
+      await fs.mkdir(path.dirname(outputPath), { recursive: true });
+      await fs.writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`);
+    }
+  } finally {
+    client.close();
+  }
+}
+
+/**
+ * Census the main process's live libuv handles, and measure how often timers
+ * actually fire. In Electron the main loop is Chromium's message pump with node
+ * integration polled on top, so every libuv timer wakeup costs a cross-thread
+ * signal + a pump round trip — the wakeup RATE drives idle CPU far more than the
+ * JS work each callback does. This is the instrument that shows the rate.
+ */
+async function handles() {
+  const target = await mainTarget();
+  const client = new CdpClient(target.webSocketDebuggerUrl);
+  try {
+    await client.send('Runtime.enable');
+
+    const measure = `(() => {
+      const counts = {};
+      for (const kind of process.getActiveResourcesInfo()) {
+        counts[kind] = (counts[kind] ?? 0) + 1;
+      }
+      return counts;
+    })()`;
+
+    // Count timer callbacks over the window by monkey-patching the timer list
+    // walker is not possible from here, so instead sample setInterval/setTimeout
+    // registrations and measure loop wakeups via a high-resolution probe.
+    const probeStart = `(() => {
+      globalThis.__perfProbe = { fires: 0, byDelay: {} };
+      const realSetInterval = setInterval;
+      const realSetTimeout = setTimeout;
+      globalThis.__perfProbeRestore = () => {
+        globalThis.setInterval = realSetInterval;
+        globalThis.setTimeout = realSetTimeout;
+      };
+      // Wrap only NEW registrations; already-live intervals are counted by the
+      // handle census above, and their delay is reported by _idleTimeout below.
+      const live = [];
+      globalThis.__perfProbeLive = live;
+      return true;
+    })()`;
+
+    // Walk node's internal timer lists to read the delay of every LIVE timer.
+    // process._getActiveHandles() is the only surface that exposes them.
+    const liveTimers = `(() => {
+      const out = [];
+      const handles = process._getActiveHandles ? process._getActiveHandles() : [];
+      for (const h of handles) {
+        const name = h && h.constructor ? h.constructor.name : typeof h;
+        const entry = { type: name };
+        if (typeof h._idleTimeout === 'number' && h._idleTimeout >= 0) entry.delayMs = h._idleTimeout;
+        if (typeof h._repeat === 'number') entry.repeatMs = h._repeat;
+        out.push(entry);
+      }
+      // Node keeps Timeouts off _getActiveHandles in modern versions; also walk
+      // the internal timers map when reachable.
+      return out;
+    })()`;
+
+    const [censusRes, timersRes] = await Promise.all([
+      client.send('Runtime.evaluate', { expression: measure, returnByValue: true, includeCommandLineAPI: true }),
+      client.send('Runtime.evaluate', { expression: liveTimers, returnByValue: true, includeCommandLineAPI: true }),
+    ]);
+    void probeStart;
+
+    // Measure the real wakeup rate: schedule nothing, just read the monotonic
+    // count of timer-list drains that node performs over the window.
+    const rateExpr = `(async () => {
+      const t0 = process.hrtime.bigint();
+      let ticks = 0;
+      await new Promise((resolve) => {
+        const started = Date.now();
+        const iv = setInterval(() => {
+          ticks += 1;
+          if (Date.now() - started >= ${Math.min(durationMs, 10000)}) { clearInterval(iv); resolve(); }
+        }, 1);
+      });
+      const elapsedMs = Number(process.hrtime.bigint() - t0) / 1e6;
+      // A 1ms interval can only fire as fast as the loop turns, so ticks/elapsed
+      // is a direct measure of the main loop's achievable turn rate.
+      return { elapsedMs, ticks, loopTurnsPerSec: Math.round((ticks / elapsedMs) * 1000) };
+    })()`;
+    const rateRes = await client.send('Runtime.evaluate', {
+      expression: rateExpr,
+      returnByValue: true,
+      awaitPromise: true,
+    });
+
+    console.log(JSON.stringify({
+      label,
+      capturedAt: new Date().toISOString(),
+      activeResources: censusRes.result.value,
+      activeHandles: timersRes.result.value,
+      loopRate: rateRes.result.value,
+    }, null, 2));
+  } finally {
+    client.close();
+  }
+}
+
+if (command === 'inspect') await inspect();
+else if (command === 'sample') await sample();
+else if (command === 'cpu') await cpu();
+else if (command === 'heap') await heap();
+else if (command === 'handles') await handles();
+else throw new Error(`Unknown command: ${command}`);

--- a/scripts/profile-electron.mjs
+++ b/scripts/profile-electron.mjs
@@ -479,11 +479,14 @@ async function heap() {
 }
 
 /**
- * Census the main process's live libuv handles, and measure how often timers
- * actually fire. In Electron the main loop is Chromium's message pump with node
- * integration polled on top, so every libuv timer wakeup costs a cross-thread
- * signal + a pump round trip — the wakeup RATE drives idle CPU far more than the
- * JS work each callback does. This is the instrument that shows the rate.
+ * Census the main process's live libuv handles (what is keeping the loop alive
+ * right now). In Electron the main loop is Chromium's message pump with node
+ * integration polled on top, so every libuv wakeup costs a cross-thread signal
+ * + a pump round trip.
+ *
+ * This reports STANDING handles, not a rate. For wakeups-per-second attributed
+ * to the code that scheduled them, use the in-process TimerCensus — the
+ * `[perf-timers]` line under `pnpm dev:perf`.
  */
 async function handles() {
   const target = await mainTarget();
@@ -497,24 +500,6 @@ async function handles() {
         counts[kind] = (counts[kind] ?? 0) + 1;
       }
       return counts;
-    })()`;
-
-    // Count timer callbacks over the window by monkey-patching the timer list
-    // walker is not possible from here, so instead sample setInterval/setTimeout
-    // registrations and measure loop wakeups via a high-resolution probe.
-    const probeStart = `(() => {
-      globalThis.__perfProbe = { fires: 0, byDelay: {} };
-      const realSetInterval = setInterval;
-      const realSetTimeout = setTimeout;
-      globalThis.__perfProbeRestore = () => {
-        globalThis.setInterval = realSetInterval;
-        globalThis.setTimeout = realSetTimeout;
-      };
-      // Wrap only NEW registrations; already-live intervals are counted by the
-      // handle census above, and their delay is reported by _idleTimeout below.
-      const live = [];
-      globalThis.__perfProbeLive = live;
-      return true;
     })()`;
 
     // Walk node's internal timer lists to read the delay of every LIVE timer.
@@ -538,37 +523,19 @@ async function handles() {
       client.send('Runtime.evaluate', { expression: measure, returnByValue: true, includeCommandLineAPI: true }),
       client.send('Runtime.evaluate', { expression: liveTimers, returnByValue: true, includeCommandLineAPI: true }),
     ]);
-    void probeStart;
 
-    // Measure the real wakeup rate: schedule nothing, just read the monotonic
-    // count of timer-list drains that node performs over the window.
-    const rateExpr = `(async () => {
-      const t0 = process.hrtime.bigint();
-      let ticks = 0;
-      await new Promise((resolve) => {
-        const started = Date.now();
-        const iv = setInterval(() => {
-          ticks += 1;
-          if (Date.now() - started >= ${Math.min(durationMs, 10000)}) { clearInterval(iv); resolve(); }
-        }, 1);
-      });
-      const elapsedMs = Number(process.hrtime.bigint() - t0) / 1e6;
-      // A 1ms interval can only fire as fast as the loop turns, so ticks/elapsed
-      // is a direct measure of the main loop's achievable turn rate.
-      return { elapsedMs, ticks, loopTurnsPerSec: Math.round((ticks / elapsedMs) * 1000) };
-    })()`;
-    const rateRes = await client.send('Runtime.evaluate', {
-      expression: rateExpr,
-      returnByValue: true,
-      awaitPromise: true,
-    });
-
+    // NOTE: there is deliberately no "wakeup rate" number here. An earlier
+    // version scheduled its own `setInterval(…, 1)` and reported how fast THAT
+    // fired, which measures the profiler's own timer, not the app's — an idle
+    // app and one already carrying a 60Hz interval produced nearly identical
+    // figures. Timer wakeup RATE comes from the in-process TimerCensus
+    // (`[perf-timers]` under `pnpm dev:perf`), which counts real fires per site;
+    // this command reports the live HANDLE census only.
     console.log(JSON.stringify({
       label,
       capturedAt: new Date().toISOString(),
       activeResources: censusRes.result.value,
       activeHandles: timersRes.result.value,
-      loopRate: rateRes.result.value,
     }, null, 2));
   } finally {
     client.close();

--- a/scripts/trpc-call.mjs
+++ b/scripts/trpc-call.mjs
@@ -19,11 +19,22 @@ const send = (method, params) => new Promise((resolve, reject) => {
 
 // superjson is what the app's tRPC link uses, so inputs must be wrapped the
 // same way ({ json: <value> }) and outputs unwrapped from the same envelope.
+// The listener and the timeout are BOTH torn down on settle. They live in the
+// renderer, not in this process, so leaking them would accumulate listeners and
+// 2-minute timers inside the very app being profiled — measurement contaminating
+// the measurement.
 const expr = `(() => new Promise((resolve) => {
   const id = Math.floor(Math.random() * 1e9);
-  const off = window.electronTRPC.onMessage((msg) => {
+  let timer = null;
+  let off = null;
+  const settle = (value) => {
+    if (timer !== null) { clearTimeout(timer); timer = null; }
+    if (typeof off === 'function') { off(); off = null; }
+    resolve(value);
+  };
+  off = window.electronTRPC.onMessage((msg) => {
     if (msg?.id !== id) return;
-    resolve(JSON.parse(JSON.stringify(msg)));
+    settle(JSON.parse(JSON.stringify(msg)));
   });
   window.electronTRPC.sendMessage({
     id,
@@ -36,7 +47,7 @@ const expr = `(() => new Promise((resolve) => {
       context: {},
     },
   });
-  setTimeout(() => resolve({ timeout: true }), 120000);
+  timer = setTimeout(() => settle({ timeout: true }), 120000);
 }))()`;
 const res = await send('Runtime.evaluate', { expression: expr, returnByValue: true, awaitPromise: true });
 console.log(JSON.stringify(res.result?.value ?? res.exceptionDetails ?? res, null, 2));

--- a/scripts/trpc-call.mjs
+++ b/scripts/trpc-call.mjs
@@ -1,0 +1,43 @@
+/**
+ * Call a cyboflow tRPC procedure from OUTSIDE the app, over the renderer's
+ * `window.electronTRPC` bridge (the same transport the React app uses), driven
+ * through CDP. Args: <path> <type: query|mutation> <inputJson>
+ */
+const port = process.env.CDP_PORT ?? '9223';
+const [path, type = 'query', inputJson = 'null'] = process.argv.slice(2);
+const list = await (await fetch(`http://127.0.0.1:${port}/json/list`)).json();
+const page = list.find((t) => t.type === 'page' && /^https?:/.test(t.url));
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((r, j) => { ws.addEventListener('open', r, {once:true}); ws.addEventListener('error', j, {once:true}); });
+const send = (method, params) => new Promise((resolve, reject) => {
+  const id = Math.floor(Math.random() * 1e9);
+  const on = (e) => { const m = JSON.parse(String(e.data)); if (m.id !== id) return; ws.removeEventListener('message', on);
+    m.error ? reject(new Error(m.error.message)) : resolve(m.result); };
+  ws.addEventListener('message', on);
+  ws.send(JSON.stringify({ id, method, params }));
+});
+
+// superjson is what the app's tRPC link uses, so inputs must be wrapped the
+// same way ({ json: <value> }) and outputs unwrapped from the same envelope.
+const expr = `(() => new Promise((resolve) => {
+  const id = Math.floor(Math.random() * 1e9);
+  const off = window.electronTRPC.onMessage((msg) => {
+    if (msg?.id !== id) return;
+    resolve(JSON.parse(JSON.stringify(msg)));
+  });
+  window.electronTRPC.sendMessage({
+    id,
+    method: 'request',
+    operation: {
+      id,
+      type: ${JSON.stringify(type)},
+      path: ${JSON.stringify(path)},
+      input: { json: ${inputJson} },
+      context: {},
+    },
+  });
+  setTimeout(() => resolve({ timeout: true }), 120000);
+}))()`;
+const res = await send('Runtime.evaluate', { expression: expr, returnByValue: true, awaitPromise: true });
+console.log(JSON.stringify(res.result?.value ?? res.exceptionDetails ?? res, null, 2));
+ws.close();


### PR DESCRIPTION
Instrumented, measured, and fixed two hot paths in the Electron main process. Every number below is an A/B against the previous build under identical conditions, with a bare-Electron control for the floor.

## Impact

| Regime | Metric | Before | After |
|---|---|---|---|
| **Idle** | main-process CPU | 1.76% | **0.30%** |
| | idle wakeups | 20 / 3s | **2 / 3s** |
| | timer wakeups | 97.7/s | **~0/s** |
| **Streaming** (2 concurrent sprints) | main-process JS per raw event | 3.51ms | **0.65ms** |
| | ZodError share of main CPU | 58.8% | **8.8%** |
| | GC | 72ms/45s | **15.6ms/45s** |

Bare-Electron idle floor is 0.03%, so idle went from ~60x that to ~10x.

Memory needed no changes: heap is flat idle (0 bytes/min allocated) and under load (~47MB, 1.4 MB/min), and RSS trends *down* as runs settle. The GC drop came free with the Zod fix.

## The two fixes

**1. `throttle.ts` — a subscription held a `setInterval(1000/hz)` for its entire life.** At `hz=60`, two live subscriptions fired ~98 times/second between them and did 0.8ms of real work per 5000ms — ~99.98% pure wakeup overhead on a completely idle app. In the Electron main process a timer fire is not the cheap thing it is in plain Node: libuv is driven by Chromium's CFRunLoop, so each one costs a `__CFRunLoopDoSources0 → uv_run → uv__run_timers` round trip plus a `uv__loop_interrupt`/`kevent` to re-arm. Now a cooldown chain, armed only while a value is pending, built from relative delays only.

**2. `streamParser/schemas.ts` — a 7-branch plain `z.union` rebuilt a `ZodError` per non-matching branch, per event.** Zod has no fast path there: it tries each branch in order and constructs a full stack-capturing error for every miss, including branches discarded before reaching the match. A Codex run emits hundreds of events matching no Claude branch at all. Every branch pins a distinct top-level `type`, so dispatch is now O(1) on that discriminant, parsing exactly one branch. Two inner unions (`contentBlockSchema`, parsed once *per content block* of every assistant message) became `discriminatedUnion`s.

## How it was measured

New opt-in harness, all behind `CYBOFLOW_PERF_TRACE=1` and free when off — see `docs/PERFORMANCE.md`:

- **`timerCensus.ts`** — attributes timer wakeups + callback time to the frame that scheduled them. No stock tool answers this: V8's profiler reported main at 0.12% busy while the OS reported 2%, because the cost is in the wakeup machinery, not the JS.
- **`pnpm dev:perf`** — dev + tracer + `--inspect` in one command.
- **`scripts/profile-electron.mjs`** — adds `cpu` (main-process V8 profile + self-time leaderboard), `heap` (allocation-site sampling), `handles`; `cpu --target renderer` profiles the renderer while driving the UI.
- **`scripts/eval-cdp.mjs` / `trpc-call.mjs`** — drive a running app from outside over `window.electronAPI` / `window.electronTRPC`, so active-session load can be generated headlessly.

Load testing ran real sprints — Claude SDK (sonnet) and Codex SDK (`gpt-5.6-luna`) concurrently against a throwaway repo. Both produced real commits, including a review-driven fix cycle.

## Adversarial review

The branch was reviewed adversarially by Codex, which found **7 real defects**, two in the "semantics-preserving" claims themselves. All fixed in `6f82c656`:

- **[High]** `narrow()` could **throw**: the dispatch guard used `in`, which walks the prototype chain, so `{"type":"constructor"}` resolved to `Object` and called a non-existent `.safeParse` — violating an explicit NEVER-throws contract. Now a `Map`.
- **[High]** The throttle derived its delay from a `Date.now()` delta — wrong across a clock jump in both directions, and it made the documented equivalence claim false (a post-idle burst emitted its first value immediately instead of coalescing). Replaced with the cooldown chain; no wall clock anywhere.
- **[Medium]** The census dropped `Symbol(nodejs.util.promisify.custom)`, breaking `promisify(setTimeout)` — the exact observer effect it must not have. Also threw where `setImmediate` is absent.
- **[Medium]** `drainTimerCensus` reset every site but returned only the top 8, biasing its own headline number low exactly when busiest.
- **[Low]** `handles` shipped dead code and a rate derived from the profiler's own 1ms interval; `trpc-call.mjs` leaked a renderer listener per call into the app being profiled.

Codex also flagged **four tests that would still pass if the optimisation were silently wrong** — all fixed rather than trusted. The map is now verified by *declared literal per branch* (so swapping two entries fails), the equivalence corpus includes prototype-reachable and non-string discriminants, and there's a clock-jump test moving `Date.now()` an hour each way.

`bd945ddd` then fixed a pre-existing teardown hazard Codex flagged. Worth noting: my first diagnosis was wrong and the test caught it. Between emissions the generator suspends at an *internal* `await`, where `.return()` is merely queued — so no teardown code ran at all, and rewriting the teardown block could never have helped. It needed an external wake, so the throttle now takes the subscription's `AbortSignal` (optional; omitting it preserves old behaviour). Impact was a leak, not a stall, and it was unreachable via today's sources.

## Verification

- `pnpm typecheck` clean, `pnpm lint` 0 errors
- `pnpm test:unit` — 535 main + 265 frontend test files (8880 + 3752 tests)
- `pnpm test:integration` — 13/13
- Rebuilt and re-ran the app after each change: 0.2 timer wakeups/sec, no errors

## Known limitations

- **Renderer performance is not validly measured here.** Every renderer profile under `pnpm dev` is dominated by `jsxDEV`, React's dev-mode runtime. I deliberately optimised nothing there rather than chase a dev-only artifact; real numbers need a production frontend build. Main-process figures are unaffected — `main/dist` is the same `tsc` output in dev and prod.
- **The throttle fix is verified at idle, not under streaming load.** The run view streams over the raw `cyboflow:stream:<runId>` IPC channel, not the throttled tRPC path, so the 60Hz path stayed cold during load testing.
- **Short runs only** — no multi-hour soak, no large session history.
- The instrumentation itself costs roughly **+1% main-process CPU**; use `dev:perf` to find problems, quote plain `dev` for results. Documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
