### PR TITLE
feat: dispatch PTY fan-out stages as dynamic workflows (default off) + 2 tracker/rest defects

### DIFF
--- a/docs/proposals/pty-dynamic-workflow-implementation-plan.md
+++ b/docs/proposals/pty-dynamic-workflow-implementation-plan.md
@@ -260,12 +260,36 @@ probe surfaced a fourth fact that neither reviewer predicted.
    | `dontAsk` | **DENIED** ❌ |
    | `bypassPermissions` | allowed |
 
-   Cyboflow's 4-mode `agentPermissionMode` is `default | acceptEdits | auto |
-   dontAsk`. **Only `auto` can dispatch.** The most permissive-sounding mode,
-   `dontAsk`, denies outright — it suppresses the prompt by refusing, not by
-   allowing. A run in `default`/`acceptEdits` will surface the gate through
-   cyboflow's approval queue (once per dispatch); a run in `dontAsk` will fail
-   every dispatch. This must be enforced or documented before enabling the mode.
+   **Mapping that table onto cyboflow needs care — the flag names and
+   cyboflow's mode names collide without meaning the same thing.** The
+   interactive path emits exactly ONE permission flag: `--permission-mode auto`,
+   and only for `agentPermissionMode === 'auto'`
+   (`interactiveClaudeManager.ts:636-638`). Every other mode passes NO flag and
+   differs only in whether cyboflow's own wildcard PreToolUse hook is installed.
+   So:
+
+   | cyboflow mode | what the CLI sees | dispatch |
+   | --- | --- | --- |
+   | `auto` | `--permission-mode auto`, no cyboflow hook | **works** (verified) |
+   | `default` / `acceptEdits` | CLI default + cyboflow's PreToolUse hook | **unknown** — see below |
+   | `dontAsk` | CLI default, NO hook | CLI's own gate prompts **in the terminal** |
+
+   `dontAsk` is the trap: cyboflow documents it as "run unrestricted, equivalent
+   to `--dangerously-skip-permissions`" (`permissionModeMapper.ts:5`,
+   `shared/types/workflows.ts:37`), which is true of the SDK path (install no
+   hook, SDK runs unrestricted) but NOT of the CLI flag of the same name, which
+   denies. On the interactive substrate cyboflow does not pass that flag at all,
+   so the effect is neither: the CLI's own review gate fires with cyboflow's
+   approval plumbing switched off, i.e. a blocking prompt in a terminal nobody is
+   watching.
+
+   **Untested:** whether an `allow` from cyboflow's PreToolUse hook pre-empts the
+   CLI's dynamic-workflow review gate in `default`/`acceptEdits`. Hooks run first
+   in the CLI permission order, which suggests it might, but this was not probed.
+
+   **Recommendation: gate the feature to `agentPermissionMode === 'auto'`** — the
+   one combination verified end-to-end — until the `default`/`acceptEdits` case
+   is probed.
 
 **Bonus verification:** the on-disk artifact contract the tracker depends on
 matches exactly — `<uuid>/workflows/scripts/<name>-wf_<id>.js` (and

--- a/docs/proposals/pty-dynamic-workflow-implementation-plan.md
+++ b/docs/proposals/pty-dynamic-workflow-implementation-plan.md
@@ -1,0 +1,224 @@
+# Implementation plan — PTY fan-out steps as dynamic workflows
+
+Companion to `pty-dynamic-workflow-orchestration.md` (the feasibility
+assessment). This is the build plan for **Option B (phase-scoped dispatch)**,
+scoped to what is implementable and testable headlessly.
+
+**Guiding constraint: default OFF.** Every plank lands inert. With
+`dynamicWorkflowFanOut` unset, a run's prompt, spawn args, and on-disk worktree
+are byte-identical to today. The one exception is Plank 1, which is a bug fix and
+lands live (it changes behaviour only when a dynamic workflow is actually running
+for the run, which today can only happen in an ultracode session).
+
+**What this plan does NOT do:** it does not verify that workflow subagents can
+reach the `cyboflow_*` MCP server (§Risk 1). That needs a live `pnpm dev` probe.
+The plan is structured so that if the probe fails, only Plank 4's prompt text
+changes — Planks 1–3 stand.
+
+---
+
+## Plank 1 — Defer rest while a dynamic workflow is running
+
+**The defect.** `RunExecutor.registerTurnEndRest` (`runExecutor.ts:1220`) routes
+every interactive turn-end through `onLifecycleTransition('drained')` →
+`restAwaitingReview`. The `Workflow` tool returns immediately and runs in the
+background; the agent then yields, which is a turn-end. The run gets parked in
+`awaiting_review` while its workflow is still executing, and the completion
+notification arrives to an already-rested run. This is live today for any
+ultracode session, independent of the rest of this plan.
+
+**Changes.**
+
+1. `DynamicWorkflowTracker.hasRunningForRun(runId: string): boolean` — new read
+   over `this.states` (`status === 'running' && runId === runId`). Trivial,
+   mirrors `list()`.
+2. A narrow injected predicate on `RunExecutor` — `dynamicWorkflowGuard?:
+   { hasRunning(runId: string): boolean }` — wired in `index.ts` to the tracker.
+   Absent (tests, boot ordering) ⇒ today's behaviour exactly. Injected, not
+   `tryGetInstance()` at the call site, so `runExecutor.test.ts` can drive both
+   arms without touching the singleton.
+3. `registerTurnEndRest`'s handler defers instead of resting when the guard
+   reports a running workflow.
+
+**The launch-detection race — the hard part.** On the interactive substrate the
+launch is detected by `WorkflowScriptWatcher`, which **polls at 1000ms**
+(`POLL_INTERVAL_MS`). The turn-end that follows a `Workflow` call can easily
+arrive before the poll fires, so a naive `if (guard.hasRunning(runId)) return;`
+loses the race and rests anyway.
+
+Resolution: on turn-end for a **dispatch-armed** run, schedule the rest through a
+`REST_DEFER_MS = 2500` timer (> 2 poll intervals) and re-check the guard when it
+fires. Re-checking, not just waiting: if no workflow materialised, rest normally
+(2.5s late). "Dispatch-armed" = the run's config opt-in is on, so a run with the
+feature off keeps today's synchronous rest and today's latency.
+
+**The stuck-run inverse.** If the rest is skipped and the agent never produces
+another turn-end (it died, or the notification never landed), the run stays
+`running` forever. Guard with a fallback: subscribe once per run to
+`dynamicWorkflowEvents` `'changed'`; on a terminal state for that runId, arm a
+`REST_FALLBACK_MS = 60_000` timer that rests the run **only if** no turn-end has
+arrived since. `restAwaitingReview` is already guarded on `status === 'running'`
+and documented re-entrant, so a redundant fire is a swallowed no-op.
+
+**Teardown.** Both timers and the emitter subscription are per-run and must be
+cleared in the same place the turn-end listener is removed
+(`runExecutor.ts:1402-1412`). A leaked timer holding a runId across a teardown is
+the obvious failure mode here — cover it with a test.
+
+**Tests** (`runExecutor.test.ts`, fake timers): rest fires normally with no
+guard; rest is skipped while the guard reports running; rest fires after
+`REST_DEFER_MS` when the guard stays empty; the fallback rests a run whose
+workflow went terminal with no further turn-end; teardown clears both timers and
+the subscription.
+
+## Plank 2 — The script renderer (pure)
+
+New `main/src/orchestrator/prompts/fan-out-workflow-script.ts`, a direct sibling
+of `fan-out-instructions.ts` and bound by the same rules: no DB / IPC / Electron
+/ fs imports, pure function of the resolved definition, fail-soft to `null`.
+
+```ts
+export function renderFanOutWorkflowScript(
+  workflowName: string,
+  step: WorkflowStep,
+  fanOut: FanOutSpec,
+): string | null
+export function fanOutScriptName(workflowName: string, stepId: string): string
+```
+
+`fanOutScriptName` is the single source of truth for the `cyboflow-<flow>-<stepId>`
+identity — the renderer's `meta.name`, the on-disk filename, and the prompt's
+`Workflow({name})` argument all derive from it, so they cannot drift.
+
+**Emitted shape.** `meta` is a pure literal (the tool rejects computed values):
+`name` = the script name, `description` from the step, `phases` = one entry per
+inner step, titles matching the `opts.phase` strings used in the body. Body:
+
+```js
+const results = await pipeline(
+  args,
+  (item) => runStage(item, 'implement', 'cyboflow-implement', 0),
+  (prev, item) => runStage(item, 'write-tests', 'cyboflow-write-tests', 1),
+  ...
+)
+return { results }
+```
+
+with a rendered `runStage` helper carrying the loopback budget. Hard rules the
+renderer must honour, each with a test:
+
+- **Never emit `isolation`.** Sprint lanes deliberately share one worktree
+  (`CLAUDE.md`); a per-agent worktree breaks lane verification.
+- **Never emit `Date.now()` / `Math.random()` / argless `new Date()`** — they
+  throw inside a script body.
+- **`agentType: 'cyboflow-<agent>'`** — resolves against the same registry as the
+  Agent tool, which `WorkflowBundleWriter` has already populated with
+  `.claude/agents/cyboflow-*.md`.
+- **Loopback** → a bounded retry loop around the failing stage, target resolved
+  by the same rule `fan-out-instructions.ts` uses (`step.loopback` when set, else
+  the first inner step id). Bound it explicitly; an unbounded loop inside a
+  script is a wedged background task with no operator surface.
+- **`optional: true` inner step** → failure skips the stage, lane continues.
+- **Concurrency** — `effectiveMaxConcurrency(fanOut)` is the shared authority
+  (already hardened against `0` / fractional / non-finite frozen-spec values).
+  `pipeline()` does not take a cap, so the renderer emits explicit batching over
+  it. **Open question for review:** the workflow runtime already caps concurrent
+  agents at `min(16, cpus-2)`; whether cyboflow's 5-lane cap should be enforced
+  on top, or deferred to, is a real decision, not a detail — the sprint cap is
+  about *review load and merge-conflict surface*, not machine capacity, so my
+  read is that it must be enforced explicitly.
+
+**Tests.** Emitted script parses through the repo's own `parseScriptMeta`
+(closing the loop with the tracker that will read it back); a forbidden-construct
+regex sweep; a golden-file render of the real sprint `fanOut` spec; `null` for a
+spec with an empty `inner`.
+
+## Plank 3 — Install + remove the scripts
+
+1. `WorkflowBundleWriter` gains a third target, `.claude/workflows`, writing
+   `cyboflow-<name>.js`. Same namespace rule and same "clear the prior cyboflow
+   set first" contract as commands/agents. `remove` strips only `cyboflow-*.js`.
+   Note the existing `removeFiles` filters on `.md` — it needs an extension
+   parameter, not a second hardcoded constant.
+2. `WorkflowBundle` gains `scripts: WorkflowBundleFile[]`. `resolveWorkflowBundle`
+   (a pure fs reader over app assets) does **not** produce these — they are
+   rendered, not read — so they are attached by the install seam, and the empty-
+   bundle short-circuit in `write()` must account for the new array.
+3. `installWorkflowBundle` resolves the run's definition (it currently reads only
+   `workflow_path`; it needs `workflows.name` + `spec_json` from the same join)
+   and renders one script per `fanOut`-bearing step. Guarded by the config
+   opt-in — off ⇒ nothing rendered, nothing written, no new dir.
+4. `CYBOFLOW_EXCLUDE_PATTERNS` gains `.claude/workflows/cyboflow-*.js` so the
+   generated scripts never surface in a run diff.
+
+**Tests.** Writer: namespace, merge-safety (a user's `.claude/workflows/mine.js`
+survives write and remove), extension scoping (a user `.md` in the workflows dir
+is untouched), idempotent remove. Install: off ⇒ no dir created; on ⇒ one script
+per fan-out step; exclude patterns updated.
+
+## Plank 4 — Prompt swap (interactive only, behind the opt-in)
+
+The interactive substrate composes its own appends —
+`interactiveClaudeManager.composePromptBody` (`:1370`) re-derives
+`buildStepReportingAppend` + `buildFanOutAppend` and **prepends** them to the
+prompt body, because there is no interactive `systemPrompt.append` channel. The
+SDK path uses `workflowPromptReaderAdapter` instead. So this change is naturally
+confined to the PTY: `workflowPromptReaderAdapter.ts` is not touched, and the SDK
+substrate cannot be affected.
+
+1. `buildFanOutAppend(def, opts?: { dispatch?: 'prose' | 'workflow' })`. Default
+   `'prose'` ⇒ byte-identical output to today (assert this with a test that
+   pins the existing rendering).
+2. `'workflow'` emits, per fan-out step, a short block: resolve the item set as
+   today, then call `Workflow({name: '<scriptName>', args: <itemIds>})`, wait for
+   the completion notification, then report the step. The item-set resolution and
+   the step-reporting contract are unchanged — only the *execution* of the inner
+   chain moves.
+3. Opt-in: `AppConfig.dynamicWorkflowFanOut?: boolean` +
+   `ConfigManager.getDynamicWorkflowFanOut()` (floors `false`), following the
+   `defaultExecutionModel` precedent, explicitly **not** seeded into the
+   constructor defaults so existing `config.json` files stay byte-identical.
+   `composePromptBody` reads it via the already-injected `configManager`.
+
+**Deliberately not doing:** setting `effort: 'ultracode'` for workflow runs. The
+prompt itself is a user turn naming a saved workflow, which is sufficient opt-in
+for the tool. Turning on ultracode would additionally make the agent fan out on
+its own initiative for *unrelated* steps — a much broader behavioural change than
+this plan intends.
+
+**Tests.** Default arm byte-identical; workflow arm names the script that
+`fanOutScriptName` produces for the same step (the drift test that matters);
+`composePromptBody` honours the config in both arms.
+
+## Verification
+
+- `pnpm typecheck && pnpm lint` (`any` is CI-error-enforced).
+- Targeted `cd main && npx vitest run <paths>` per plank while building.
+- `pnpm test:unit` once, over the settled tree, at the end.
+- Nothing here touches `main/src/services/panels/claude/` behaviour under test by
+  the mocked-SDK suite except `interactiveClaudeManager` — run
+  `pnpm test:integration` too, since that directory is the trigger for it.
+- **Manual, not covered:** the live MCP-reach probe (Risk 1), and any end-to-end
+  run with the flag on. Both need `pnpm dev`.
+
+## Risks
+
+1. **MCP reach from workflow subagents is unverified** (the load-bearing
+   assumption). If lane agents cannot reach `cyboflow_update_sprint_task`, lane
+   `current_step` never advances and the sprint UI goes dark mid-fan-out. Fallback
+   design: stages return structured lane results and the top-level agent performs
+   the writes between `Workflow` calls — correct, but loses live lane progress.
+   The flag stays off until the probe passes either way.
+2. **Agent-count guideline.** 5 lanes × a 5-step chain reads as over the default
+   ~15-agent guideline. Unknown whether that counts concurrent or cumulative
+   agents; if cumulative, large fan-outs may be truncated. Needs the same probe.
+3. **Loopback semantics drift.** Two renderers (prose and script) now encode the
+   same loopback rule. They must share `loopbackTargetId`, not re-implement it.
+4. **Rest deferral latency.** `REST_DEFER_MS` delays the merge-button enable by
+   2.5s for dispatch-armed runs. Acceptable; called out so it is not discovered
+   as a regression.
+
+## Order
+
+Plank 1 → 2 → 3 → 4, each with its tests green before the next. Plank 1 is
+independently correct and could ship alone.

--- a/docs/proposals/pty-dynamic-workflow-implementation-plan.md
+++ b/docs/proposals/pty-dynamic-workflow-implementation-plan.md
@@ -1,224 +1,162 @@
-# Implementation plan — PTY fan-out steps as dynamic workflows
+# Implementation plan — PTY fan-out steps as dynamic workflows (v2, post-review)
 
-Companion to `pty-dynamic-workflow-orchestration.md` (the feasibility
-assessment). This is the build plan for **Option B (phase-scoped dispatch)**,
-scoped to what is implementable and testable headlessly.
+Companion to `pty-dynamic-workflow-orchestration.md`.
 
-**Guiding constraint: default OFF.** Every plank lands inert. With
-`dynamicWorkflowFanOut` unset, a run's prompt, spawn args, and on-disk worktree
-are byte-identical to today. The one exception is Plank 1, which is a bug fix and
-lands live (it changes behaviour only when a dynamic workflow is actually running
-for the run, which today can only happen in an ultracode session).
+**v1 of this plan was adversarially reviewed by two independent reviewers
+(Claude Fable 5 and Codex). Both rejected it.** They converged on four defects
+that invalidate its core design, and each found one the other missed. This v2
+records the outcome, states what was built, and states what must be redesigned
+before any of the rest is worth writing.
 
-**What this plan does NOT do:** it does not verify that workflow subagents can
-reach the `cyboflow_*` MCP server (§Risk 1). That needs a live `pnpm dev` probe.
-The plan is structured so that if the probe fails, only Plank 4's prompt text
-changes — Planks 1–3 stand.
+Status: **Planks A–C built and green. Planks 2–4 (renderer / writer / prompt
+swap) NOT built — the design is wrong as specified.**
 
 ---
 
-## Plank 1 — Defer rest while a dynamic workflow is running
+## What the review changed
 
-**The defect.** `RunExecutor.registerTurnEndRest` (`runExecutor.ts:1220`) routes
-every interactive turn-end through `onLifecycleTransition('drained')` →
-`restAwaitingReview`. The `Workflow` tool returns immediately and runs in the
-background; the agent then yields, which is a turn-end. The run gets parked in
-`awaiting_review` while its workflow is still executing, and the completion
-notification arrives to an already-rested run. This is live today for any
-ultracode session, independent of the rest of this plan.
+### The dispatch shape is wrong (both reviewers, independently)
 
-**Changes.**
+v1 proposed one `Workflow` call per fan-out step, executing the whole per-item
+inner chain. That cannot work, for reasons that are structural rather than
+fixable in the renderer:
 
-1. `DynamicWorkflowTracker.hasRunningForRun(runId: string): boolean` — new read
-   over `this.states` (`status === 'running' && runId === runId`). Trivial,
-   mirrors `list()`.
-2. A narrow injected predicate on `RunExecutor` — `dynamicWorkflowGuard?:
-   { hasRunning(runId: string): boolean }` — wired in `index.ts` to the tracker.
-   Absent (tests, boot ordering) ⇒ today's behaviour exactly. Injected, not
-   `tryGetInstance()` at the call site, so `runExecutor.test.ts` can drive both
-   arms without touching the singleton.
-3. `registerTurnEndRest`'s handler defers instead of resting when the guard
-   reports a running workflow.
+- **The lane chain is not a pure agent pipeline.** Between inner steps the main
+  session does entity work: it moves `current_step` via
+  `cyboflow_update_sprint_task`, carries `attempt: <n>` on loopback, files
+  findings with `cyboflow_report_finding`, and makes ONE git commit per task on
+  success (`fan-out-instructions.ts:275-293`). One opaque phase-wide call leaves
+  no control point for any of it.
+- **`visual-verify` is not an agent stage at all.** The prose is explicit:
+  *"there is NO subagent to delegate for this step; YOU fire the request"*
+  (`fan-out-instructions.ts:141-165`). The main session calls
+  `cyboflow_request_verification`, parks the lane at `awaiting-verify`, and an
+  async external verdict drives it off the park. The `cyboflow-visual-verify`
+  agent that exists is the *central* verifier, deployed by the main-process
+  scheduler into an isolated snapshot worktree with `$VERIFY_*` env — invoked as
+  a bare `agentType` in the lane's shared worktree it cannot function. Worse,
+  the step is `optional: true`, so v1's "optional ⇒ skip on failure" rule would
+  have silently converted the visual merge-gate into a guaranteed skip.
+- **Domain failure is not promise failure** (Codex). `code-review` and
+  `task-verify` return *normally* while reporting `REVIEW: BLOCKING` /
+  `VERDICT: FAIL`. The programmatic controller has explicit parsers for exactly
+  this (`workflowController.ts:947,1003`). A `runStage` keyed on rejection treats
+  a blocking review as success.
+- **Wave selection is not a concurrency cap** (Codex). The current orchestration
+  dispatches dependency-ready, file-disjoint waves and re-resolves added/removed
+  tasks at every wave boundary (`workflowController.ts:1124,1180,1261`). A frozen
+  ID list plus a cap does none of that.
 
-**The launch-detection race — the hard part.** On the interactive substrate the
-launch is detected by `WorkflowScriptWatcher`, which **polls at 1000ms**
-(`POLL_INTERVAL_MS`). The turn-end that follows a `Workflow` call can easily
-arrive before the poll fires, so a naive `if (guard.hasRunning(runId)) return;`
-loses the race and rests anyway.
+### The MCP-reach question was already answered — no (both reviewers)
 
-Resolution: on turn-end for a **dispatch-armed** run, schedule the rest through a
-`REST_DEFER_MS = 2500` timer (> 2 poll intervals) and re-check the guard when it
-fires. Re-checking, not just waiting: if no workflow materialised, rest normally
-(2.5s late). "Dispatch-armed" = the run's config opt-in is on, so a run with the
-feature off keeps today's synchronous rest and today's latency.
+v1 treated subagent MCP reach as an open probe that "decides everything". It is
+closed, in the repo: every lane agent pins an explicit allowlist —
+`tools: Read, Edit, Write, Bash, Grep, Glob` — and each is documented "Never
+writes cyboflow state" (`sprint/agents/*.md`). Granting them `cyboflow_*` would
+break the single-writer invariant that the step-reporting append states to the
+model verbatim, which is the same invariant for which the feasibility doc
+rejected Option C.
 
-**The stuck-run inverse.** If the rest is skipped and the agent never produces
-another turn-end (it died, or the notification never landed), the run stays
-`running` forever. Guard with a fallback: subscribe once per run to
-`dynamicWorkflowEvents` `'changed'`; on a terminal state for that runId, arm a
-`REST_FALLBACK_MS = 60_000` timer that rests the run **only if** no turn-end has
-arrived since. `restAwaitingReview` is already guarded on `status === 'running'`
-and documented re-entrant, so a redundant fire is a swallowed no-op.
+### The tracker could not see workflow runs at all (Codex only)
 
-**Teardown.** Both timers and the emitter subscription are per-run and must be
-cleared in the same place the turn-end listener is removed
-(`runExecutor.ts:1402-1412`). A leaked timer holding a runId across a teardown is
-the obvious failure mode here — cover it with a test.
+The decisive find, and the one that made Plank 1 unimplementable as designed:
+the tracker resolved its watcher's worktree path only through the `sessions`
+table, and a flow run has no `sessions` row. See §4.7 of the feasibility doc.
 
-**Tests** (`runExecutor.test.ts`, fake timers): rest fires normally with no
-guard; rest is skipped while the guard reports running; rest fires after
-`REST_DEFER_MS` when the guard stays empty; the fallback rests a run whose
-workflow went terminal with no further turn-end; teardown clears both timers and
-the subscription.
+### Consequently
 
-## Plank 2 — The script renderer (pure)
+**The viable design is stage-major, host-controlled dispatch**, not item-major:
+the top-level agent dispatches ONE ready, file-disjoint wave of ONE inner step at
+a time, agents return typed structured results and write nothing, and the main
+session reconciles through the router chokepoints between calls. That preserves
+single-writer, keeps lane progress live, keeps `visual-verify` host-owned, and
+keeps wave re-resolution. It is a materially different and larger design than v1,
+and it still rests on three unverified CLI behaviours (below).
 
-New `main/src/orchestrator/prompts/fan-out-workflow-script.ts`, a direct sibling
-of `fan-out-instructions.ts` and bound by the same rules: no DB / IPC / Electron
-/ fs imports, pure function of the resolved definition, fail-soft to `null`.
+## What was built
 
-```ts
-export function renderFanOutWorkflowScript(
-  workflowName: string,
-  step: WorkflowStep,
-  fanOut: FanOutSpec,
-): string | null
-export function fanOutScriptName(workflowName: string, stepId: string): string
-```
+### Plank A — the tracker blind spot (live defect, fixed)
 
-`fanOutScriptName` is the single source of truth for the `cyboflow-<flow>-<stepId>`
-identity — the renderer's `meta.name`, the on-disk filename, and the prompt's
-`Workflow({name})` argument all derive from it, so they cannot drift.
+`DynamicWorkflowRunContext.worktreePath`, passed by both managers from the
+spawn's own `options.worktreePath`, with the `sessions` lookup kept as the
+quick-session fallback. Without it no dynamic workflow inside a PTY *workflow
+run* was ever tracked.
 
-**Emitted shape.** `meta` is a pure literal (the tool rejects computed values):
-`name` = the script name, `description` from the step, `phases` = one entry per
-inner step, titles matching the `opts.phase` strings used in the body. Body:
+Tests: `dynamicWorkflows/__tests__/dynamicWorkflowTrackerWatcher.test.ts` (8),
+including a case pinning the pre-fix behaviour (no watcher for a flow run that
+supplies no path).
 
-```js
-const results = await pipeline(
-  args,
-  (item) => runStage(item, 'implement', 'cyboflow-implement', 0),
-  (prev, item) => runStage(item, 'write-tests', 'cyboflow-write-tests', 1),
-  ...
-)
-return { results }
-```
+### Plank B — quick-session premature completion (live defect, fixed)
 
-with a rendered `runStage` helper carrying the loopback budget. Hard rules the
-renderer must honour, each with a test:
+`index.ts`'s quick-session turn-end listener flipped `sessions.status` to
+`'completed'` on the turn-end that follows a `Workflow` launch. This is reachable
+**today**: the Ultracode wizard card launches quick PTY sessions with
+`--settings '{"ultracode":true}'`, which is precisely the setting that makes the
+agent fan work out as dynamic workflows. Now guarded on
+`hasRunningForRun(runId)`.
 
-- **Never emit `isolation`.** Sprint lanes deliberately share one worktree
-  (`CLAUDE.md`); a per-agent worktree breaks lane verification.
-- **Never emit `Date.now()` / `Math.random()` / argless `new Date()`** — they
-  throw inside a script body.
-- **`agentType: 'cyboflow-<agent>'`** — resolves against the same registry as the
-  Agent tool, which `WorkflowBundleWriter` has already populated with
-  `.claude/agents/cyboflow-*.md`.
-- **Loopback** → a bounded retry loop around the failing stage, target resolved
-  by the same rule `fan-out-instructions.ts` uses (`step.loopback` when set, else
-  the first inner step id). Bound it explicitly; an unbounded loop inside a
-  script is a wedged background task with no operator surface.
-- **`optional: true` inner step** → failure skips the stage, lane continues.
-- **Concurrency** — `effectiveMaxConcurrency(fanOut)` is the shared authority
-  (already hardened against `0` / fractional / non-finite frozen-spec values).
-  `pipeline()` does not take a cap, so the renderer emits explicit batching over
-  it. **Open question for review:** the workflow runtime already caps concurrent
-  agents at `min(16, cpus-2)`; whether cyboflow's 5-lane cap should be enforced
-  on top, or deferred to, is a real decision, not a detail — the sprint cap is
-  about *review load and merge-conflict surface*, not machine capacity, so my
-  read is that it must be enforced explicitly.
+No stuck-session risk: a live agent turns again on the completion notification
+(that turn-end rests it), and a dead agent is covered by the process-exit handler
+that already writes `'completed'`/`'stopped'` (`events.ts:435-500`).
 
-**Tests.** Emitted script parses through the repo's own `parseScriptMeta`
-(closing the loop with the tracker that will read it back); a forbidden-construct
-regex sweep; a golden-file render of the real sprint `fanOut` spec; `null` for a
-spec with an empty `inner`.
+Not unit-tested — it is a guard clause inside the composition root's inline
+listener, which has no existing test harness. Its predicate is tested.
 
-## Plank 3 — Install + remove the scripts
+### Plank C — the workflow-run rest guard
 
-1. `WorkflowBundleWriter` gains a third target, `.claude/workflows`, writing
-   `cyboflow-<name>.js`. Same namespace rule and same "clear the prior cyboflow
-   set first" contract as commands/agents. `remove` strips only `cyboflow-*.js`.
-   Note the existing `removeFiles` filters on `.md` — it needs an extension
-   parameter, not a second hardcoded constant.
-2. `WorkflowBundle` gains `scripts: WorkflowBundleFile[]`. `resolveWorkflowBundle`
-   (a pure fs reader over app assets) does **not** produce these — they are
-   rendered, not read — so they are attached by the install seam, and the empty-
-   bundle short-circuit in `write()` must account for the new array.
-3. `installWorkflowBundle` resolves the run's definition (it currently reads only
-   `workflow_path`; it needs `workflows.name` + `spec_json` from the same join)
-   and renders one script per `fanOut`-bearing step. Guarded by the config
-   opt-in — off ⇒ nothing rendered, nothing written, no new dir.
-4. `CYBOFLOW_EXCLUDE_PATTERNS` gains `.claude/workflows/cyboflow-*.js` so the
-   generated scripts never surface in a run diff.
+`RunExecutor` takes an optional `hasRunningDynamicWorkflow` probe (slot 17) and
+skips the event-driven rest while it holds.
 
-**Tests.** Writer: namespace, merge-safety (a user's `.claude/workflows/mine.js`
-survives write and remove), extension scoping (a user `.md` in the workflows dir
-is untouched), idempotent remove. Install: off ⇒ no dir created; on ⇒ one script
-per fan-out step; exclude patterns updated.
+Two review findings shaped this:
 
-## Plank 4 — Prompt swap (interactive only, behind the opt-in)
+- Codex disproved v1's premise that a redundant rest is harmless.
+  `onLifecycleTransition` runs its side effects — task-stage derivation, usage
+  rollup, compound-findings close-out — *even when the status transition is
+  rejected as a race* (documented at its `catch`), and the compound close-out
+  clears `selected` on still-pending seeded findings.
+- Both reviewers showed v1's 2500ms defer timer is unsafe: a question ask is
+  itself a turn-end, so a timer armed before the human answers can fire while the
+  run is legitimately mid-turn again — and `restAwaitingReview`'s
+  `status === 'running'` guard *passes* in exactly that state.
 
-The interactive substrate composes its own appends —
-`interactiveClaudeManager.composePromptBody` (`:1370`) re-derives
-`buildStepReportingAppend` + `buildFanOutAppend` and **prepends** them to the
-prompt body, because there is no interactive `systemPrompt.append` channel. The
-SDK path uses `workflowPromptReaderAdapter` instead. So this change is naturally
-confined to the PTY: `workflowPromptReaderAdapter.ts` is not touched, and the SDK
-substrate cannot be affected.
+So the guard ships **without** the defer timer. This leaves a known residual: the
+launch is observed by a 1s-poll watcher, so a turn-end inside that window still
+rests. Closing it needs a deferred re-check gated on a per-run execution epoch +
+turn generation + `hasTurnInFlightForSession`, which belongs with the change that
+makes dispatch routine. Documented at the call site.
 
-1. `buildFanOutAppend(def, opts?: { dispatch?: 'prose' | 'workflow' })`. Default
-   `'prose'` ⇒ byte-identical output to today (assert this with a test that
-   pins the existing rendering).
-2. `'workflow'` emits, per fan-out step, a short block: resolve the item set as
-   today, then call `Workflow({name: '<scriptName>', args: <itemIds>})`, wait for
-   the completion notification, then report the step. The item-set resolution and
-   the step-reporting contract are unchanged — only the *execution* of the inner
-   chain moves.
-3. Opt-in: `AppConfig.dynamicWorkflowFanOut?: boolean` +
-   `ConfigManager.getDynamicWorkflowFanOut()` (floors `false`), following the
-   `defaultExecutionModel` precedent, explicitly **not** seeded into the
-   constructor defaults so existing `config.json` files stay byte-identical.
-   `composePromptBody` reads it via the already-injected `configManager`.
+Tests: 2 added to `runExecutor.test.ts` (guarded arm; no-probe arm byte-identical).
 
-**Deliberately not doing:** setting `effort: 'ultracode'` for workflow runs. The
-prompt itself is a user turn naming a saved workflow, which is sufficient opt-in
-for the tool. Turning on ultracode would additionally make the agent fan out on
-its own initiative for *unrelated* steps — a much broader behavioural change than
-this plan intends.
+**Gate:** `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm test:integration`
+(25), `pnpm test:unit` (8890 main + 3752 frontend, 0 failures).
 
-**Tests.** Default arm byte-identical; workflow arm names the script that
-`fanOutScriptName` produces for the same step (the drift test that matters);
-`composePromptBody` honours the config in both arms.
+## What must happen before Planks 2–4
 
-## Verification
-
-- `pnpm typecheck && pnpm lint` (`any` is CI-error-enforced).
-- Targeted `cd main && npx vitest run <paths>` per plank while building.
-- `pnpm test:unit` once, over the settled tree, at the end.
-- Nothing here touches `main/src/services/panels/claude/` behaviour under test by
-  the mocked-SDK suite except `interactiveClaudeManager` — run
-  `pnpm test:integration` too, since that directory is the trigger for it.
-- **Manual, not covered:** the live MCP-reach probe (Risk 1), and any end-to-end
-  run with the flag on. Both need `pnpm dev`.
-
-## Risks
-
-1. **MCP reach from workflow subagents is unverified** (the load-bearing
-   assumption). If lane agents cannot reach `cyboflow_update_sprint_task`, lane
-   `current_step` never advances and the sprint UI goes dark mid-fan-out. Fallback
-   design: stages return structured lane results and the top-level agent performs
-   the writes between `Workflow` calls — correct, but loses live lane progress.
-   The flag stays off until the probe passes either way.
-2. **Agent-count guideline.** 5 lanes × a 5-step chain reads as over the default
-   ~15-agent guideline. Unknown whether that counts concurrent or cumulative
-   agents; if cumulative, large fan-outs may be truncated. Needs the same probe.
-3. **Loopback semantics drift.** Two renderers (prose and script) now encode the
-   same loopback rule. They must share `loopbackTargetId`, not re-implement it.
-4. **Rest deferral latency.** `REST_DEFER_MS` delays the merge-button enable by
-   2.5s for dispatch-armed runs. Acceptable; called out so it is not discovered
-   as a regression.
-
-## Order
-
-Plank 1 → 2 → 3 → 4, each with its tests green before the next. Plank 1 is
-independently correct and could ship alone.
+1. **Redesign to stage-major dispatch** (above). This is the real work and it
+   is not a renderer detail.
+2. **Three live probes**, none runnable headlessly, each fatal alone:
+   - Is the `Workflow` tool available without the `ultracode` setting? v1 asserted
+     yes from a reading of tool policy; it was never observed.
+   - Does a worktree-local `.claude/workflows/` resolve by name? The string is in
+     the CLI bundle; project-scoped resolution was never exercised.
+   - Does a completion notification actually re-wake a yielded PTY REPL? The whole
+     design assumes it. If not, the normal case is a run that never processes its
+     results.
+3. **Then** the renderer, with the constraints both reviewers added to v1's list:
+   structured per-stage output schemas with domain-outcome parsing;
+   `JSON.stringify` for every emitted literal and a filename-safe slug with path
+   containment (workflow names and step ids are free-form — slashes escape the
+   directory, quotes break the script); AST-level validation, since
+   `parseScriptMeta` is a fail-soft regex scanner that will happily accept
+   syntactically invalid JavaScript.
+4. **Writer caveats** found in review: `installWorkflowBundle` is substrate-shared
+   (the SDK calls it too, so "confined to interactive" holds only for the prompt);
+   `ensureBundleExcluded` runs unconditionally, so adding a glob mutates
+   `.git/info/exclude` even with the feature off; `write()` returns before
+   `remove()` on an empty bundle, so stale scripts survive an on→off transition;
+   and the writer's `cyboflow-` prefix would double up on a `fanOutScriptName`
+   that already carries it.
+5. **Config threading**: a global `AppConfig` flag read at three different times
+   is not enough — resolve a typed dispatch mode ONCE per run and thread that
+   snapshot to prompt composition, installation, and the rest guard. `AppConfig`
+   is declared separately in main and frontend and needs parity.

--- a/docs/proposals/pty-dynamic-workflow-implementation-plan.md
+++ b/docs/proposals/pty-dynamic-workflow-implementation-plan.md
@@ -8,9 +8,11 @@ that invalidate its core design, and each found one the other missed. This v2
 records the outcome, states what was built, and states what must be redesigned
 before any of the rest is worth writing.
 
-Status: **Planks A–C (defect fixes) and D–G (the stage-major redesign) built and
-green, default OFF.** The three live CLI probes in "What is still unverified"
-remain outstanding — the feature must not be switched on until they pass.
+Status: **Planks A–C (defect fixes), D–G (the redesign), and H (firm gates +
+batching) built and green, default OFF. All three CLI assumptions VERIFIED
+against claude 2.1.231** — see "CLI assumptions" below, including a fourth
+finding (dispatch is permission-gated, and only `auto` works) that must be
+handled before the mode is switched on.
 
 ---
 
@@ -133,7 +135,35 @@ Tests: 2 added to `runExecutor.test.ts` (guarded arm; no-probe arm byte-identica
 
 ## The stage-major build (Planks D–G)
 
-### Plank D — the stage-script renderer
+### Plank H — firm gates and batching (the efficiency change)
+
+The first cut was strictly stage-major: one dispatch per stage, orchestrator
+re-entered between every one. That is maximally safe and needlessly slow — it
+reintroduces a barrier at every stage boundary, which is most of what the
+workflow path was supposed to remove.
+
+`FanOutInnerStep.firmGate` now marks the stages where the orchestrator genuinely
+must regain control. Everything else batches: a maximal run of consecutive
+non-gated stages is dispatched as ONE workflow, and each item walks that whole
+sub-chain (`implement → write-tests → code-review → task-verify`) inside it,
+concurrently with the other items, retrying its own loopback up to 3 attempts —
+with no return to the orchestrator in between. For the built-in sprint and ship
+chains that is one dispatch instead of four, and a fast item is never held at a
+barrier waiting for a slow sibling.
+
+**Only `visual-verify` carries `firmGate: true`,** and it is a gate for a
+structural reason rather than a cautious one: it has no subagent at all. The
+orchestrator fires `cyboflow_request_verification` and parks the lane while an
+async external verdict drives it. `ALWAYS_GATED_INNER_IDS` keeps that true even
+if an author clears the flag.
+
+**The trade, taken deliberately:** lane `current_step` no longer ticks per stage
+inside a batch. Each result carries the item's full `trail`, and the orchestrator
+backfills the stage history when the batch returns — so nothing is lost but live
+per-stage granularity, and the dynamic-workflow tracker still shows per-agent
+progress throughout. The prompt states this in as many words.
+
+### Plank D — the batch-script renderer
 
 `orchestrator/prompts/fanOutStageScript.ts`, a pure sibling of
 `fan-out-instructions.ts`. Renders ONE inner stage of a fan-out step into a
@@ -199,21 +229,56 @@ prompt composition — so a mid-run config flip can never leave a run whose prom
 cites scripts its worktree lacks.
 
 **Gate:** `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm test:integration` (25),
-`pnpm test:unit` (8942 main + 3752 frontend, 0 failures). 53 new tests.
+`pnpm test:unit` (8947 main + 3752 frontend, 0 failures). 58 new tests.
 
-## What is still unverified
+## CLI assumptions — VERIFIED (claude 2.1.231, 2026-08-14)
 
-Three live CLI behaviours, none runnable headlessly, each fatal alone. **Do not
-switch `fanOutDispatch` to `workflow` before these pass:**
+Probed empirically against the real CLI in a scratch repo carrying one
+`.claude/workflows/cyboflow-probe-stage.js`. All three assumptions hold, and the
+probe surfaced a fourth fact that neither reviewer predicted.
 
-1. Is the `Workflow` tool available without the `ultracode` setting? The design
-   relies on the run prompt naming a saved workflow being sufficient opt-in.
-2. Does a worktree-local `.claude/workflows/` resolve by name? The string is in
-   the CLI bundle; project-scoped resolution was never exercised.
-3. Does a completion notification actually re-wake a yielded PTY REPL? If not,
-   the normal case is a run that never processes its stage results. Plank C's
-   guard keeps such a run from being falsely rested, but it will sit `running`.
+1. **The `Workflow` tool IS available without `ultracode`.** ✅ It was invoked in
+   every probe, including default settings — a user turn naming a saved workflow
+   is sufficient opt-in, as designed.
+2. **A worktree-local `.claude/workflows/` DOES resolve by name.** ✅
+   `Workflow({name: 'cyboflow-probe-stage'})` resolved and launched
+   (`wf_061286ce-20a`) with no path given.
+3. **A completion notification DOES re-wake a yielded agent.** ✅ Two distinct
+   assistant turns: *"running in the background… I'll report once it completes"*,
+   then *"The workflow completed… `PROBE_AGENT_OK`"*. That is exactly the
+   yield→re-wake cycle the whole design depends on, and it is why Plank C's rest
+   guard matters.
+4. **NEW — launching a dynamic workflow is PERMISSION-GATED**
+   (`"Review dynamic workflow before running"`), and the matrix is
+   counterintuitive:
 
-A fourth, cheaper to answer once the above pass: whether the ~15-agent workflow
-size guideline counts concurrent or cumulative agents, since a 5-lane wave is
-5 agents per stage.
+   | `--permission-mode` | Result |
+   | --- | --- |
+   | (default / `manual`) | **blocked** — needs interactive approval |
+   | `acceptEdits` | **blocked** |
+   | `auto` | **allowed** ✅ |
+   | `dontAsk` | **DENIED** ❌ |
+   | `bypassPermissions` | allowed |
+
+   Cyboflow's 4-mode `agentPermissionMode` is `default | acceptEdits | auto |
+   dontAsk`. **Only `auto` can dispatch.** The most permissive-sounding mode,
+   `dontAsk`, denies outright — it suppresses the prompt by refusing, not by
+   allowing. A run in `default`/`acceptEdits` will surface the gate through
+   cyboflow's approval queue (once per dispatch); a run in `dontAsk` will fail
+   every dispatch. This must be enforced or documented before enabling the mode.
+
+**Bonus verification:** the on-disk artifact contract the tracker depends on
+matches exactly — `<uuid>/workflows/scripts/<name>-wf_<id>.js` (and
+`WorkflowScriptWatcher`'s `SCRIPT_RE` extracts the right id from it),
+`<uuid>/subagents/workflows/<wf_id>/journal.jsonl` with `started`/`result` lines
+keyed by `agentId`, and `<uuid>/workflows/wf_<id>.json` carrying
+`status`/`summary`/`agentCount` **plus the script's return value under `result`**
+— so the orchestrator gets its structured results back through the completion
+record.
+
+One practical finding folded into the prompt: the agent's first instinct was to
+try `Skill(<name>)` and `Bash` before reaching for `Workflow`. The dispatch block
+now names the Workflow tool explicitly ("not Skill, not Bash").
+
+Still open, and cheap to answer next: whether the ~15-agent workflow size
+guideline counts concurrent or cumulative agents.

--- a/docs/proposals/pty-dynamic-workflow-implementation-plan.md
+++ b/docs/proposals/pty-dynamic-workflow-implementation-plan.md
@@ -8,8 +8,9 @@ that invalidate its core design, and each found one the other missed. This v2
 records the outcome, states what was built, and states what must be redesigned
 before any of the rest is worth writing.
 
-Status: **Planks A–C built and green. Planks 2–4 (renderer / writer / prompt
-swap) NOT built — the design is wrong as specified.**
+Status: **Planks A–C (defect fixes) and D–G (the stage-major redesign) built and
+green, default OFF.** The three live CLI probes in "What is still unverified"
+remain outstanding — the feature must not be switched on until they pass.
 
 ---
 
@@ -130,33 +131,89 @@ Tests: 2 added to `runExecutor.test.ts` (guarded arm; no-probe arm byte-identica
 **Gate:** `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm test:integration`
 (25), `pnpm test:unit` (8890 main + 3752 frontend, 0 failures).
 
-## What must happen before Planks 2–4
+## The stage-major build (Planks D–G)
 
-1. **Redesign to stage-major dispatch** (above). This is the real work and it
-   is not a renderer detail.
-2. **Three live probes**, none runnable headlessly, each fatal alone:
-   - Is the `Workflow` tool available without the `ultracode` setting? v1 asserted
-     yes from a reading of tool policy; it was never observed.
-   - Does a worktree-local `.claude/workflows/` resolve by name? The string is in
-     the CLI bundle; project-scoped resolution was never exercised.
-   - Does a completion notification actually re-wake a yielded PTY REPL? The whole
-     design assumes it. If not, the normal case is a run that never processes its
-     results.
-3. **Then** the renderer, with the constraints both reviewers added to v1's list:
-   structured per-stage output schemas with domain-outcome parsing;
-   `JSON.stringify` for every emitted literal and a filename-safe slug with path
-   containment (workflow names and step ids are free-form — slashes escape the
-   directory, quotes break the script); AST-level validation, since
-   `parseScriptMeta` is a fail-soft regex scanner that will happily accept
-   syntactically invalid JavaScript.
-4. **Writer caveats** found in review: `installWorkflowBundle` is substrate-shared
-   (the SDK calls it too, so "confined to interactive" holds only for the prompt);
-   `ensureBundleExcluded` runs unconditionally, so adding a glob mutates
-   `.git/info/exclude` even with the feature off; `write()` returns before
-   `remove()` on an empty bundle, so stale scripts survive an on→off transition;
-   and the writer's `cyboflow-` prefix would double up on a `fanOutScriptName`
-   that already carries it.
-5. **Config threading**: a global `AppConfig` flag read at three different times
-   is not enough — resolve a typed dispatch mode ONCE per run and thread that
-   snapshot to prompt composition, installation, and the rest guard. `AppConfig`
-   is declared separately in main and frontend and needs parity.
+### Plank D — the stage-script renderer
+
+`orchestrator/prompts/fanOutStageScript.ts`, a pure sibling of
+`fan-out-instructions.ts`. Renders ONE inner stage of a fan-out step into a
+`.claude/workflows/*.js` script that fans that stage across ONE already-chosen
+wave and returns schema-validated per-item results. Every review constraint is
+enforced and tested:
+
+- **Host-owned stages are never rendered.** `HOST_OWNED_INNER_IDS` (matched on
+  BOTH step id and agent id, since a custom flow may rename one) keeps
+  `visual-verify` on the prose path, with its request/park protocol verbatim.
+- **Domain outcome, not promise outcome.** Each agent returns
+  `{outcome: ok|blocked|failed|not_applicable, summary, filesTouched, findings,
+  visualTask}`. A blocking review is `blocked`, not a resolved promise. A null
+  agent slot becomes a `failed` item rather than a silently dropped one.
+- **Injection + traversal safety.** `slugSegment` reduces free-form
+  workflow/step/agent ids to `[a-z0-9-]`, and every emitted literal goes through
+  `JSON.stringify`. Tested against `../../etc/passwd`, quotes, backticks,
+  `${...}`, and newlines.
+- **Name drift is structurally impossible.** `fanOutStageLogicalName` (what the
+  writer prefixes) and `fanOutStageWorkflowName` (`meta.name`, the on-disk
+  basename, and the prompt's `Workflow({name})`) derive from one function.
+- No `isolation` (lanes share one worktree), no `Date.now`/`Math.random`.
+- **Real syntax validation.** Tests compile the emitted source with `vm.Script`
+  in the shape the runtime consumes it (meta lifted off, body in an async
+  function). `parseScriptMeta` is a fail-soft regex scanner and would accept
+  broken source, so it is used only for the tracker round-trip.
+
+### Plank E — the writer
+
+`.claude/workflows/cyboflow-*.js` as a third target. Extension is now a
+parameter, not a hardcoded `.md`, so a user's `.js` beside our `.md` is never
+touched and generated scripts are actually reclaimed. `write()` reconciles
+**before** the empty-bundle early return, so an on→off transition cannot strand a
+stale script the CLI would still resolve by name. Target paths are containment-
+checked and a name that would escape its directory is skipped, not written.
+
+### Plank F — the install seam
+
+Renders from `resolveRunFrozenSpec` — the run's frozen variant graph, the same
+source the prompt resolves — NOT the live `workflows.spec_json` join used for
+`workflow_path`; a variant run would otherwise install scripts for a different
+chain than its prompt walks. The scripts glob is added to `.git/info/exclude`
+only when scripts are actually installed, so dispatch-off leaves the exclude file
+byte-identical. Dispatch is a threaded ARGUMENT: the SDK manager passes `'prose'`
+explicitly, because this seam is substrate-shared and SDK worktrees consume no
+scripts.
+
+### Plank G — prompt + config
+
+`buildFanOutAppend(def, opts?)` gains a `workflow` arm that replaces per-task
+Agent-tool delegation with per-stage `Workflow({name, args})` dispatch and an
+explicit reconcile step (advance / loopback+attempt / file findings / carry
+`visualTask`). It changes only the DELEGATION — wave selection, every
+`cyboflow_*` write, the loopback protocol, the visual gate, and the per-task
+commit stay with the orchestrator, and the prompt says so. Defaulted to `prose`,
+with a test asserting the default arm is byte-identical to an explicit prose
+request. A stage whose name cannot be slugged falls back to prose per step.
+
+Config: `FanOutDispatch` lives in `shared/` (both `AppConfig` declarations carry
+the field, per the IPC type-parity rule), floors to `'prose'` on absent/invalid,
+and is **snapshotted once per spawn** and threaded to both installation and
+prompt composition — so a mid-run config flip can never leave a run whose prompt
+cites scripts its worktree lacks.
+
+**Gate:** `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm test:integration` (25),
+`pnpm test:unit` (8942 main + 3752 frontend, 0 failures). 53 new tests.
+
+## What is still unverified
+
+Three live CLI behaviours, none runnable headlessly, each fatal alone. **Do not
+switch `fanOutDispatch` to `workflow` before these pass:**
+
+1. Is the `Workflow` tool available without the `ultracode` setting? The design
+   relies on the run prompt naming a saved workflow being sufficient opt-in.
+2. Does a worktree-local `.claude/workflows/` resolve by name? The string is in
+   the CLI bundle; project-scoped resolution was never exercised.
+3. Does a completion notification actually re-wake a yielded PTY REPL? If not,
+   the normal case is a run that never processes its stage results. Plank C's
+   guard keeps such a run from being falsely rested, but it will sit `running`.
+
+A fourth, cheaper to answer once the above pass: whether the ~15-agent workflow
+size guideline counts concurrent or cumulative agents, since a 5-lane wave is
+5 agents per stage.

--- a/docs/proposals/pty-dynamic-workflow-orchestration.md
+++ b/docs/proposals/pty-dynamic-workflow-orchestration.md
@@ -1,0 +1,232 @@
+# PTY workflow runs as dynamic workflows (feasibility)
+
+Status: **feasibility assessment — nothing built.** Investigation only; no
+production code changed on this branch.
+
+**Question.** Today an interactive (PTY) workflow run is walked by a *manual
+orchestrator*: the run's prompt body (`workflows/<flow>.md` + the derived
+step-reporting and fan-out appends) tells a top-level `claude` REPL agent to
+sequence the DAG itself, delegating heavy phases to `cyboflow-<agent>` subagents
+via the Agent tool. Can that walk instead be handed to Claude Code's **dynamic
+workflows** (the in-session `Workflow` tool) *inside the same interactive
+session*?
+
+**Verdict: yes, and cyboflow is unusually well-positioned for it — but only in
+the phase-scoped form (Option B below).** Every mechanism the change needs
+already exists in the tree or in the CLI; the whole-DAG form (Option C) breaks
+three live invariants and should not be the target. There is one genuine
+blocking defect to fix first (premature rest, §4.1) and one unverified
+assumption that needs a live probe (MCP reach from workflow subagents, §5).
+
+---
+
+## 1. What exists today
+
+| Piece | Where | State |
+| --- | --- | --- |
+| Manual orchestrator prompt | `main/src/orchestrator/workflows/*.md` | live |
+| Step-reporting append (flattened step ids → `cyboflow_report_step`) | `main/src/orchestrator/prompts/step-reporting-instructions.ts` | live |
+| Fan-out append (per-item chain, concurrency cap, loopback rules) | `main/src/orchestrator/prompts/fan-out-instructions.ts` | live |
+| Phase subagents written into the worktree `.claude/agents/cyboflow-*.md` | `main/src/services/panels/claude/workflowBundleWriter.ts` | live |
+| `ultracode` session setting → `--settings '{"ultracode":true}'` | `interactiveClaudeManager.ts:664` | live, **quick sessions only** |
+| Dynamic-workflow **detection** + live progress visualisation | `main/src/orchestrator/dynamicWorkflows/`, `frontend/src/stores/dynamicWorkflowStore.ts` | live, **passive** |
+| Blocking human gate over MCP | `cyboflow_request_user_input` (`mcpServer/cyboflowMcpServer.ts:508`) | live |
+
+The header of `shared/types/dynamicWorkflows.ts` states the current boundary
+plainly: *"Cyboflow does NOT launch these itself — it passively DETECTS that a
+session's agent launched one."* This proposal is about crossing that line
+deliberately.
+
+Note the shape of what's already there: the fan-out append exists **because**
+sprint/ship parallelism (DAG waves, the 5-lane cap, the per-task
+`implement → write-tests → code-review → task-verify → visual-verify` chain with
+loopback-to-`implement`) had to be re-expressed as prose for an agent to execute
+by hand. That prose is a hand-rolled `pipeline()` with a concurrency cap. The
+`Workflow` tool's `pipeline(items, ...stages)` is the same construct as a
+deterministic primitive. That correspondence is the core of the opportunity.
+
+## 2. The three mechanisms the change needs — all present
+
+**(a) A trigger.** The `Workflow` tool requires explicit opt-in. Two of its
+accepted forms are already reachable:
+
+- `--settings '{"ultracode":true}'` makes the opt-in *standing* for the session.
+  The interactive manager already emits exactly this flag for
+  `effort: 'ultracode'`; workflow runs simply never set it (it is wired only
+  through the "Ultracode" wizard card for quick sessions — `ipc/session.ts:1314`).
+  Plumbing it for workflow runs is small.
+- The run's prompt is delivered as claude's **positional argv prompt**, i.e. as a
+  *user turn* (`interactiveClaudeManager.ts:1116-1140`). A prompt body that says
+  "run the saved workflow `cyboflow-sprint-fanout`" satisfies the tool's
+  "user asked to run a specific named or saved workflow" opt-in on its own.
+
+**(b) Script delivery.** Verified: the CLI binary at `2.1.231` resolves named
+workflows from `.claude/workflows/` (string present in the bundle).
+`WorkflowBundleWriter` already installs namespaced `cyboflow-*.md` files into the
+worktree's `.claude/commands` and `.claude/agents`, with a merge-safe
+write-clears-prior-cyboflow-set contract and a remove that touches only
+`cyboflow-*`. A third target dir (`.claude/workflows`, `cyboflow-*.js`) is a
+mechanical extension of that class — same namespace rule, same lifecycle.
+
+**(c) MCP reach.** The `Workflow` tool documents that workflow agents reach all
+session-connected MCP tools via `ToolSearch`. The interactive session already
+injects the cyboflow stdio server via `--mcp-config
+<worktree>/.cyboflow/interactive-mcp.json`, and `cyboflow` is explicitly never
+disable-able. **Unverified in this environment** — see §5.
+
+## 3. Design options
+
+### Option A — status quo (manual orchestrator)
+
+Keep as is. Cost: the fan-out prose is a deterministic algorithm expressed as
+natural language, re-interpreted by the model on every run. It is the single
+largest source of run-to-run variance in sprint/ship.
+
+### Option B — phase-scoped dispatch **(recommended)**
+
+The top-level PTY agent stays the orchestrator, the single writer, and the human
+seam. It changes *how it executes one step*: for a step carrying `fanOut` (and
+only those), instead of hand-rolling N Agent-tool calls with a manual wave
+counter, it calls `Workflow({name: 'cyboflow-<flow>-<step>', args: [...items]})`
+once. Cyboflow renders that script from the step's `FanOutSpec` — `inner` chain →
+`pipeline()` stages, `effectiveMaxConcurrency` → item batching, `loopback` →
+a bounded retry loop inside the stage — and installs it into
+`.claude/workflows/` next to the agent bundle.
+
+Preserved by construction:
+
+- **Single writer.** Step reporting and entity writes stay in the main session,
+  between `Workflow` calls. The existing step-reporting append is unchanged.
+- **Human gates.** `human: true` steps never enter a script; the top-level agent
+  still handles them conversationally.
+- **Prompt/DAG parity.** The fan-out append becomes a *short* pointer to the
+  named workflow instead of ~200 lines of re-derived prose. The DAG stays the
+  single source of truth — the script is rendered from it, exactly as the append
+  is today.
+
+Gained: deterministic waves, real concurrency capping, per-item pipelining with
+no barrier between stages, and — free — the existing `DynamicWorkflowTracker`
+visualisation of every lane, which today shows nothing for a manual fan-out.
+
+### Option C — whole-DAG-as-one-script
+
+Render the entire `WorkflowDefinition` to one script and call `Workflow` once.
+Rejected for now; it breaks three live invariants:
+
+1. **Single writer.** Every phase agent would need `cyboflow_*` to write
+   entities. The step-reporting append states the opposite as a rule:
+   *"The Agent-tool subagents you delegate heavy phases to are deliberately
+   scoped WITHOUT the cyboflow tools."*
+2. **Step timeline.** One `Workflow` call is one tool call; nothing reports back
+   until it returns, so `step_results` would freeze for the whole run unless
+   subagents call `cyboflow_report_step` themselves (which is exactly (1)).
+   `cyboflow_report_step` is documented as observational-only, so a narrow
+   carve-out is defensible — but it is a decision, not a detail.
+3. **Human gates.** A gate mid-DAG would have to block inside a subagent on
+   `cyboflow_request_user_input` for a potentially unbounded time (§4.3).
+
+Option C becomes reasonable *after* B ships and those three are settled. Note
+that this is essentially the `programmatic` execution model
+(`docs/proposals/sdk-program-driven-workflows.md`) re-hosted on the PTY — worth
+naming, because that proposal's hard rule is **interactive ⇒ orchestrated**, on
+the stated grounds that "a `claude` REPL has no in-process control channel for a
+host loop to drive." Dynamic workflows are precisely such a channel, in-process
+to the REPL rather than to the main process. If Option C is ever pursued, that
+rule and its rationale need revisiting rather than quiet contradiction.
+
+## 4. Blockers and risks
+
+### 4.1 Premature rest — the one genuine blocker
+
+`RunExecutor.registerTurnEndRest` (`runExecutor.ts:1220`) rests an interactive run
+into `awaiting_review` on **every** turn-end. The `Workflow` tool returns
+immediately and runs in the background; the agent then yields, which is a
+turn-end. So the run would be marked resting while its workflow is still
+executing, and the completion notification would arrive to an already-rested run.
+
+Fix: gate the rest on "no `running` dynamic workflow tracked for this runId".
+The `DynamicWorkflowTracker` already holds exactly that state, keyed by `runId`
+(`DynamicWorkflowRunState.status === 'running'`), and already emits on change —
+so the rest can be deferred and re-driven off the tracker's completion signal.
+This is a small, well-scoped change, but it must land **before** anything
+launches a workflow from a workflow run.
+
+### 4.2 Cancel / pause
+
+Fine as is. `AbstractCliManager.killProcessTree` kills the CLI's whole descendant
+tree, and workflow agents run inside the CLI process, so an existing cancel
+already stops them. No new teardown path needed. Resume is *not* covered — the
+tool's `resumeFromRunId` is same-session only, so a cancelled workflow re-runs
+from scratch on retry.
+
+### 4.3 Human gates from inside a script
+
+`cyboflow_request_user_input` explicitly *"BLOCKS until the human answers"*, so a
+gate is mechanically expressible from a subagent. The risk is duration: a gate
+may sit open for hours and no MCP tool timeout is configured anywhere in
+`main/src` (defaults apply). Option B sidesteps this entirely by keeping gates at
+the top level. Do not put a gate inside a script without first measuring the
+default MCP tool timeout.
+
+### 4.4 Worktree isolation collision
+
+The tool's `isolation: 'worktree'` gives each agent its own git worktree. Cyboflow
+already runs the whole run in a worktree, and per `CLAUDE.md` sprint lanes
+deliberately **share one worktree**. Rendered scripts must never set
+`isolation` — a nested worktree per lane would break the shared-tree assumption
+that lane verification and the final settled-tree `test:unit` run depend on.
+
+### 4.5 Script authoring constraints
+
+Rendered scripts are plain JS (no TypeScript), and `Date.now()` / `Math.random()` /
+argless `new Date()` throw inside a script body (they would break resume). A
+renderer must not emit timestamps or ids from those sources — pass them through
+`args`. Scripts also have no filesystem access in the body (agents do).
+
+### 4.6 Agent-count guideline
+
+The session-level "Dynamic workflow size" guideline caps workflows at ~15 agents
+by default. A sprint with 5 concurrent lanes × a 5-step inner chain is 25 agent
+calls over the run (concurrency-capped, not simultaneous), which reads as over the
+guideline. Worth confirming how the cap is counted before rendering large fan-outs.
+
+### 4.7 Detection already survives the interactive transcript regression
+
+Worth noting as a positive: `WorkflowScriptWatcher` exists because claude 2.1.177
+made the session `<uuid>` a directory, which broke stream-based detection on the
+interactive substrate. Launch detection is therefore filesystem-based and
+substrate-independent already — so tracking a workflow *we* launch needs no new
+detection work.
+
+## 5. What is not verified
+
+- **MCP reach from a workflow subagent.** Documented by the tool, not observed
+  here. This is the load-bearing assumption for any variant where lane agents
+  write entities (`cyboflow_update_sprint_task` drives lane `current_step`).
+  Cheapest probe: a `pnpm dev` session on a scratch project, one hand-written
+  `.claude/workflows/probe.js` whose single agent is asked to call
+  `cyboflow_get_run` via ToolSearch, and check whether it resolves.
+- **Named-workflow resolution from a worktree's `.claude/workflows/`.** The
+  string is present in the CLI bundle; project-scoped resolution (as opposed to
+  `~/.claude/workflows`) was not exercised. Same probe covers it.
+- **Whether flag-tier `ultracode` composes with the run's other
+  `--settings` keys** (`fastMode`, `hooks`, `enabledPlugins` all ride one JSON
+  object). Probably fine — it is additive — but it is a one-line probe.
+
+## 6. Suggested staging
+
+1. **Probe** (§5) — half a day, decides everything downstream.
+2. **Fix premature rest** (§4.1) — independently correct, and a prerequisite.
+   Ships and is testable on its own.
+3. **Renderer** — `FanOutSpec` → workflow script, as a pure function beside
+   `fan-out-instructions.ts` (same no-DB/IPC/fs constraint, same fail-soft
+   contract: no renderable fan-out ⇒ empty, never a throw).
+4. **Writer** — extend the bundle writer to a third `.claude/workflows` target
+   with the same `cyboflow-` namespace and merge-safe remove.
+5. **Prompt swap** — behind a per-workflow opt-in, replace the fan-out prose
+   append with the named-workflow pointer. Both appends stay derived from the
+   resolved definition, so the DAG remains the single source of truth.
+6. **Measure** — sprint run-to-run variance and wall-clock, prose vs script,
+   before making it the default.
+
+Steps 1–2 are worth doing regardless of whether the rest proceeds.

--- a/docs/proposals/pty-dynamic-workflow-orchestration.md
+++ b/docs/proposals/pty-dynamic-workflow-orchestration.md
@@ -190,13 +190,27 @@ by default. A sprint with 5 concurrent lanes × a 5-step inner chain is 25 agent
 calls over the run (concurrency-capped, not simultaneous), which reads as over the
 guideline. Worth confirming how the cap is counted before rendering large fan-outs.
 
-### 4.7 Detection already survives the interactive transcript regression
+### 4.7 Detection did NOT cover workflow runs — corrected
 
-Worth noting as a positive: `WorkflowScriptWatcher` exists because claude 2.1.177
-made the session `<uuid>` a directory, which broke stream-based detection on the
-interactive substrate. Launch detection is therefore filesystem-based and
-substrate-independent already — so tracking a workflow *we* launch needs no new
-detection work.
+**This section originally claimed tracking needs no new detection work. That was
+wrong, and the adversarial review caught it.** `WorkflowScriptWatcher` is indeed
+filesystem-based and substrate-independent (it exists because claude 2.1.177 made
+the session `<uuid>` a directory, breaking stream-based detection on the
+interactive substrate). But the tracker only *started* a watcher when it could
+resolve a worktree path, and it resolved that path exclusively through
+`SELECT worktree_path FROM sessions WHERE id = ?`.
+
+A **flow run has no `sessions` row** — the orchestrator invariant is
+`panelId === runId === sessionId`, and `getDbSession(sessionId)` is undefined for
+it (the gate-vehicle discriminator in `interactiveClaudeManager.spawnCliProcess`
+depends on exactly that). So the lookup returned null, no watcher started, and —
+with stream detection also inoperative on the interactive layout — a dynamic
+workflow launched inside a PTY **workflow run** was invisible to the tracker
+entirely. Only quick sessions (which do own a `sessions` row) were ever tracked.
+
+Fixed: `DynamicWorkflowRunContext` now carries the spawn's authoritative
+`worktreePath`, passed by both managers, with the `sessions` lookup retained as
+the quick-session fallback.
 
 ## 5. What is not verified
 

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -2,6 +2,7 @@ import type { AgentProviderAccess } from '../../../shared/types/agentRuntime';
 import type { AssistantContextRetention } from '../../../shared/types/agentThread';
 import type { CliSubstrate } from '../../../shared/types/substrate';
 import type { ExecutionModel } from '../../../shared/types/executionModel';
+import type { FanOutDispatch } from '../../../shared/types/fanOutDispatch';
 import type { PermissionMode } from '../../../shared/types/workflows';
 import type { QuickSessionWorktreeMode } from '../../../shared/types/worktreeMode';
 import type { VisualVerifyConfig } from '../../../shared/types/visualVerification';
@@ -58,6 +59,13 @@ export interface AppConfig {
   // default to the in-process host loop; the interactive substrate always
   // hard-pins 'orchestrated' regardless of this value.
   defaultExecutionModel?: ExecutionModel;
+  // Fan-out dispatch mode for orchestrated INTERACTIVE runs ('prose' | 'workflow').
+  // 'workflow' dispatches each inner stage of a wave to a pre-installed dynamic
+  // workflow script instead of the agent driving lanes by hand; the orchestrator
+  // stays the single writer either way. Floors to 'prose' when unset, and is NOT
+  // seeded into the constructor defaults so existing config.json files stay
+  // byte-identical.
+  fanOutDispatch?: FanOutDispatch;
   // Global default for where QUICK sessions work ('worktree' | 'in-place').
   // Floors to 'worktree' when unset. The launch wizard's Advanced "Workspace"
   // tri-state overrides it per launch; workflow-host sessions always pin

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -3099,6 +3099,12 @@ async function initializeServices(): Promise<boolean> {
     // §3c#1): the fallback resolveRunAgentPermissionMode uses when a run's owning
     // session has a NULL agent_permission_mode (inherit the global default).
     () => configManager.getDefaultAgentPermissionMode(),
+    // Dynamic-workflow liveness probe: the interactive rest seam consults this so
+    // a turn-end that merely yields to a background `Workflow` task does not park
+    // the run in awaiting_review while its subagents are still working. Read
+    // through tryGetInstance so boot ordering (tracker initialized above, but
+    // defensively) can never throw here.
+    (runId) => DynamicWorkflowTracker.tryGetInstance()?.hasRunningForRun(runId) === true,
   );
 
   // Raw-PTY byte path (TASK-814 / IDEA-030): subscribe the facade's 'pty-output'
@@ -3144,6 +3150,16 @@ async function initializeServices(): Promise<boolean> {
       // the chat session (and vice versa).
       if (!dbSession.chat_run_id || dbSession.chat_run_id !== evt.runId) return;
       if (dbSession.status !== 'running') return;
+      // A turn-end that lands while a dynamic workflow is still RUNNING for this
+      // run is the agent yielding to a background Workflow task, not the session
+      // finishing — the CLI re-invokes it when the workflow completes. Flipping
+      // to 'completed' here would strand the session in a terminal-looking state
+      // (and enable Merge) while its subagents are still writing the worktree.
+      // This is reachable today: the Ultracode wizard card launches quick PTY
+      // sessions with `--settings '{"ultracode":true}'`, which is exactly the
+      // setting that makes the agent fan work out as dynamic workflows.
+      // The session rests on the NEXT turn-end after the workflow goes terminal.
+      if (DynamicWorkflowTracker.tryGetInstance()?.hasRunningForRun(evt.runId) === true) return;
       // Direct DB write + manual session-updated emit — the same shape as the
       // SDK exit handler in events.ts (updateSession would re-map 'completed'
       // through mapSessionStatusToDbStatus and lose the completed_unviewed edge).

--- a/main/src/orchestrator/__tests__/runExecutor.test.ts
+++ b/main/src/orchestrator/__tests__/runExecutor.test.ts
@@ -3251,6 +3251,77 @@ describe('RunExecutor — event-driven rest (persistent interactive substrate)',
     expect(restAwaitingReview).toHaveBeenCalledWith(run.id);
   });
 
+  it('does NOT rest on a turn-end that merely yields to a live dynamic workflow; rests on the next turn-end once it is terminal', async () => {
+    const { mock: lt, restAwaitingReview } = makeLifecycleTransitions();
+
+    const run = makeWorkflowRunRow({ worktree_path: '/my/worktree', status: 'running', substrate: 'interactive' });
+    const workflow = makeWorkflowRow({ id: run.workflow_id });
+    const registry: WorkflowRegistryLike = {
+      getRunById: vi.fn().mockReturnValue(run),
+      getById: vi.fn().mockReturnValue(workflow),
+    };
+
+    const source = new EventEmitter();
+    const { spawner, resolveSpawn, spawnStarted } = makeControllableSpawner();
+
+    // The liveness probe: true while the background Workflow task is running.
+    let workflowRunning = true;
+    const hasRunningDynamicWorkflow = vi.fn((_runId: string) => workflowRunning);
+
+    const executor = new TestableRunExecutor(
+      spawner, registry, makeSpyLogger(), undefined, lt, undefined, undefined, source,
+      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+      hasRunningDynamicWorkflow, // 17th arg: the dynamic-workflow liveness probe
+    );
+
+    const executePromise = executor.execute(run.id);
+    await spawnStarted;
+
+    // The agent launched a Workflow and yielded — this turn-end must NOT rest.
+    source.emit('turn-end', { panelId: run.id, sessionId: run.id, runId: run.id });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(hasRunningDynamicWorkflow).toHaveBeenCalledWith(run.id);
+    expect(restAwaitingReview).not.toHaveBeenCalled();
+
+    // The workflow completes; the CLI re-invokes the agent, whose turn ends normally.
+    workflowRunning = false;
+    source.emit('turn-end', { panelId: run.id, sessionId: run.id, runId: run.id });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(restAwaitingReview).toHaveBeenCalledTimes(1);
+    expect(restAwaitingReview).toHaveBeenCalledWith(run.id);
+
+    resolveSpawn();
+    await executePromise;
+  });
+
+  it('rests normally when no dynamic-workflow probe is injected (byte-identical to the pre-seam path)', async () => {
+    const { mock: lt, restAwaitingReview } = makeLifecycleTransitions();
+
+    const run = makeWorkflowRunRow({ worktree_path: '/my/worktree', status: 'running', substrate: 'interactive' });
+    const workflow = makeWorkflowRow({ id: run.workflow_id });
+    const registry: WorkflowRegistryLike = {
+      getRunById: vi.fn().mockReturnValue(run),
+      getById: vi.fn().mockReturnValue(workflow),
+    };
+
+    const source = new EventEmitter();
+    const { spawner, resolveSpawn, spawnStarted } = makeControllableSpawner();
+
+    const executor = new TestableRunExecutor(
+      spawner, registry, makeSpyLogger(), undefined, lt, undefined, undefined, source,
+    );
+
+    const executePromise = executor.execute(run.id);
+    await spawnStarted;
+
+    source.emit('turn-end', { panelId: run.id, sessionId: run.id, runId: run.id });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(restAwaitingReview).toHaveBeenCalledTimes(1);
+
+    resolveSpawn();
+    await executePromise;
+  });
+
   it('teardownRun (bridge dispose) does NOT fire while the interactive REPL is alive; fires only on explicit termination', async () => {
     const run = makeWorkflowRunRow({ worktree_path: '/my/worktree', status: 'running', substrate: 'interactive' });
     const workflow = makeWorkflowRow({ id: run.workflow_id });

--- a/main/src/orchestrator/dynamicWorkflows/__tests__/dynamicWorkflowTrackerWatcher.test.ts
+++ b/main/src/orchestrator/dynamicWorkflows/__tests__/dynamicWorkflowTrackerWatcher.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit tests for DynamicWorkflowTracker's launch-watcher WIRING and the
+ * `hasRunningForRun` lifecycle predicate.
+ *
+ * Kept separate from dynamicWorkflowTracker.test.ts because this file mocks the
+ * WorkflowScriptWatcher module wholesale (to assert the key dir it is handed
+ * without touching the real `~/.claude/projects`), which the sibling suite
+ * deliberately exercises for real.
+ *
+ * The regression under test: a FLOW run has NO `sessions` row — the orchestrator
+ * invariant is `panelId === runId === sessionId` and `getDbSession(sessionId)`
+ * is undefined for it — so the tracker's `sessions`-keyed worktree lookup
+ * resolved null and NO launch watcher started. Combined with stream detection
+ * being inoperative on the interactive transcript layout, a dynamic workflow
+ * launched inside a PTY workflow run was invisible to the tracker entirely.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { EventRouter } from '../../../services/streamParser/eventRouter';
+import { encodeCwd } from '../../../services/panels/claude/transcript/encodeCwd';
+import type { DatabaseLike } from '../../types';
+
+// Mock the watcher module so construction is observable and no fs polling starts.
+const watcherCtor = vi.fn();
+const watcherStart = vi.fn();
+const watcherStop = vi.fn();
+vi.mock('../workflowScriptWatcher', () => ({
+  WorkflowScriptWatcher: class {
+    constructor(...args: unknown[]) {
+      watcherCtor(...args);
+    }
+    start(): void {
+      watcherStart();
+    }
+    stop(): void {
+      watcherStop();
+    }
+  },
+}));
+
+// Imported AFTER the mock declaration (vi.mock is hoisted, so this is fine).
+import { DynamicWorkflowTracker } from '../dynamicWorkflowTracker';
+
+/**
+ * Minimal DatabaseLike stub. `sessionRows` maps a session id to the row the
+ * tracker's lookups return; an id that is absent returns undefined — exactly how
+ * a flow run's non-existent `sessions` row behaves.
+ */
+function buildDb(sessionRows: Record<string, { worktree_path?: string | null; name?: string; project_id?: number }>): DatabaseLike {
+  return {
+    prepare: (sql: string) => ({
+      get: (id?: unknown) => {
+        if (typeof id !== 'string') return undefined;
+        const row = sessionRows[id];
+        if (row === undefined) return undefined;
+        if (sql.includes('worktree_path')) return { worktree_path: row.worktree_path ?? null };
+        return { name: row.name ?? 'sess', project_id: row.project_id ?? 1 };
+      },
+      all: () => [],
+      run: () => ({ changes: 0 }),
+    }),
+  } as unknown as DatabaseLike;
+}
+
+/** The key dir the tracker should derive for a given worktree path. */
+function expectedKeyDir(worktreePath: string): string {
+  return path.join(os.homedir(), '.claude', 'projects', encodeCwd(worktreePath));
+}
+
+describe('DynamicWorkflowTracker — launch-watcher wiring', () => {
+  beforeEach(() => {
+    watcherCtor.mockClear();
+    watcherStart.mockClear();
+    watcherStop.mockClear();
+  });
+
+  afterEach(() => {
+    DynamicWorkflowTracker._resetForTesting();
+  });
+
+  it('starts a watcher for a FLOW run (no sessions row) from the supplied worktreePath', () => {
+    // The regression: sessionRows is EMPTY, exactly as for a flow run whose
+    // sessionId === runId and which owns no `sessions` row.
+    const tracker = DynamicWorkflowTracker.initialize(buildDb({}));
+    const worktreePath = '/tmp/worktrees/run-flow-1';
+
+    tracker.attachToRouter(new EventRouter(), {
+      runId: 'run-flow-1',
+      sessionId: 'run-flow-1',
+      worktreePath,
+    });
+
+    expect(watcherCtor).toHaveBeenCalledTimes(1);
+    expect(watcherCtor.mock.calls[0][0]).toBe(expectedKeyDir(worktreePath));
+    expect(watcherStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts NO watcher for a flow run when no worktreePath is supplied (the pre-fix behaviour)', () => {
+    const tracker = DynamicWorkflowTracker.initialize(buildDb({}));
+
+    tracker.attachToRouter(new EventRouter(), { runId: 'run-flow-2', sessionId: 'run-flow-2' });
+
+    expect(watcherCtor).not.toHaveBeenCalled();
+    expect(watcherStart).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the sessions lookup for a QUICK session that supplies no path', () => {
+    const tracker = DynamicWorkflowTracker.initialize(
+      buildDb({ 'sess-1': { worktree_path: '/tmp/worktrees/quick-1' } }),
+    );
+
+    tracker.attachToRouter(new EventRouter(), { runId: 'chat-run-1', sessionId: 'sess-1' });
+
+    expect(watcherCtor).toHaveBeenCalledTimes(1);
+    expect(watcherCtor.mock.calls[0][0]).toBe(expectedKeyDir('/tmp/worktrees/quick-1'));
+  });
+
+  it('prefers the supplied worktreePath over the sessions row', () => {
+    const tracker = DynamicWorkflowTracker.initialize(
+      buildDb({ 'sess-2': { worktree_path: '/tmp/worktrees/stale' } }),
+    );
+
+    tracker.attachToRouter(new EventRouter(), {
+      runId: 'chat-run-2',
+      sessionId: 'sess-2',
+      worktreePath: '/tmp/worktrees/authoritative',
+    });
+
+    expect(watcherCtor.mock.calls[0][0]).toBe(expectedKeyDir('/tmp/worktrees/authoritative'));
+  });
+
+  it('treats a blank supplied worktreePath as absent and falls back', () => {
+    const tracker = DynamicWorkflowTracker.initialize(
+      buildDb({ 'sess-3': { worktree_path: '/tmp/worktrees/quick-3' } }),
+    );
+
+    tracker.attachToRouter(new EventRouter(), {
+      runId: 'chat-run-3',
+      sessionId: 'sess-3',
+      worktreePath: '   ',
+    });
+
+    expect(watcherCtor.mock.calls[0][0]).toBe(expectedKeyDir('/tmp/worktrees/quick-3'));
+  });
+
+  it('replaces (stops) a prior watcher when the same runId re-attaches', () => {
+    const tracker = DynamicWorkflowTracker.initialize(buildDb({}));
+    const ctx = { runId: 'run-flow-3', sessionId: 'run-flow-3', worktreePath: '/tmp/w/3' };
+
+    tracker.attachToRouter(new EventRouter(), ctx);
+    tracker.attachToRouter(new EventRouter(), ctx);
+
+    expect(watcherCtor).toHaveBeenCalledTimes(2);
+    expect(watcherStop).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('DynamicWorkflowTracker.hasRunningForRun', () => {
+  afterEach(() => {
+    DynamicWorkflowTracker._resetForTesting();
+  });
+
+  it('is false for an unknown run', () => {
+    const tracker = DynamicWorkflowTracker.initialize(buildDb({}));
+    expect(tracker.hasRunningForRun('nope')).toBe(false);
+  });
+
+  it('is true while a tracked workflow for the run is running, false once terminal', () => {
+    const tracker = DynamicWorkflowTracker.initialize(buildDb({}));
+    // injectDemoWorkflow is the only public seam that materializes state without
+    // an on-disk journal; it registers as 'running' synchronously.
+    tracker.injectDemoWorkflow({ runId: 'run-a', sessionId: 'sess-a' });
+
+    expect(tracker.hasRunningForRun('run-a')).toBe(true);
+    // Scoped to the run — a sibling run is unaffected.
+    expect(tracker.hasRunningForRun('run-b')).toBe(false);
+
+    // Dismissal drops the state entirely (the terminal card's dismiss CTA).
+    const state = tracker.list('sess-a')[0];
+    tracker.dismiss(state.wfRunId);
+    expect(tracker.hasRunningForRun('run-a')).toBe(false);
+  });
+});

--- a/main/src/orchestrator/dynamicWorkflows/dynamicWorkflowTracker.ts
+++ b/main/src/orchestrator/dynamicWorkflows/dynamicWorkflowTracker.ts
@@ -63,6 +63,24 @@ const TERMINAL_NOTIFICATION_STATUSES = new Set(['completed', 'failed', 'killed']
 export interface DynamicWorkflowRunContext {
   runId: string;
   sessionId: string;
+  /**
+   * The spawn's AUTHORITATIVE worktree path, used to derive the claude project
+   * key dir the {@link WorkflowScriptWatcher} polls.
+   *
+   * Load-bearing for FLOW runs. A workflow run has NO `sessions` row — the
+   * orchestrator invariant is `panelId === runId === sessionId`, and
+   * `getDbSession(sessionId)` returns undefined for it (see the gate-vehicle
+   * discriminator in interactiveClaudeManager.spawnCliProcess). So the
+   * `sessions`-keyed {@link lookupWorktreePath} fallback resolves null for every
+   * flow run, no watcher starts, and — since stream detection does not work on
+   * the interactive layout either (see startScriptWatcher) — a dynamic workflow
+   * launched inside a PTY FLOW run was invisible to the tracker entirely.
+   *
+   * Both managers have the path in `options.worktreePath` at attach time, so
+   * they pass it here. Optional (not required) so the existing quick-session
+   * callers and the tracker's own tests keep working off the `sessions` lookup.
+   */
+  worktreePath?: string;
 }
 
 interface SubagentUsageSink {
@@ -210,13 +228,21 @@ export class DynamicWorkflowTracker {
   }
 
   /**
-   * Start the per-run {@link WorkflowScriptWatcher} over the session's claude
+   * Start the per-run {@link WorkflowScriptWatcher} over the run's claude
    * project key dir (`~/.claude/projects/<encodeCwd(worktree)>`). Skipped (no-op)
-   * when the session's worktree path cannot be resolved. Replaces any prior
-   * watcher for the same runId.
+   * when no worktree path resolves. Replaces any prior watcher for the same runId.
+   *
+   * Path resolution prefers the caller-supplied `ctx.worktreePath` (the spawn's
+   * own authoritative value) and falls back to the `sessions` lookup. The
+   * fallback is quick-session-only in practice: a FLOW run has no `sessions`
+   * row, so without the supplied path this returned null and the run got no
+   * watcher — see {@link DynamicWorkflowRunContext.worktreePath}.
    */
   private startScriptWatcher(ctx: DynamicWorkflowRunContext): void {
-    const worktreePath = this.lookupWorktreePath(ctx.sessionId);
+    const worktreePath =
+      ctx.worktreePath !== undefined && ctx.worktreePath.trim().length > 0
+        ? ctx.worktreePath
+        : this.lookupWorktreePath(ctx.sessionId);
     if (worktreePath === null) return;
 
     this.scriptWatchers.get(ctx.runId)?.stop();
@@ -447,6 +473,27 @@ export class DynamicWorkflowTracker {
     const all = [...this.states.values()];
     const filtered = sessionId === undefined ? all : all.filter((s) => s.sessionId === sessionId);
     return filtered.map((s) => this.snapshot(s));
+  }
+
+  /**
+   * True when ANY tracked workflow for `runId` is still running.
+   *
+   * The lifecycle predicate: a turn-end that lands while this holds is the agent
+   * yielding to a BACKGROUND workflow, not the run finishing, so the caller must
+   * not rest/complete on it. Deliberately scoped to a run rather than a single
+   * wfRunId — a run may launch several workflows over its life, and resting is
+   * only safe once EVERY one of them is terminal.
+   *
+   * NOTE the attribution caveat: a launch is stamped with whichever attached
+   * context's watcher observed the script first, and a session's chat panel and
+   * its flow run poll the SAME project key dir. Callers must treat a `false` as
+   * "no evidence of a running workflow", not proof of absence.
+   */
+  hasRunningForRun(runId: string): boolean {
+    for (const state of this.states.values()) {
+      if (state.runId === runId && state.status === 'running') return true;
+    }
+    return false;
   }
 
   // --------------------------------------------------------------------------

--- a/main/src/orchestrator/prompts/__tests__/fan-out-instructions.test.ts
+++ b/main/src/orchestrator/prompts/__tests__/fan-out-instructions.test.ts
@@ -21,6 +21,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { buildFanOutAppend } from '../fan-out-instructions';
+import { fanOutStageWorkflowName } from '../fanOutStageScript';
 import { WORKFLOW_DEFINITIONS, type WorkflowDefinition } from '../../../../../shared/types/workflows';
 
 /**
@@ -217,5 +218,71 @@ describe('buildFanOutAppend — fail-soft', () => {
     const block = buildFanOutAppend(WORKFLOW_DEFINITIONS.sprint);
     expect(block).toContain('## Fan-out execution — `execute-tasks`');
     expect(block).toContain('at most **5**');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stage-major workflow dispatch (opts.dispatch === 'workflow')
+// ---------------------------------------------------------------------------
+
+describe('buildFanOutAppend — dispatch mode', () => {
+  const def = canonicalFanOutDef();
+
+  it('defaults to prose — byte-identical to an explicit prose request', () => {
+    expect(buildFanOutAppend(def)).toBe(buildFanOutAppend(def, { dispatch: 'prose' }));
+  });
+
+  it('the prose arm never mentions the Workflow tool', () => {
+    expect(buildFanOutAppend(def)).not.toContain('Workflow({');
+  });
+
+  describe('workflow arm', () => {
+    const block = buildFanOutAppend(def, { dispatch: 'workflow', workflowName: 'sprint' });
+
+    it('dispatches each agent-backed stage to its named script', () => {
+      // Names MUST match what the renderer/writer produce for the same inputs.
+      for (const inner of ['implement', 'write-tests', 'code-review', 'task-verify']) {
+        const expected = fanOutStageWorkflowName('sprint', 'execute-tasks', inner);
+        expect(expected).not.toBeNull();
+        expect(block).toContain(`Workflow({ name: '${expected as string}'`);
+      }
+    });
+
+    it('keeps the host-owned visual merge-gate on the prose path', () => {
+      const visualScript = fanOutStageWorkflowName('sprint', 'execute-tasks', 'visual-verify');
+      expect(block).not.toContain(`name: '${visualScript as string}'`);
+      // Its original protocol survives verbatim.
+      expect(block).toContain('cyboflow_request_verification');
+      expect(block).toContain('there is NO subagent to delegate');
+    });
+
+    it('advances one stage at a time across the wave (stage-major, not item-major)', () => {
+      expect(block).toContain('ONE STAGE AT A TIME');
+      expect(block).toContain('Pass ONLY the members of the CURRENT wave');
+    });
+
+    it('reconciles domain outcomes rather than assuming success', () => {
+      expect(block).toContain('outcome: "blocked"');
+      expect(block).toContain('outcome: "not_applicable"');
+    });
+
+    it('keeps every cyboflow write with the orchestrator', () => {
+      expect(block).toContain('SOLE writer of cyboflow');
+      expect(block).toContain('The script writes NO cyboflow state by design');
+      expect(block).toContain('cyboflow_report_finding');
+    });
+
+    it('retains the shared dispatch + loopback protocol', () => {
+      expect(block).toContain('at most **5** concurrently');
+      expect(block).toContain('Loopback + attempt protocol');
+      expect(block).toContain('make');
+      expect(block).toContain('ONE git commit for that task');
+    });
+
+    it('falls back to prose for a stage whose name cannot be slugged', () => {
+      const weird = buildFanOutAppend(def, { dispatch: 'workflow', workflowName: '***' });
+      expect(weird).not.toContain('Workflow({');
+      expect(weird).toContain('cyboflow-implement');
+    });
   });
 });

--- a/main/src/orchestrator/prompts/__tests__/fan-out-instructions.test.ts
+++ b/main/src/orchestrator/prompts/__tests__/fan-out-instructions.test.ts
@@ -21,7 +21,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { buildFanOutAppend } from '../fan-out-instructions';
-import { fanOutStageWorkflowName } from '../fanOutStageScript';
+import { fanOutBatchWorkflowName } from '../fanOutStageScript';
 import { WORKFLOW_DEFINITIONS, type WorkflowDefinition } from '../../../../../shared/types/workflows';
 
 /**
@@ -239,31 +239,36 @@ describe('buildFanOutAppend — dispatch mode', () => {
   describe('workflow arm', () => {
     const block = buildFanOutAppend(def, { dispatch: 'workflow', workflowName: 'sprint' });
 
-    it('dispatches each agent-backed stage to its named script', () => {
-      // Names MUST match what the renderer/writer produce for the same inputs.
-      for (const inner of ['implement', 'write-tests', 'code-review', 'task-verify']) {
-        const expected = fanOutStageWorkflowName('sprint', 'execute-tasks', inner);
-        expect(expected).not.toBeNull();
-        expect(block).toContain(`Workflow({ name: '${expected as string}'`);
-      }
+    it('dispatches the whole non-gated sub-chain as ONE batch', () => {
+      const batchName = fanOutBatchWorkflowName('sprint', 'execute-tasks', 'implement');
+      expect(batchName).not.toBeNull();
+      expect(block).toContain(`Workflow({ name: '${batchName as string}'`);
+      // ONE dispatch, not one per stage.
+      expect(block.match(/Workflow\(\{ name:/g)).toHaveLength(1);
+      expect(block).toContain('dispatched as ONE batch, no orchestrator gate between them');
     });
 
-    it('keeps the host-owned visual merge-gate on the prose path', () => {
-      const visualScript = fanOutStageWorkflowName('sprint', 'execute-tasks', 'visual-verify');
-      expect(block).not.toContain(`name: '${visualScript as string}'`);
-      // Its original protocol survives verbatim.
+    it('names the Workflow tool explicitly so the agent does not try Skill first', () => {
+      expect(block).toContain('use the **Workflow tool** (not Skill, not Bash)');
+    });
+
+    it('keeps the firm visual gate on the prose path', () => {
+      const gateName = fanOutBatchWorkflowName('sprint', 'execute-tasks', 'visual-verify');
+      expect(block).not.toContain(`name: '${gateName as string}'`);
       expect(block).toContain('cyboflow_request_verification');
       expect(block).toContain('there is NO subagent to delegate');
     });
 
-    it('advances one stage at a time across the wave (stage-major, not item-major)', () => {
-      expect(block).toContain('ONE STAGE AT A TIME');
-      expect(block).toContain('Pass ONLY the members of the CURRENT wave');
+    it('states the lane-granularity trade explicitly', () => {
+      expect(block).toContain('does not');
+      expect(block).toContain('tick per stage');
+      expect(block).toContain('backfill');
     });
 
     it('reconciles domain outcomes rather than assuming success', () => {
-      expect(block).toContain('outcome: "blocked"');
-      expect(block).toContain('outcome: "not_applicable"');
+      expect(block).toContain('outcome: "ok"');
+      expect(block).toContain('outcome: "failed"');
+      expect(block).toContain('failedStage');
     });
 
     it('keeps every cyboflow write with the orchestrator', () => {
@@ -275,11 +280,10 @@ describe('buildFanOutAppend — dispatch mode', () => {
     it('retains the shared dispatch + loopback protocol', () => {
       expect(block).toContain('at most **5** concurrently');
       expect(block).toContain('Loopback + attempt protocol');
-      expect(block).toContain('make');
       expect(block).toContain('ONE git commit for that task');
     });
 
-    it('falls back to prose for a stage whose name cannot be slugged', () => {
+    it('falls back to prose for a batch whose name cannot be slugged', () => {
       const weird = buildFanOutAppend(def, { dispatch: 'workflow', workflowName: '***' });
       expect(weird).not.toContain('Workflow({');
       expect(weird).toContain('cyboflow-implement');

--- a/main/src/orchestrator/prompts/__tests__/fanOutStageScript.test.ts
+++ b/main/src/orchestrator/prompts/__tests__/fanOutStageScript.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Unit tests for the fan-out STAGE script renderer.
+ *
+ * The important ones are the safety tests: the emitted file is JavaScript that a
+ * separate runtime executes, and its name is joined into a filesystem path, so
+ * free-form workflow/step/agent ids must not be able to escape either. Note that
+ * `parseScriptMeta` (the tracker's reader) is a deliberately fail-soft REGEX
+ * scanner — it will happily accept syntactically invalid source — so real syntax
+ * validation here goes through the JS parser, not through that.
+ */
+import { describe, it, expect } from 'vitest';
+import * as vm from 'node:vm';
+import {
+  fanOutStageLogicalName,
+  fanOutStageWorkflowName,
+  isHostOwnedInnerStep,
+  renderFanOutStageScript,
+  renderFanOutStageScripts,
+  slugSegment,
+} from '../fanOutStageScript';
+import { parseScriptMeta } from '../../dynamicWorkflows/scriptMeta';
+import { resolveWorkflowDefinition } from '../../../../../shared/types/workflows';
+import type { FanOutInnerStep, FanOutSpec, WorkflowStep } from '../../../../../shared/types/workflows';
+
+const INNER: FanOutInnerStep[] = [
+  { id: 'implement', agent: 'implement', name: 'Implement' },
+  { id: 'write-tests', agent: 'write-tests', name: 'Write tests', loopback: 'implement' },
+  { id: 'visual-verify', agent: 'visual-verify', name: 'Visual verify', optional: true },
+];
+
+const FAN_OUT: FanOutSpec = { over: 'tasks', inner: INNER, maxConcurrency: 5 };
+
+const STEP: WorkflowStep = {
+  id: 'execute',
+  name: 'Execute',
+  agent: 'orchestrator',
+  mcps: [],
+  retries: 0,
+  fanOut: FAN_OUT,
+};
+
+/**
+ * Syntax-check the emitted source the way the workflow runtime consumes it: the
+ * `export const meta` declaration is lifted off, and the remaining body runs
+ * inside an async function (which is what legalizes its top-level `await` and
+ * top-level `return`). Compiling that shape with `vm.Script` is a real parse —
+ * unlike `parseScriptMeta`, which is a fail-soft regex scanner and would accept
+ * broken source. `vm.SourceTextModule` is deliberately not used: it needs
+ * --experimental-vm-modules, and it would reject the top-level return anyway.
+ */
+function assertParses(source: string): void {
+  const body = source.replace(/^export\s+const\s+meta\s*=/m, 'const meta =');
+  const wrapped = `(async (args, agent, parallel, pipeline, log, phase, workflow, budget) => {\n${body}\n})`;
+  expect(() => new vm.Script(wrapped, { filename: 'stage.js' })).not.toThrow();
+}
+
+describe('slugSegment', () => {
+  it('reduces free-form input to a filename-safe segment', () => {
+    expect(slugSegment('Sprint Flow')).toBe('sprint-flow');
+    expect(slugSegment('write_tests')).toBe('write-tests');
+    expect(slugSegment('  --Weird--  ')).toBe('weird');
+  });
+
+  it('neutralizes path traversal and separators', () => {
+    expect(slugSegment('../../etc/passwd')).toBe('etc-passwd');
+    expect(slugSegment('a/b')).toBe('a-b');
+    expect(slugSegment('..')).toBe('');
+    expect(slugSegment('/')).toBe('');
+  });
+
+  it('returns empty for input with no usable characters', () => {
+    expect(slugSegment('***')).toBe('');
+    expect(slugSegment('')).toBe('');
+  });
+
+  it('caps segment length', () => {
+    expect(slugSegment('a'.repeat(200)).length).toBeLessThanOrEqual(40);
+  });
+});
+
+describe('naming', () => {
+  it('pairs the logical name with the invocable name (writer adds the prefix exactly once)', () => {
+    expect(fanOutStageLogicalName('sprint', 'execute', 'implement')).toBe('sprint-execute-implement');
+    expect(fanOutStageWorkflowName('sprint', 'execute', 'implement')).toBe('cyboflow-sprint-execute-implement');
+  });
+
+  it('does not double the cyboflow- prefix when the flow is already named that way', () => {
+    const invocable = fanOutStageWorkflowName('cyboflow', 'execute', 'implement');
+    expect(invocable).toBe('cyboflow-cyboflow-execute-implement');
+    // The LOGICAL name is what the writer prefixes — assert the writer's output
+    // basename would carry exactly one leading namespace segment beyond the flow.
+    expect(`cyboflow-${fanOutStageLogicalName('cyboflow', 'execute', 'implement')}`).toBe(invocable);
+  });
+
+  it('is null when any segment cannot be slugged', () => {
+    expect(fanOutStageLogicalName('***', 'execute', 'implement')).toBeNull();
+    expect(fanOutStageWorkflowName('sprint', '', 'implement')).toBeNull();
+  });
+});
+
+describe('host-owned stages', () => {
+  it('recognizes visual-verify by id and by agent', () => {
+    expect(isHostOwnedInnerStep({ id: 'visual-verify', agent: 'x' })).toBe(true);
+    expect(isHostOwnedInnerStep({ id: 'renamed', agent: 'visual-verify' })).toBe(true);
+    expect(isHostOwnedInnerStep({ id: 'implement', agent: 'implement' })).toBe(false);
+  });
+
+  it('never renders a script for the visual merge-gate', () => {
+    expect(renderFanOutStageScript('sprint', STEP, FAN_OUT, INNER[2])).toBeNull();
+  });
+});
+
+describe('renderFanOutStageScript', () => {
+  const source = renderFanOutStageScript('sprint', STEP, FAN_OUT, INNER[0]) as string;
+
+  it('emits parseable JavaScript', () => {
+    expect(source).not.toBeNull();
+    assertParses(source);
+  });
+
+  it('emits a meta literal the tracker can read back', () => {
+    const meta = parseScriptMeta(source);
+    expect(meta.name).toBe('cyboflow-sprint-execute-implement');
+    expect(meta.phases.map((p) => p.title)).toEqual(['Implement']);
+  });
+
+  it('binds the stage to its cyboflow- agent definition', () => {
+    expect(source).toContain('"cyboflow-implement"');
+    expect(source).toContain('agentType: AGENT_TYPE');
+  });
+
+  it('never emits worktree isolation (lanes share one worktree)', () => {
+    expect(source).not.toContain('isolation');
+  });
+
+  it('never emits constructs that throw inside a script body', () => {
+    expect(source).not.toMatch(/Date\.now\(\)/);
+    expect(source).not.toMatch(/Math\.random\(\)/);
+    expect(source).not.toMatch(/new Date\(\s*\)/);
+  });
+
+  it('carries a domain-outcome schema rather than keying on promise rejection', () => {
+    expect(source).toContain("'blocked'");
+    expect(source).toContain("required: ['outcome', 'summary']");
+    // A null agent slot becomes a failed item, never a silently dropped one.
+    expect(source).toContain("outcome: 'failed'");
+  });
+
+  it('returns an empty result set for an empty wave', () => {
+    expect(source).toContain('return { stage: STAGE_ID, results: [] }');
+  });
+
+  it('is null when the spec has no inner steps', () => {
+    const empty: FanOutSpec = { over: 'tasks', inner: [] };
+    expect(renderFanOutStageScript('sprint', STEP, empty, INNER[0])).toBeNull();
+  });
+});
+
+describe('injection safety', () => {
+  const hostile = [
+    'quote"break',
+    "apos'break",
+    'back`tick',
+    'dollar${expr}',
+    'new\nline',
+    'back\\slash',
+    'unicode- -sep',
+  ];
+
+  for (const raw of hostile) {
+    it(`survives a hostile agent id: ${JSON.stringify(raw)}`, () => {
+      const inner: FanOutInnerStep = { id: 'implement', agent: raw, name: raw };
+      const spec: FanOutSpec = { over: 'tasks', inner: [inner] };
+      const source = renderFanOutStageScript('sprint', STEP, spec, inner);
+      expect(source).not.toBeNull();
+      assertParses(source as string);
+    });
+  }
+
+  it('survives a hostile workflow name in the description without breaking the source', () => {
+    const inner: FanOutInnerStep = { id: 'implement', agent: 'implement' };
+    const spec: FanOutSpec = { over: 'tasks', inner: [inner] };
+    const step: WorkflowStep = { ...STEP, id: 'exec"ute\n' };
+    const source = renderFanOutStageScript('sprint', step, spec, inner);
+    // The id still slugs to something usable, and the source stays valid.
+    expect(source).not.toBeNull();
+    assertParses(source as string);
+  });
+});
+
+describe('renderFanOutStageScripts over the real sprint definition', () => {
+  const def = resolveWorkflowDefinition('sprint', '{}');
+  const steps = def === null ? [] : def.phases.flatMap((p) => p.steps);
+  const scripts = renderFanOutStageScripts('sprint', steps);
+
+  it('renders one script per scriptable inner stage and skips the visual gate', () => {
+    expect(scripts.length).toBeGreaterThan(0);
+    const names = scripts.map((s) => s.name);
+    expect(names.some((n) => n.endsWith('-implement'))).toBe(true);
+    expect(names.some((n) => n.endsWith('-visual-verify'))).toBe(false);
+  });
+
+  it('every rendered script parses and round-trips its meta', () => {
+    for (const script of scripts) {
+      assertParses(script.content);
+      expect(parseScriptMeta(script.content).name).toBe(`cyboflow-${script.name}`);
+    }
+  });
+
+  it('produces unique names', () => {
+    const names = scripts.map((s) => s.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});

--- a/main/src/orchestrator/prompts/__tests__/fanOutStageScript.test.ts
+++ b/main/src/orchestrator/prompts/__tests__/fanOutStageScript.test.ts
@@ -1,34 +1,39 @@
 /**
- * Unit tests for the fan-out STAGE script renderer.
+ * Unit tests for the fan-out BATCH script renderer.
  *
- * The important ones are the safety tests: the emitted file is JavaScript that a
- * separate runtime executes, and its name is joined into a filesystem path, so
- * free-form workflow/step/agent ids must not be able to escape either. Note that
- * `parseScriptMeta` (the tracker's reader) is a deliberately fail-soft REGEX
- * scanner — it will happily accept syntactically invalid source — so real syntax
- * validation here goes through the JS parser, not through that.
+ * Two things carry the most weight here:
+ *  - Segmentation. Consecutive non-gated stages must coalesce into ONE batch
+ *    (that is the whole efficiency argument), and a firm gate must always break
+ *    the chain — `visual-verify` structurally, any stage the author flags.
+ *  - Safety. The emitted file is JavaScript another runtime executes, and its
+ *    name is joined into a filesystem path, so free-form workflow/step/agent ids
+ *    must not be able to escape either. `parseScriptMeta` (the tracker's reader)
+ *    is a fail-soft REGEX scanner and would accept syntactically invalid source,
+ *    so real syntax validation goes through the JS parser instead.
  */
 import { describe, it, expect } from 'vitest';
 import * as vm from 'node:vm';
 import {
-  fanOutStageLogicalName,
-  fanOutStageWorkflowName,
-  isHostOwnedInnerStep,
-  renderFanOutStageScript,
-  renderFanOutStageScripts,
+  fanOutBatchLogicalName,
+  fanOutBatchWorkflowName,
+  isFirmGateInnerStep,
+  renderFanOutBatchScript,
+  renderFanOutBatchScripts,
+  segmentFanOutInner,
   slugSegment,
 } from '../fanOutStageScript';
 import { parseScriptMeta } from '../../dynamicWorkflows/scriptMeta';
 import { resolveWorkflowDefinition } from '../../../../../shared/types/workflows';
-import type { FanOutInnerStep, FanOutSpec, WorkflowStep } from '../../../../../shared/types/workflows';
+import type { FanOutInnerStep, WorkflowStep } from '../../../../../shared/types/workflows';
 
+/** The canonical sprint chain: four batchable stages then the firm visual gate. */
 const INNER: FanOutInnerStep[] = [
   { id: 'implement', agent: 'implement', name: 'Implement' },
   { id: 'write-tests', agent: 'write-tests', name: 'Write tests', loopback: 'implement' },
-  { id: 'visual-verify', agent: 'visual-verify', name: 'Visual verify', optional: true },
+  { id: 'code-review', agent: 'code-review', name: 'Code review', loopback: 'implement' },
+  { id: 'task-verify', agent: 'task-verify', name: 'Verify', loopback: 'implement' },
+  { id: 'visual-verify', agent: 'visual-verify', name: 'Visual check', optional: true, firmGate: true },
 ];
-
-const FAN_OUT: FanOutSpec = { over: 'tasks', inner: INNER, maxConcurrency: 5 };
 
 const STEP: WorkflowStep = {
   id: 'execute',
@@ -36,22 +41,20 @@ const STEP: WorkflowStep = {
   agent: 'orchestrator',
   mcps: [],
   retries: 0,
-  fanOut: FAN_OUT,
+  fanOut: { over: 'tasks', inner: INNER, maxConcurrency: 5 },
 };
 
 /**
  * Syntax-check the emitted source the way the workflow runtime consumes it: the
  * `export const meta` declaration is lifted off, and the remaining body runs
  * inside an async function (which is what legalizes its top-level `await` and
- * top-level `return`). Compiling that shape with `vm.Script` is a real parse —
- * unlike `parseScriptMeta`, which is a fail-soft regex scanner and would accept
- * broken source. `vm.SourceTextModule` is deliberately not used: it needs
+ * top-level `return`). `vm.SourceTextModule` is deliberately not used: it needs
  * --experimental-vm-modules, and it would reject the top-level return anyway.
  */
 function assertParses(source: string): void {
   const body = source.replace(/^export\s+const\s+meta\s*=/m, 'const meta =');
   const wrapped = `(async (args, agent, parallel, pipeline, log, phase, workflow, budget) => {\n${body}\n})`;
-  expect(() => new vm.Script(wrapped, { filename: 'stage.js' })).not.toThrow();
+  expect(() => new vm.Script(wrapped, { filename: 'batch.js' })).not.toThrow();
 }
 
 describe('slugSegment', () => {
@@ -80,53 +83,106 @@ describe('slugSegment', () => {
 
 describe('naming', () => {
   it('pairs the logical name with the invocable name (writer adds the prefix exactly once)', () => {
-    expect(fanOutStageLogicalName('sprint', 'execute', 'implement')).toBe('sprint-execute-implement');
-    expect(fanOutStageWorkflowName('sprint', 'execute', 'implement')).toBe('cyboflow-sprint-execute-implement');
-  });
-
-  it('does not double the cyboflow- prefix when the flow is already named that way', () => {
-    const invocable = fanOutStageWorkflowName('cyboflow', 'execute', 'implement');
-    expect(invocable).toBe('cyboflow-cyboflow-execute-implement');
-    // The LOGICAL name is what the writer prefixes — assert the writer's output
-    // basename would carry exactly one leading namespace segment beyond the flow.
-    expect(`cyboflow-${fanOutStageLogicalName('cyboflow', 'execute', 'implement')}`).toBe(invocable);
+    expect(fanOutBatchLogicalName('sprint', 'execute', 'implement')).toBe('sprint-execute-implement');
+    expect(fanOutBatchWorkflowName('sprint', 'execute', 'implement')).toBe('cyboflow-sprint-execute-implement');
+    expect(`cyboflow-${fanOutBatchLogicalName('sprint', 'execute', 'implement') as string}`).toBe(
+      fanOutBatchWorkflowName('sprint', 'execute', 'implement'),
+    );
   });
 
   it('is null when any segment cannot be slugged', () => {
-    expect(fanOutStageLogicalName('***', 'execute', 'implement')).toBeNull();
-    expect(fanOutStageWorkflowName('sprint', '', 'implement')).toBeNull();
+    expect(fanOutBatchLogicalName('***', 'execute', 'implement')).toBeNull();
+    expect(fanOutBatchWorkflowName('sprint', '', 'implement')).toBeNull();
   });
 });
 
-describe('host-owned stages', () => {
-  it('recognizes visual-verify by id and by agent', () => {
-    expect(isHostOwnedInnerStep({ id: 'visual-verify', agent: 'x' })).toBe(true);
-    expect(isHostOwnedInnerStep({ id: 'renamed', agent: 'visual-verify' })).toBe(true);
-    expect(isHostOwnedInnerStep({ id: 'implement', agent: 'implement' })).toBe(false);
+describe('firm gates', () => {
+  it('honours the explicit flag', () => {
+    expect(isFirmGateInnerStep({ id: 'anything', agent: 'x', firmGate: true })).toBe(true);
+    expect(isFirmGateInnerStep({ id: 'implement', agent: 'implement' })).toBe(false);
+    expect(isFirmGateInnerStep({ id: 'implement', agent: 'implement', firmGate: false })).toBe(false);
   });
 
-  it('never renders a script for the visual merge-gate', () => {
-    expect(renderFanOutStageScript('sprint', STEP, FAN_OUT, INNER[2])).toBeNull();
+  it('treats visual-verify as gated even with the flag off (no subagent exists for it)', () => {
+    expect(isFirmGateInnerStep({ id: 'visual-verify', agent: 'x', firmGate: false })).toBe(true);
+    expect(isFirmGateInnerStep({ id: 'renamed', agent: 'visual-verify' })).toBe(true);
   });
 });
 
-describe('renderFanOutStageScript', () => {
-  const source = renderFanOutStageScript('sprint', STEP, FAN_OUT, INNER[0]) as string;
+describe('segmentFanOutInner', () => {
+  it('coalesces the four implementation stages into ONE batch, gate last', () => {
+    const segments = segmentFanOutInner(INNER);
+    expect(segments).toHaveLength(2);
+    expect(segments[0]).toMatchObject({ kind: 'batch' });
+    expect((segments[0] as { steps: FanOutInnerStep[] }).steps.map((s) => s.id)).toEqual([
+      'implement',
+      'write-tests',
+      'code-review',
+      'task-verify',
+    ]);
+    expect(segments[1]).toMatchObject({ kind: 'gate' });
+  });
+
+  it('splits around a gate in the middle', () => {
+    const segments = segmentFanOutInner([
+      { id: 'a', agent: 'a' },
+      { id: 'gate', agent: 'g', firmGate: true },
+      { id: 'b', agent: 'b' },
+      { id: 'c', agent: 'c' },
+    ]);
+    expect(segments.map((s) => s.kind)).toEqual(['batch', 'gate', 'batch']);
+    expect((segments[2] as { steps: FanOutInnerStep[] }).steps.map((s) => s.id)).toEqual(['b', 'c']);
+  });
+
+  it('handles an all-gated chain and an all-batchable chain', () => {
+    expect(segmentFanOutInner([{ id: 'g', agent: 'g', firmGate: true }]).map((s) => s.kind)).toEqual(['gate']);
+    expect(segmentFanOutInner([{ id: 'a', agent: 'a' }, { id: 'b', agent: 'b' }]).map((s) => s.kind)).toEqual([
+      'batch',
+    ]);
+    expect(segmentFanOutInner([])).toEqual([]);
+  });
+});
+
+describe('renderFanOutBatchScript', () => {
+  const batch = (segmentFanOutInner(INNER)[0] as { steps: FanOutInnerStep[] }).steps;
+  const source = renderFanOutBatchScript('sprint', STEP, batch) as string;
 
   it('emits parseable JavaScript', () => {
     expect(source).not.toBeNull();
     assertParses(source);
   });
 
-  it('emits a meta literal the tracker can read back', () => {
+  it('emits a meta literal the tracker can read back, one phase per stage', () => {
     const meta = parseScriptMeta(source);
     expect(meta.name).toBe('cyboflow-sprint-execute-implement');
-    expect(meta.phases.map((p) => p.title)).toEqual(['Implement']);
+    expect(meta.phases.map((p) => p.title)).toEqual(['Implement', 'Write tests', 'Code review', 'Verify']);
   });
 
-  it('binds the stage to its cyboflow- agent definition', () => {
-    expect(source).toContain('"cyboflow-implement"');
-    expect(source).toContain('agentType: AGENT_TYPE');
+  it('binds every stage to its own cyboflow- agent definition', () => {
+    for (const agent of ['implement', 'write-tests', 'code-review', 'task-verify']) {
+      expect(source).toContain(`agentType: "cyboflow-${agent}"`);
+    }
+  });
+
+  it('runs items concurrently with a sequential chain inside each (no cross-item barrier)', () => {
+    expect(source).toContain('parallel(items.map((item) => () => runItem(item)))');
+    expect(source).toContain('while (i < STAGES.length)');
+  });
+
+  it('retries within the batch via loopback, bounded', () => {
+    expect(source).toContain('const MAX_ATTEMPTS = 3');
+    expect(source).toContain('i = stage.loopbackTo');
+    // write-tests/code-review/task-verify all loop back to implement (index 0).
+    expect(source).toContain('loopbackTo: 0');
+  });
+
+  it('skips an optional stage on failure instead of failing the item', () => {
+    const withOptional = renderFanOutBatchScript('sprint', STEP, [
+      { id: 'implement', agent: 'implement' },
+      { id: 'lint', agent: 'lint', optional: true },
+    ]) as string;
+    expect(withOptional).toContain('optional: true');
+    expect(withOptional).toContain('optional stage skipped after failure');
   });
 
   it('never emits worktree isolation (lanes share one worktree)', () => {
@@ -142,62 +198,51 @@ describe('renderFanOutStageScript', () => {
   it('carries a domain-outcome schema rather than keying on promise rejection', () => {
     expect(source).toContain("'blocked'");
     expect(source).toContain("required: ['outcome', 'summary']");
-    // A null agent slot becomes a failed item, never a silently dropped one.
-    expect(source).toContain("outcome: 'failed'");
+    expect(source).toContain("outcome: 'failed', summary: 'agent produced no result'");
   });
 
   it('returns an empty result set for an empty wave', () => {
-    expect(source).toContain('return { stage: STAGE_ID, results: [] }');
+    expect(source).toContain('results: [] }');
   });
 
-  it('is null when the spec has no inner steps', () => {
-    const empty: FanOutSpec = { over: 'tasks', inner: [] };
-    expect(renderFanOutStageScript('sprint', STEP, empty, INNER[0])).toBeNull();
+  it('is null for an empty batch', () => {
+    expect(renderFanOutBatchScript('sprint', STEP, [])).toBeNull();
   });
 });
 
 describe('injection safety', () => {
-  const hostile = [
-    'quote"break',
-    "apos'break",
-    'back`tick',
-    'dollar${expr}',
-    'new\nline',
-    'back\\slash',
-    'unicode- -sep',
-  ];
+  const hostile = ['quote"break', "apos'break", 'back`tick', 'dollar${expr}', 'new\nline', 'back\\slash'];
 
   for (const raw of hostile) {
     it(`survives a hostile agent id: ${JSON.stringify(raw)}`, () => {
-      const inner: FanOutInnerStep = { id: 'implement', agent: raw, name: raw };
-      const spec: FanOutSpec = { over: 'tasks', inner: [inner] };
-      const source = renderFanOutStageScript('sprint', STEP, spec, inner);
+      const source = renderFanOutBatchScript('sprint', STEP, [{ id: 'implement', agent: raw, name: raw }]);
       expect(source).not.toBeNull();
       assertParses(source as string);
     });
   }
 
-  it('survives a hostile workflow name in the description without breaking the source', () => {
-    const inner: FanOutInnerStep = { id: 'implement', agent: 'implement' };
-    const spec: FanOutSpec = { over: 'tasks', inner: [inner] };
+  it('survives a hostile outer step id', () => {
     const step: WorkflowStep = { ...STEP, id: 'exec"ute\n' };
-    const source = renderFanOutStageScript('sprint', step, spec, inner);
-    // The id still slugs to something usable, and the source stays valid.
+    const source = renderFanOutBatchScript('sprint', step, [{ id: 'implement', agent: 'implement' }]);
     expect(source).not.toBeNull();
     assertParses(source as string);
   });
 });
 
-describe('renderFanOutStageScripts over the real sprint definition', () => {
+describe('renderFanOutBatchScripts over the real sprint definition', () => {
   const def = resolveWorkflowDefinition('sprint', '{}');
   const steps = def === null ? [] : def.phases.flatMap((p) => p.steps);
-  const scripts = renderFanOutStageScripts('sprint', steps);
+  const scripts = renderFanOutBatchScripts('sprint', steps);
 
-  it('renders one script per scriptable inner stage and skips the visual gate', () => {
-    expect(scripts.length).toBeGreaterThan(0);
-    const names = scripts.map((s) => s.name);
-    expect(names.some((n) => n.endsWith('-implement'))).toBe(true);
-    expect(names.some((n) => n.endsWith('-visual-verify'))).toBe(false);
+  it('renders ONE batch script for the whole implementation sub-chain', () => {
+    expect(scripts).toHaveLength(1);
+    expect(scripts[0].name.endsWith('-implement')).toBe(true);
+  });
+
+  it('the batch spans every stage up to the visual gate, and excludes it', () => {
+    const meta = parseScriptMeta(scripts[0].content);
+    expect(meta.phases.map((p) => p.title)).toEqual(['Implement', 'Write tests', 'Code review', 'Verify']);
+    expect(scripts[0].content).not.toContain('cyboflow-visual-verify');
   });
 
   it('every rendered script parses and round-trips its meta', () => {
@@ -205,10 +250,5 @@ describe('renderFanOutStageScripts over the real sprint definition', () => {
       assertParses(script.content);
       expect(parseScriptMeta(script.content).name).toBe(`cyboflow-${script.name}`);
     }
-  });
-
-  it('produces unique names', () => {
-    const names = scripts.map((s) => s.name);
-    expect(new Set(names).size).toBe(names.length);
   });
 });

--- a/main/src/orchestrator/prompts/fan-out-instructions.ts
+++ b/main/src/orchestrator/prompts/fan-out-instructions.ts
@@ -41,6 +41,23 @@ import {
   type WorkflowStep,
 } from '../../../../shared/types/workflows';
 import { AWAITING_VERIFY_STEP } from '../../../../shared/types/sprintBatch';
+import {
+  DEFAULT_FAN_OUT_DISPATCH,
+  type FanOutDispatch,
+} from '../../../../shared/types/fanOutDispatch';
+import { fanOutStageWorkflowName, isHostOwnedInnerStep } from './fanOutStageScript';
+
+/** Options for {@link buildFanOutAppend}. Both default to today's prose behavior. */
+export interface FanOutAppendOptions {
+  /** How the inner chain is executed. Defaults to `prose`. */
+  dispatch?: FanOutDispatch;
+  /**
+   * The workflow NAME used to derive stage-script names — must be the same value
+   * the install seam rendered with (`workflows.name`), or the prompt will name
+   * scripts that are not on disk. Defaults to the definition's `id`.
+   */
+  workflowName?: string;
+}
 
 // ---------------------------------------------------------------------------
 // Loopback resolution
@@ -240,8 +257,66 @@ function itemSource(fanOut: FanOutSpec): string {
     : `the resolved item set (\`${fanOut.over}\`) — **one lane per item**`;
 }
 
+/**
+ * Render the STAGE-MAJOR per-task chain: the same lane protocol, except each
+ * agent-backed inner step is executed by dispatching ONE dynamic-workflow script
+ * across the whole wave instead of issuing per-task Agent-tool calls by hand.
+ *
+ * Only the DELEGATION changes. The orchestrator still owns wave selection, every
+ * `cyboflow_*` write, the loopback/attempt protocol, the host-owned visual
+ * merge-gate, and the per-task commit — workflow subagents carry no cyboflow
+ * tools and must never be asked to write state.
+ *
+ * A host-owned inner step (the visual gate) keeps its ORIGINAL prose entry, and
+ * so does any step whose script could not be named — both fall back to the
+ * agent-driven path per step, so a partial render degrades gracefully.
+ */
+function renderStageMajorChain(
+  workflowName: string,
+  step: WorkflowStep,
+  fanOut: FanOutSpec,
+  ctx: ChainContext,
+): string {
+  const entries = fanOut.inner.map((inner, i) => {
+    const scriptName = isHostOwnedInnerStep(inner)
+      ? null
+      : fanOutStageWorkflowName(workflowName, step.id, inner.id);
+
+    // Host-owned or unnameable → the untouched prose entry (the visual gate's
+    // request/park protocol has no scripted equivalent).
+    if (scriptName === null) return renderChainEntry(inner, i + 1, ctx);
+
+    const label = inner.name !== undefined && inner.name.length > 0 ? inner.name : inner.id;
+    return [
+      `${i + 1}. **\`${inner.id}\`** (${label}) — move every wave member's \`current_step\` to`,
+      `   \`${inner.id}\` via \`cyboflow_update_sprint_task\`, then dispatch the WHOLE wave in one`,
+      `   call: \`Workflow({ name: '${scriptName}', args: [...] })\`. Each \`args\` entry is one`,
+      '   item: `{ id, ref, title, brief, expectedFiles, priorSummary }` — `brief` carries the',
+      '   task body + acceptance criteria, `priorSummary` the previous stage\'s `summary` for',
+      '   that item. Pass ONLY the members of the CURRENT wave.',
+      '   Wait for the workflow to finish, then read its `results` array and reconcile each item:',
+      '   - `outcome: "ok"` → advance that lane to the next stage.',
+      `   - \`outcome: "blocked"\` or \`"failed"\` → apply the loopback protocol below for that item`,
+      '     (bump `attempt`, move `current_step` back to the loopback target, re-dispatch it in a',
+      '     later wave with the blocking `summary` as its `priorSummary`).',
+      '   - `outcome: "not_applicable"` → treat as a skip and advance.',
+      '   - every `findings[]` entry → file it with `cyboflow_report_finding` (the subagents',
+      '     cannot; they only report). A `visualTask` string is the fence the visual gate needs —',
+      '     carry it forward verbatim.',
+      '   The script writes NO cyboflow state by design: every lane move, finding, and commit in',
+      '   this stage is YOURS to make from this session.',
+    ].join('\n');
+  });
+  return entries.join('\n');
+}
+
 /** Render the full instruction section for ONE fanOut-bearing outer step. */
-function renderFanOutSection(step: WorkflowStep, fanOut: FanOutSpec): string {
+function renderFanOutSection(
+  step: WorkflowStep,
+  fanOut: FanOutSpec,
+  dispatch: FanOutDispatch,
+  workflowName: string,
+): string {
   const cap = effectiveMaxConcurrency(fanOut);
   const firstId = fanOut.inner.length > 0 ? fanOut.inner[0].id : '';
   const innerById = new Map<string, FanOutInnerStep>(
@@ -250,7 +325,10 @@ function renderFanOutSection(step: WorkflowStep, fanOut: FanOutSpec): string {
   const ctx: ChainContext = { firstId, innerById };
   const laneIds = fanOut.inner.map((s) => `\`${s.id}\``).join(', ');
 
-  const chain = fanOut.inner.map((s, i) => renderChainEntry(s, i + 1, ctx)).join('\n');
+  const chain =
+    dispatch === 'workflow'
+      ? renderStageMajorChain(workflowName, step, fanOut, ctx)
+      : fanOut.inner.map((s, i) => renderChainEntry(s, i + 1, ctx)).join('\n');
 
   return [
     `## Fan-out execution — \`${step.id}\``,
@@ -262,11 +340,23 @@ function renderFanOutSection(step: WorkflowStep, fanOut: FanOutSpec): string {
     '',
     renderDispatch(cap),
     '',
-    '### Per-task chain',
-    '',
-    'Drive each task’s lane through this chain, in order. Move the lane’s `current_step`',
-    'with `cyboflow_update_sprint_task` as each stage begins, using the EXACT lane step ids and',
-    `\`cyboflow-<agent>\` subagent_type names below (${laneIds}) so the lane auto-advances:`,
+    ...(dispatch === 'workflow'
+      ? [
+          '### Per-stage chain (workflow dispatch)',
+          '',
+          'Advance the wave through this chain ONE STAGE AT A TIME: every member of the wave',
+          'completes stage N before any member starts stage N+1. Move each lane’s `current_step`',
+          `with \`cyboflow_update_sprint_task\` as each stage begins, using the EXACT lane step ids`,
+          `below (${laneIds}) so the lane auto-advances. You remain the SOLE writer of cyboflow`,
+          'state — the dispatched workflows return structured results and write nothing:',
+        ]
+      : [
+          '### Per-task chain',
+          '',
+          'Drive each task’s lane through this chain, in order. Move the lane’s `current_step`',
+          'with `cyboflow_update_sprint_task` as each stage begins, using the EXACT lane step ids and',
+          `\`cyboflow-<agent>\` subagent_type names below (${laneIds}) so the lane auto-advances:`,
+        ]),
     '',
     chain,
     '',
@@ -307,14 +397,22 @@ function renderFanOutSection(step: WorkflowStep, fanOut: FanOutSpec): string {
  *   workflow has no resolvable definition: the generator returns `''` (fail-soft).
  * @returns The append text, or `''` when `def` is null or has no fanOut steps.
  */
-export function buildFanOutAppend(def: WorkflowDefinition | null): string {
+export function buildFanOutAppend(
+  def: WorkflowDefinition | null,
+  opts?: FanOutAppendOptions,
+): string {
   if (def === null) return '';
+
+  // Defaulted so every existing caller — notably the SDK-only
+  // workflowPromptReaderAdapter — keeps emitting byte-identical prose.
+  const dispatch = opts?.dispatch ?? DEFAULT_FAN_OUT_DISPATCH;
+  const workflowName = opts?.workflowName ?? def.id;
 
   const sections: string[] = [];
   for (const phase of def.phases) {
     for (const step of phase.steps) {
       if (step.fanOut !== undefined) {
-        sections.push(renderFanOutSection(step, step.fanOut));
+        sections.push(renderFanOutSection(step, step.fanOut, dispatch, workflowName));
       }
     }
   }

--- a/main/src/orchestrator/prompts/fan-out-instructions.ts
+++ b/main/src/orchestrator/prompts/fan-out-instructions.ts
@@ -45,7 +45,7 @@ import {
   DEFAULT_FAN_OUT_DISPATCH,
   type FanOutDispatch,
 } from '../../../../shared/types/fanOutDispatch';
-import { fanOutStageWorkflowName, isHostOwnedInnerStep } from './fanOutStageScript';
+import { fanOutBatchWorkflowName, segmentFanOutInner } from './fanOutStageScript';
 
 /** Options for {@link buildFanOutAppend}. Both default to today's prose behavior. */
 export interface FanOutAppendOptions {
@@ -277,36 +277,62 @@ function renderStageMajorChain(
   fanOut: FanOutSpec,
   ctx: ChainContext,
 ): string {
-  const entries = fanOut.inner.map((inner, i) => {
-    const scriptName = isHostOwnedInnerStep(inner)
-      ? null
-      : fanOutStageWorkflowName(workflowName, step.id, inner.id);
+  // Prose entries are numbered against the ORIGINAL chain so a gate's entry
+  // keeps its position in the sequence the reader sees.
+  const positionOf = new Map(fanOut.inner.map((s, i) => [s.id, i + 1] as [string, number]));
+  const entries: string[] = [];
 
-    // Host-owned or unnameable → the untouched prose entry (the visual gate's
-    // request/park protocol has no scripted equivalent).
-    if (scriptName === null) return renderChainEntry(inner, i + 1, ctx);
+  for (const segment of segmentFanOutInner(fanOut.inner)) {
+    if (segment.kind === 'gate') {
+      // Firm gate → the untouched prose entry. The visual gate's request/park
+      // protocol has no delegable equivalent.
+      entries.push(renderChainEntry(segment.step, positionOf.get(segment.step.id) ?? 0, ctx));
+      continue;
+    }
 
-    const label = inner.name !== undefined && inner.name.length > 0 ? inner.name : inner.id;
-    return [
-      `${i + 1}. **\`${inner.id}\`** (${label}) — move every wave member's \`current_step\` to`,
-      `   \`${inner.id}\` via \`cyboflow_update_sprint_task\`, then dispatch the WHOLE wave in one`,
-      `   call: \`Workflow({ name: '${scriptName}', args: [...] })\`. Each \`args\` entry is one`,
-      '   item: `{ id, ref, title, brief, expectedFiles, priorSummary }` — `brief` carries the',
-      '   task body + acceptance criteria, `priorSummary` the previous stage\'s `summary` for',
-      '   that item. Pass ONLY the members of the CURRENT wave.',
-      '   Wait for the workflow to finish, then read its `results` array and reconcile each item:',
-      '   - `outcome: "ok"` → advance that lane to the next stage.',
-      `   - \`outcome: "blocked"\` or \`"failed"\` → apply the loopback protocol below for that item`,
-      '     (bump `attempt`, move `current_step` back to the loopback target, re-dispatch it in a',
-      '     later wave with the blocking `summary` as its `priorSummary`).',
-      '   - `outcome: "not_applicable"` → treat as a skip and advance.',
-      '   - every `findings[]` entry → file it with `cyboflow_report_finding` (the subagents',
-      '     cannot; they only report). A `visualTask` string is the fence the visual gate needs —',
-      '     carry it forward verbatim.',
-      '   The script writes NO cyboflow state by design: every lane move, finding, and commit in',
-      '   this stage is YOURS to make from this session.',
-    ].join('\n');
-  });
+    const batch = segment.steps;
+    const scriptName = fanOutBatchWorkflowName(workflowName, step.id, batch[0].id);
+    if (scriptName === null) {
+      // Unnameable → fall back to per-stage prose for this batch.
+      for (const inner of batch) {
+        entries.push(renderChainEntry(inner, positionOf.get(inner.id) ?? 0, ctx));
+      }
+      continue;
+    }
+
+    const first = positionOf.get(batch[0].id) ?? 0;
+    const last = positionOf.get(batch[batch.length - 1].id) ?? 0;
+    const span = batch.length === 1 ? `${first}` : `${first}–${last}`;
+    const ids = batch.map((s) => `\`${s.id}\``).join(' → ');
+
+    entries.push(
+      [
+        `${span}. ${ids} — dispatched as ONE batch, no orchestrator gate between them.`,
+        `   Move every wave member's \`current_step\` to \`${batch[0].id}\` via`,
+        '   `cyboflow_update_sprint_task`, then use the **Workflow tool** (not Skill, not Bash):',
+        `   \`Workflow({ name: '${scriptName}', args: [...] })\`. Each \`args\` entry is one item:`,
+        '   `{ id, ref, title, brief, expectedFiles }` — `brief` carries the task body +',
+        '   acceptance criteria. Pass ONLY the members of the CURRENT wave.',
+        '   Each item walks the whole sub-chain inside the workflow, concurrently with the other',
+        '   items, retrying its own loopback up to 3 attempts. You are NOT consulted in between —',
+        `   that is the point: the next gate is ${
+          last === fanOut.inner.length ? 'the end of the chain' : `step ${last + 1}`
+        }.`,
+        '   When it returns, reconcile each entry of `results`:',
+        '   - `outcome: "ok"` → the item cleared every stage in the batch; advance its lane to the',
+        '     stage after this batch and backfill its `current_step` history from `trail`.',
+        '   - `outcome: "failed"` → the item exhausted its attempts at `failedStage`. Record',
+        '     `attempts`, mark the lane `failed` per the protocol below, and keep the other lanes',
+        '     running.',
+        '   - every `trail[].findings` entry → file it with `cyboflow_report_finding` (the',
+        '     subagents cannot; they only report). A `trail[].visualTask` is the fence the visual',
+        '     gate needs — carry it forward verbatim.',
+        '   The script writes NO cyboflow state by design: every lane move, finding, and commit is',
+        '   YOURS to make from this session.',
+      ].join('\n'),
+    );
+  }
+
   return entries.join('\n');
 }
 
@@ -344,11 +370,12 @@ function renderFanOutSection(
       ? [
           '### Per-stage chain (workflow dispatch)',
           '',
-          'Advance the wave through this chain ONE STAGE AT A TIME: every member of the wave',
-          'completes stage N before any member starts stage N+1. Move each lane’s `current_step`',
-          `with \`cyboflow_update_sprint_task\` as each stage begins, using the EXACT lane step ids`,
-          `below (${laneIds}) so the lane auto-advances. You remain the SOLE writer of cyboflow`,
-          'state — the dispatched workflows return structured results and write nothing:',
+          'Consecutive stages with no firm gate between them are dispatched as ONE batch: each',
+          'item walks that whole sub-chain inside the workflow, concurrently with the other items,',
+          'without returning to you in between. A firm gate ends a batch and is yours to drive.',
+          `The lane step ids are ${laneIds}. Inside a batch the lane's \`current_step\` does not`,
+          'tick per stage — backfill it from each result’s `trail` when the batch returns. You',
+          'remain the SOLE writer of cyboflow state; the dispatched workflows write nothing:',
         ]
       : [
           '### Per-task chain',

--- a/main/src/orchestrator/prompts/fanOutStageScript.ts
+++ b/main/src/orchestrator/prompts/fanOutStageScript.ts
@@ -1,0 +1,327 @@
+/**
+ * fanOutStageScript.ts
+ *
+ * Pure, side-effect-free renderer that turns ONE inner step of a `FanOutSpec`
+ * into a Claude Code **dynamic-workflow script** (`.claude/workflows/*.js`, the
+ * `Workflow` tool's named-script surface).
+ *
+ * ── Stage-major, not item-major ──────────────────────────────────────────────
+ * The obvious design — one script that walks each item through the WHOLE inner
+ * chain — is wrong for cyboflow, and an adversarial review of the first plan
+ * killed it. Three reasons, all structural:
+ *
+ *   1. SINGLE WRITER. Between inner steps the main session does entity work:
+ *      it moves the lane's `current_step` (`cyboflow_update_sprint_task`),
+ *      carries `attempt: <n>` on loopback, files findings, and makes ONE git
+ *      commit per task on success. Workflow subagents cannot do any of it —
+ *      every `cyboflow-<agent>` definition pins a `tools:` allowlist with no
+ *      cyboflow MCP tools, deliberately ("Never writes cyboflow state"). One
+ *      whole-chain call leaves no control point for the writes.
+ *   2. HOST-OWNED STAGES. `visual-verify` has no subagent at all: the main
+ *      session fires `cyboflow_request_verification` and PARKS the lane while an
+ *      async external verdict drives it. See HOST_OWNED_INNER_IDS below.
+ *   3. LIVE WAVE RE-RESOLUTION. Dispatch is dependency-ready and file-disjoint,
+ *      and the ready set is re-read at every wave boundary. A frozen item list
+ *      plus a concurrency cap does not reproduce that.
+ *
+ * So a script here fans exactly ONE stage across ONE already-chosen wave, and
+ * returns structured per-item results. The top-level agent stays the DAG walker,
+ * the single writer, and the human seam; it reconciles each stage's results
+ * through the router chokepoints before dispatching the next one.
+ *
+ * ── Domain outcome vs promise outcome ────────────────────────────────────────
+ * `code-review` and `task-verify` return NORMALLY while reporting failure
+ * (`REVIEW: BLOCKING`, `VERDICT: FAIL`) — the programmatic controller carries
+ * explicit parsers for exactly this. A stage result is therefore a SCHEMA'd
+ * object with an explicit `outcome`, never a resolved/rejected promise.
+ *
+ * No DB, IPC, Electron, or fs imports — a pure string builder, mirroring
+ * `fan-out-instructions.ts` (its prose sibling) so both stay testable in plain
+ * Node/vitest. Fail-soft: an unrenderable stage yields `null`, never a throw.
+ */
+import type { FanOutInnerStep, FanOutSpec, WorkflowStep } from '../../../../shared/types/workflows';
+
+// ---------------------------------------------------------------------------
+// Host-owned stages
+// ---------------------------------------------------------------------------
+
+/**
+ * Inner-step ids the HOST (main session) owns end-to-end — never rendered as a
+ * script, never delegated to a workflow subagent.
+ *
+ * `visual-verify` is the async visual merge-gate: the orchestrator calls
+ * `cyboflow_request_verification` and parks the lane at `awaiting-verify`; the
+ * central verification agent is deployed separately by the main-process
+ * scheduler into an ISOLATED snapshot worktree with `$VERIFY_PORT` /
+ * `$VERIFY_ARTIFACTS_DIR` / `$VERIFY_DRIVER` provided. Invoking
+ * `cyboflow-visual-verify` as a bare workflow agent in the lane's shared
+ * worktree would break both its isolation and its environment contract — and
+ * because the step is `optional`, a failure there would be SILENTLY skipped,
+ * turning the merge-gate into a no-op.
+ *
+ * KEEP IN SYNC with the `case 'visual-verify'` arm of
+ * `fan-out-instructions.ts` — that switch is the prose authority for the same
+ * fact. Matched on BOTH the step id and the agent id, because a custom flow may
+ * rename one without the other.
+ */
+export const HOST_OWNED_INNER_IDS: ReadonlySet<string> = new Set(['visual-verify']);
+
+/** True when this inner step must stay with the main session (see above). */
+export function isHostOwnedInnerStep(inner: FanOutInnerStep): boolean {
+  return HOST_OWNED_INNER_IDS.has(inner.id) || HOST_OWNED_INNER_IDS.has(inner.agent);
+}
+
+// ---------------------------------------------------------------------------
+// Naming — the single source of truth for script identity
+// ---------------------------------------------------------------------------
+
+/** The namespace every generated cyboflow file carries (WorkflowBundleWriter's). */
+const CYBOFLOW_PREFIX = 'cyboflow-';
+
+/** Max characters per slug segment — keeps the composed basename well under any FS limit. */
+const MAX_SEGMENT = 40;
+
+/**
+ * Reduce an arbitrary, user-editable identifier to a filename-safe segment.
+ *
+ * Load-bearing for SAFETY, not aesthetics: workflow names are validated only as
+ * non-empty strings and step/agent ids are explicitly free-form, so a raw value
+ * could carry `/`, `..`, quotes, backticks, or newlines — which would escape the
+ * target directory when joined into a path, or break/inject the generated
+ * JavaScript when interpolated. Everything outside `[a-z0-9-]` collapses to a
+ * single dash. Returns `''` for input with no usable characters, which callers
+ * treat as unrenderable.
+ */
+export function slugSegment(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, MAX_SEGMENT)
+    .replace(/-+$/g, '');
+}
+
+/**
+ * The LOGICAL bundle name for a stage script — i.e. WITHOUT the `cyboflow-`
+ * prefix, because `WorkflowBundleWriter` prepends that itself when it writes.
+ * Returns `null` when any segment slugs to empty.
+ */
+export function fanOutStageLogicalName(
+  workflowName: string,
+  outerStepId: string,
+  innerStepId: string,
+): string | null {
+  const parts = [slugSegment(workflowName), slugSegment(outerStepId), slugSegment(innerStepId)];
+  if (parts.some((p) => p.length === 0)) return null;
+  return parts.join('-');
+}
+
+/**
+ * The INVOCABLE workflow name — what `meta.name` carries, what the on-disk
+ * basename is (`<name>.js`), and what the prompt passes to `Workflow({name})`.
+ * Exactly `cyboflow-` + the logical name, so the three can never drift.
+ */
+export function fanOutStageWorkflowName(
+  workflowName: string,
+  outerStepId: string,
+  innerStepId: string,
+): string | null {
+  const logical = fanOutStageLogicalName(workflowName, outerStepId, innerStepId);
+  return logical === null ? null : `${CYBOFLOW_PREFIX}${logical}`;
+}
+
+// ---------------------------------------------------------------------------
+// Emission helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Encode any value as a JavaScript literal via JSON.
+ *
+ * EVERY interpolated value in the emitted script goes through this — names,
+ * descriptions, ids, agent types. Raw interpolation of a free-form id carrying a
+ * quote, backtick, newline, or `${` would produce broken or injected source.
+ * `</script` is not a concern here (this is never HTML), but line separators are
+ * escaped by JSON.stringify already.
+ */
+function lit(value: unknown): string {
+  return JSON.stringify(value ?? null);
+}
+
+/** Human label for an inner step (its `name`, falling back to its id). */
+function innerLabel(inner: FanOutInnerStep): string {
+  return inner.name !== undefined && inner.name.trim().length > 0 ? inner.name : inner.id;
+}
+
+// ---------------------------------------------------------------------------
+// The rendered script
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the dynamic-workflow script for ONE inner stage of a fan-out step.
+ *
+ * The emitted script takes the wave as `args` — an array of item objects the
+ * top-level agent composes (`{ id, ref?, title?, brief?, expectedFiles?,
+ * priorSummary? }`) — runs ONE `cyboflow-<agent>` subagent per item
+ * concurrently, and returns `{ stage, results: [...] }` with one schema-validated
+ * result per item. It performs NO cyboflow writes and reaches no MCP tool.
+ *
+ * @returns The script source, or `null` when the stage is host-owned, when the
+ *   name cannot be slugged, or when the spec carries no inner steps.
+ */
+export function renderFanOutStageScript(
+  workflowName: string,
+  step: WorkflowStep,
+  fanOut: FanOutSpec,
+  inner: FanOutInnerStep,
+): string | null {
+  if (fanOut.inner.length === 0) return null;
+  if (isHostOwnedInnerStep(inner)) return null;
+
+  const name = fanOutStageWorkflowName(workflowName, step.id, inner.id);
+  if (name === null) return null;
+
+  const label = innerLabel(inner);
+  const agentType = `${CYBOFLOW_PREFIX}${inner.agent}`;
+  const description = `Fan the ${label} stage of ${step.id} across one wave of items; returns structured per-item results and writes no cyboflow state.`;
+
+  // NOTE ON CONSTRUCTS: no `isolation` (lanes deliberately SHARE one worktree —
+  // a per-agent worktree would break lane verification and the settled-tree test
+  // run); no Date.now()/Math.random()/argless new Date() (they throw inside a
+  // script body); `parallel` rather than `pipeline` because a stage-major
+  // dispatch IS one barrier by construction — the caller already sized the wave
+  // to the concurrency cap, so there is nothing to batch here.
+  return `${'/'}* GENERATED by cyboflow (fanOutStageScript.ts) — do not edit. *${'/'}
+export const meta = {
+  name: ${lit(name)},
+  description: ${lit(description)},
+  phases: [{ title: ${lit(label)}, detail: ${lit(`one ${agentType} agent per item in the wave`)} }],
+}
+
+// One schema'd result per item. \`outcome\` is the DOMAIN verdict and is
+// authoritative: an agent that finishes normally while reporting a blocking
+// review or a failed verification MUST return 'blocked'/'failed' here. The
+// top-level orchestrator reads these and performs every cyboflow write itself.
+const RESULT_SCHEMA = {
+  type: 'object',
+  properties: {
+    outcome: {
+      type: 'string',
+      enum: ['ok', 'blocked', 'failed', 'not_applicable'],
+      description:
+        "'ok' = stage succeeded. 'blocked' = finished but the work is not acceptable " +
+        '(blocking review comments, failing verification, unmet acceptance criteria). ' +
+        "'failed' = could not complete. 'not_applicable' = nothing to do for this item.",
+    },
+    summary: { type: 'string', description: 'What you did, or why it is blocked/failed. 1-4 sentences.' },
+    filesTouched: { type: 'array', items: { type: 'string' }, description: 'Repo-relative paths written.' },
+    findings: {
+      type: 'array',
+      description: 'Out-of-scope or minor issues worth human triage. Blocking issues belong in outcome/summary.',
+      items: {
+        type: 'object',
+        properties: {
+          severity: { type: 'string', enum: ['low', 'medium', 'high'] },
+          title: { type: 'string' },
+          body: { type: 'string' },
+        },
+        required: ['severity', 'title'],
+      },
+    },
+    visualTask: {
+      type: 'string',
+      description:
+        'Verbatim JSON fence for the visual merge-gate when this stage produces one; omit otherwise. ' +
+        'The orchestrator forwards it to cyboflow_request_verification — do not act on it yourself.',
+    },
+  },
+  required: ['outcome', 'summary'],
+}
+
+const STAGE_ID = ${lit(inner.id)}
+const AGENT_TYPE = ${lit(agentType)}
+const STAGE_LABEL = ${lit(label)}
+
+${'/'}** Compose the per-item prompt. \`item\` is supplied by the orchestrator. *${'/'}
+function buildPrompt(item) {
+  const lines = [
+    'You are running the ' + STAGE_LABEL + ' stage for ONE item of a cyboflow fan-out.',
+    '',
+    'Item id: ' + String(item && item.id),
+  ]
+  if (item && item.ref) lines.push('Item ref: ' + String(item.ref))
+  if (item && item.title) lines.push('Title: ' + String(item.title))
+  if (item && item.brief) lines.push('', String(item.brief))
+  if (item && item.expectedFiles && item.expectedFiles.length > 0) {
+    lines.push('', 'Expected files: ' + item.expectedFiles.join(', '))
+  }
+  if (item && item.priorSummary) {
+    lines.push('', 'Result of the previous stage for this item:', String(item.priorSummary))
+  }
+  lines.push(
+    '',
+    'Work ONLY on this item, in the shared worktree. Do NOT commit, do NOT touch',
+    'cyboflow state, and do NOT start work belonging to another stage or item.',
+    'Return the structured result: set outcome to the DOMAIN verdict (a blocking',
+    'review or a failed check is "blocked", not "ok"), and list every file you wrote.',
+  )
+  return lines.join('\\n')
+}
+
+const items = Array.isArray(args) ? args.filter((it) => it && it.id !== undefined) : []
+if (items.length === 0) {
+  log('no items in this wave — nothing to dispatch')
+  return { stage: STAGE_ID, results: [] }
+}
+
+log(STAGE_LABEL + ': dispatching ' + items.length + ' item(s)')
+
+// The wave is already sized to the fan-out cap by the orchestrator, so this
+// barrier is the whole point of a stage-major dispatch: every item's result is
+// reconciled together before the next stage is chosen.
+const settled = await parallel(
+  items.map((item) => () =>
+    agent(buildPrompt(item), {
+      label: STAGE_ID + ':' + String(item.id),
+      phase: STAGE_LABEL,
+      schema: RESULT_SCHEMA,
+      agentType: AGENT_TYPE,
+    }).then((result) => ({ itemId: item.id, ...(result || {}) })),
+  ),
+)
+
+// A null slot means the agent died or was skipped — surface it as a failed item
+// rather than dropping it, so the orchestrator can loop it back or fail the lane.
+const results = settled.map((entry, i) =>
+  entry && entry.outcome
+    ? entry
+    : { itemId: items[i].id, outcome: 'failed', summary: 'agent produced no result' },
+)
+
+return { stage: STAGE_ID, results }
+`;
+}
+
+/**
+ * Render every scriptable stage of a resolved definition's fan-out steps.
+ *
+ * Returns one entry per rendered stage, keyed by the LOGICAL bundle name (the
+ * writer adds the `cyboflow-` prefix). Host-owned and unslug-able stages are
+ * skipped silently — they stay on the prose path.
+ */
+export function renderFanOutStageScripts(
+  workflowName: string,
+  steps: ReadonlyArray<WorkflowStep>,
+): Array<{ name: string; content: string }> {
+  const out: Array<{ name: string; content: string }> = [];
+  for (const step of steps) {
+    const fanOut = step.fanOut;
+    if (fanOut === undefined) continue;
+    for (const inner of fanOut.inner) {
+      const content = renderFanOutStageScript(workflowName, step, fanOut, inner);
+      const logical = fanOutStageLogicalName(workflowName, step.id, inner.id);
+      if (content === null || logical === null) continue;
+      out.push({ name: logical, content });
+    }
+  }
+  return out;
+}

--- a/main/src/orchestrator/prompts/fanOutStageScript.ts
+++ b/main/src/orchestrator/prompts/fanOutStageScript.ts
@@ -1,74 +1,106 @@
 /**
  * fanOutStageScript.ts
  *
- * Pure, side-effect-free renderer that turns ONE inner step of a `FanOutSpec`
- * into a Claude Code **dynamic-workflow script** (`.claude/workflows/*.js`, the
- * `Workflow` tool's named-script surface).
+ * Pure, side-effect-free renderer that turns a BATCH of consecutive fan-out
+ * inner stages into a Claude Code **dynamic-workflow script**
+ * (`.claude/workflows/*.js`, the `Workflow` tool's named-script surface).
  *
- * ── Stage-major, not item-major ──────────────────────────────────────────────
- * The obvious design — one script that walks each item through the WHOLE inner
- * chain — is wrong for cyboflow, and an adversarial review of the first plan
- * killed it. Three reasons, all structural:
+ * ── Batching, and what a firm gate is for ────────────────────────────────────
+ * The chain is split at FIRM GATES (`FanOutInnerStep.firmGate`). Every maximal
+ * run of consecutive non-gated stages becomes ONE script that walks each item
+ * through that whole sub-chain — `implement → write-tests → code-review →
+ * task-verify` in one dispatch — with per-item concurrency and NO return to the
+ * orchestrator in between. That is where the efficiency comes from: the
+ * orchestrator is not re-entered per stage, and a fast item is not held at a
+ * barrier waiting for a slow sibling.
  *
- *   1. SINGLE WRITER. Between inner steps the main session does entity work:
- *      it moves the lane's `current_step` (`cyboflow_update_sprint_task`),
- *      carries `attempt: <n>` on loopback, files findings, and makes ONE git
- *      commit per task on success. Workflow subagents cannot do any of it —
- *      every `cyboflow-<agent>` definition pins a `tools:` allowlist with no
- *      cyboflow MCP tools, deliberately ("Never writes cyboflow state"). One
- *      whole-chain call leaves no control point for the writes.
- *   2. HOST-OWNED STAGES. `visual-verify` has no subagent at all: the main
- *      session fires `cyboflow_request_verification` and PARKS the lane while an
- *      async external verdict drives it. See HOST_OWNED_INNER_IDS below.
- *   3. LIVE WAVE RE-RESOLUTION. Dispatch is dependency-ready and file-disjoint,
- *      and the ready set is re-read at every wave boundary. A frozen item list
- *      plus a concurrency cap does not reproduce that.
+ * The deliberate trade, chosen explicitly: lane `current_step` does not tick per
+ * stage inside a batch. The script returns each item's full stage trail and the
+ * orchestrator backfills it when the batch returns, so nothing is lost except
+ * live per-stage granularity — and the dynamic-workflow tracker still shows
+ * per-agent progress meanwhile.
  *
- * So a script here fans exactly ONE stage across ONE already-chosen wave, and
- * returns structured per-item results. The top-level agent stays the DAG walker,
- * the single writer, and the human seam; it reconciles each stage's results
- * through the router chokepoints before dispatching the next one.
+ * A firm gate ends a batch and stays with the orchestrator. `visual-verify` is
+ * the only one in the built-in chains, and it is a gate for a hard reason rather
+ * than a cautious one: it has NO subagent. The orchestrator fires
+ * `cyboflow_request_verification` and PARKS the lane while an async external
+ * verdict (produced by the central verifier, deployed by the main-process
+ * scheduler into an isolated snapshot worktree with `$VERIFY_*` env) drives it
+ * off the park. There is nothing to delegate, so it is excluded structurally by
+ * {@link isFirmGateInnerStep}, not by policy.
+ *
+ * ── What still never moves ───────────────────────────────────────────────────
+ * Every cyboflow WRITE stays with the orchestrator. Workflow subagents carry no
+ * cyboflow MCP tools by design (`cyboflow-<agent>` definitions pin a `tools:`
+ * allowlist and are documented "Never writes cyboflow state"), so the scripts
+ * report and the orchestrator records: lane moves, findings, attempts, the
+ * per-task commit.
  *
  * ── Domain outcome vs promise outcome ────────────────────────────────────────
  * `code-review` and `task-verify` return NORMALLY while reporting failure
- * (`REVIEW: BLOCKING`, `VERDICT: FAIL`) — the programmatic controller carries
- * explicit parsers for exactly this. A stage result is therefore a SCHEMA'd
- * object with an explicit `outcome`, never a resolved/rejected promise.
+ * (`REVIEW: BLOCKING`, `VERDICT: FAIL`). Every stage result is therefore a
+ * SCHEMA'd object with an explicit `outcome`, never a resolved/rejected promise.
  *
  * No DB, IPC, Electron, or fs imports — a pure string builder, mirroring
- * `fan-out-instructions.ts` (its prose sibling) so both stay testable in plain
- * Node/vitest. Fail-soft: an unrenderable stage yields `null`, never a throw.
+ * `fan-out-instructions.ts` (its prose sibling). Fail-soft: an unrenderable
+ * batch yields `null`, never a throw.
  */
 import type { FanOutInnerStep, FanOutSpec, WorkflowStep } from '../../../../shared/types/workflows';
 
 // ---------------------------------------------------------------------------
-// Host-owned stages
+// Firm gates
 // ---------------------------------------------------------------------------
 
 /**
- * Inner-step ids the HOST (main session) owns end-to-end — never rendered as a
- * script, never delegated to a workflow subagent.
+ * Inner-step ids that are ALWAYS orchestrator-owned regardless of their
+ * `firmGate` flag, because no delegable subagent exists for them.
  *
- * `visual-verify` is the async visual merge-gate: the orchestrator calls
- * `cyboflow_request_verification` and parks the lane at `awaiting-verify`; the
- * central verification agent is deployed separately by the main-process
- * scheduler into an ISOLATED snapshot worktree with `$VERIFY_PORT` /
- * `$VERIFY_ARTIFACTS_DIR` / `$VERIFY_DRIVER` provided. Invoking
- * `cyboflow-visual-verify` as a bare workflow agent in the lane's shared
- * worktree would break both its isolation and its environment contract — and
- * because the step is `optional`, a failure there would be SILENTLY skipped,
- * turning the merge-gate into a no-op.
- *
- * KEEP IN SYNC with the `case 'visual-verify'` arm of
- * `fan-out-instructions.ts` — that switch is the prose authority for the same
- * fact. Matched on BOTH the step id and the agent id, because a custom flow may
- * rename one without the other.
+ * KEEP IN SYNC with the `case 'visual-verify'` arm of `fan-out-instructions.ts`
+ * — that switch is the prose authority for the same fact. Matched on BOTH the
+ * step id and the agent id, because a custom flow may rename one without the
+ * other. This is a floor, not the mechanism: the flag is what authors set.
  */
-export const HOST_OWNED_INNER_IDS: ReadonlySet<string> = new Set(['visual-verify']);
+export const ALWAYS_GATED_INNER_IDS: ReadonlySet<string> = new Set(['visual-verify']);
 
-/** True when this inner step must stay with the main session (see above). */
-export function isHostOwnedInnerStep(inner: FanOutInnerStep): boolean {
-  return HOST_OWNED_INNER_IDS.has(inner.id) || HOST_OWNED_INNER_IDS.has(inner.agent);
+/**
+ * True when this stage must NOT be folded into a delegated batch — either the
+ * author flagged it a firm gate, or it is structurally undelegable.
+ */
+export function isFirmGateInnerStep(inner: FanOutInnerStep): boolean {
+  return (
+    inner.firmGate === true ||
+    ALWAYS_GATED_INNER_IDS.has(inner.id) ||
+    ALWAYS_GATED_INNER_IDS.has(inner.agent)
+  );
+}
+
+/** One piece of a split inner chain: a delegable batch, or a single firm gate. */
+export type FanOutSegment =
+  | { kind: 'batch'; steps: FanOutInnerStep[] }
+  | { kind: 'gate'; step: FanOutInnerStep };
+
+/**
+ * Split an inner chain into batches and firm gates, preserving order.
+ * Consecutive non-gated stages coalesce into one batch; each gate stands alone.
+ */
+export function segmentFanOutInner(inner: ReadonlyArray<FanOutInnerStep>): FanOutSegment[] {
+  const segments: FanOutSegment[] = [];
+  let current: FanOutInnerStep[] = [];
+
+  for (const step of inner) {
+    if (isFirmGateInnerStep(step)) {
+      if (current.length > 0) {
+        segments.push({ kind: 'batch', steps: current });
+        current = [];
+      }
+      segments.push({ kind: 'gate', step });
+      continue;
+    }
+    current.push(step);
+  }
+  if (current.length > 0) segments.push({ kind: 'batch', steps: current });
+
+  return segments;
 }
 
 // ---------------------------------------------------------------------------
@@ -80,6 +112,9 @@ const CYBOFLOW_PREFIX = 'cyboflow-';
 
 /** Max characters per slug segment — keeps the composed basename well under any FS limit. */
 const MAX_SEGMENT = 40;
+
+/** Attempt bound per item inside a batch — mirrors the prose "up to 3 attempts". */
+const MAX_ITEM_ATTEMPTS = 3;
 
 /**
  * Reduce an arbitrary, user-editable identifier to a filename-safe segment.
@@ -102,16 +137,17 @@ export function slugSegment(raw: string): string {
 }
 
 /**
- * The LOGICAL bundle name for a stage script — i.e. WITHOUT the `cyboflow-`
+ * The LOGICAL bundle name for a batch script — i.e. WITHOUT the `cyboflow-`
  * prefix, because `WorkflowBundleWriter` prepends that itself when it writes.
+ * Keyed by the batch's FIRST stage id, which is unique within the chain.
  * Returns `null` when any segment slugs to empty.
  */
-export function fanOutStageLogicalName(
+export function fanOutBatchLogicalName(
   workflowName: string,
   outerStepId: string,
-  innerStepId: string,
+  firstInnerId: string,
 ): string | null {
-  const parts = [slugSegment(workflowName), slugSegment(outerStepId), slugSegment(innerStepId)];
+  const parts = [slugSegment(workflowName), slugSegment(outerStepId), slugSegment(firstInnerId)];
   if (parts.some((p) => p.length === 0)) return null;
   return parts.join('-');
 }
@@ -121,12 +157,12 @@ export function fanOutStageLogicalName(
  * basename is (`<name>.js`), and what the prompt passes to `Workflow({name})`.
  * Exactly `cyboflow-` + the logical name, so the three can never drift.
  */
-export function fanOutStageWorkflowName(
+export function fanOutBatchWorkflowName(
   workflowName: string,
   outerStepId: string,
-  innerStepId: string,
+  firstInnerId: string,
 ): string | null {
-  const logical = fanOutStageLogicalName(workflowName, outerStepId, innerStepId);
+  const logical = fanOutBatchLogicalName(workflowName, outerStepId, firstInnerId);
   return logical === null ? null : `${CYBOFLOW_PREFIX}${logical}`;
 }
 
@@ -140,8 +176,6 @@ export function fanOutStageWorkflowName(
  * EVERY interpolated value in the emitted script goes through this — names,
  * descriptions, ids, agent types. Raw interpolation of a free-form id carrying a
  * quote, backtick, newline, or `${` would produce broken or injected source.
- * `</script` is not a concern here (this is never HTML), but line separators are
- * escaped by JSON.stringify already.
  */
 function lit(value: unknown): string {
   return JSON.stringify(value ?? null);
@@ -152,55 +186,89 @@ function innerLabel(inner: FanOutInnerStep): string {
   return inner.name !== undefined && inner.name.trim().length > 0 ? inner.name : inner.id;
 }
 
+/**
+ * Resolve a stage's loopback target INDEX within the batch.
+ *
+ * Mirrors the prose rule (`step.loopback` when set, else the chain's first
+ * stage), but clamped to this batch: a loopback pointing at a stage in an
+ * earlier batch or at a gate cannot be re-driven from inside here, so it falls
+ * back to the batch's own first stage and the orchestrator sees the failure in
+ * the returned trail. `-1` when the batch is empty.
+ */
+function loopbackIndex(steps: FanOutInnerStep[], step: FanOutInnerStep): number {
+  const target = step.loopback;
+  if (target !== undefined && target.length > 0) {
+    const idx = steps.findIndex((s) => s.id === target);
+    if (idx >= 0) return idx;
+  }
+  return steps.length > 0 ? 0 : -1;
+}
+
 // ---------------------------------------------------------------------------
 // The rendered script
 // ---------------------------------------------------------------------------
 
 /**
- * Render the dynamic-workflow script for ONE inner stage of a fan-out step.
+ * Render the dynamic-workflow script for ONE batch of consecutive non-gated
+ * stages.
  *
- * The emitted script takes the wave as `args` — an array of item objects the
- * top-level agent composes (`{ id, ref?, title?, brief?, expectedFiles?,
- * priorSummary? }`) — runs ONE `cyboflow-<agent>` subagent per item
- * concurrently, and returns `{ stage, results: [...] }` with one schema-validated
- * result per item. It performs NO cyboflow writes and reaches no MCP tool.
+ * The emitted script takes the wave as `args` — item objects the orchestrator
+ * composes (`{ id, ref?, title?, brief?, expectedFiles? }`) — and runs each
+ * item's full sub-chain CONCURRENTLY with the others (`parallel` over items, a
+ * sequential stage loop inside each). Per-item loopback is handled in-script and
+ * bounded by {@link MAX_ITEM_ATTEMPTS}; an `optional` stage that fails is
+ * skipped rather than failing its item. It performs NO cyboflow writes and
+ * reaches no MCP tool.
  *
- * @returns The script source, or `null` when the stage is host-owned, when the
- *   name cannot be slugged, or when the spec carries no inner steps.
+ * @returns The script source, or `null` when the batch is empty or its name
+ *   cannot be slugged.
  */
-export function renderFanOutStageScript(
+export function renderFanOutBatchScript(
   workflowName: string,
   step: WorkflowStep,
-  fanOut: FanOutSpec,
-  inner: FanOutInnerStep,
+  steps: FanOutInnerStep[],
 ): string | null {
-  if (fanOut.inner.length === 0) return null;
-  if (isHostOwnedInnerStep(inner)) return null;
+  if (steps.length === 0) return null;
 
-  const name = fanOutStageWorkflowName(workflowName, step.id, inner.id);
+  const name = fanOutBatchWorkflowName(workflowName, step.id, steps[0].id);
   if (name === null) return null;
 
-  const label = innerLabel(inner);
-  const agentType = `${CYBOFLOW_PREFIX}${inner.agent}`;
-  const description = `Fan the ${label} stage of ${step.id} across one wave of items; returns structured per-item results and writes no cyboflow state.`;
+  const labels = steps.map(innerLabel);
+  const description =
+    `Run the ${labels.join(' → ')} sub-chain of ${step.id} for each item in a wave, ` +
+    'concurrently per item; returns each item\'s stage trail and writes no cyboflow state.';
 
-  // NOTE ON CONSTRUCTS: no `isolation` (lanes deliberately SHARE one worktree —
-  // a per-agent worktree would break lane verification and the settled-tree test
+  // The stage table is emitted as data so the chain loop stays generic (and so a
+  // hostile id cannot reach the source as code — every field goes through lit()).
+  const stageTable = steps
+    .map((s, i) => {
+      const parts = [
+        `  { id: ${lit(s.id)}`,
+        `label: ${lit(innerLabel(s))}`,
+        `agentType: ${lit(`${CYBOFLOW_PREFIX}${s.agent}`)}`,
+        `optional: ${s.optional === true ? 'true' : 'false'}`,
+        `loopbackTo: ${loopbackIndex(steps, s)}`,
+      ];
+      return `${parts.join(', ')} }${i === steps.length - 1 ? '' : ','}`;
+    })
+    .join('\n');
+
+  // NOTE ON CONSTRUCTS: no `isolation` (lanes deliberately SHARE one worktree — a
+  // per-agent worktree would break lane verification and the settled-tree test
   // run); no Date.now()/Math.random()/argless new Date() (they throw inside a
-  // script body); `parallel` rather than `pipeline` because a stage-major
-  // dispatch IS one barrier by construction — the caller already sized the wave
-  // to the concurrency cap, so there is nothing to batch here.
+  // script body). `parallel` over ITEMS with a sequential loop inside each is what
+  // gives per-item pipelining with no cross-item barrier between stages.
   return `${'/'}* GENERATED by cyboflow (fanOutStageScript.ts) — do not edit. *${'/'}
 export const meta = {
   name: ${lit(name)},
   description: ${lit(description)},
-  phases: [{ title: ${lit(label)}, detail: ${lit(`one ${agentType} agent per item in the wave`)} }],
+  phases: [${labels.map((l) => `{ title: ${lit(l)} }`).join(', ')}],
 }
 
-// One schema'd result per item. \`outcome\` is the DOMAIN verdict and is
+// One schema'd result per stage. \`outcome\` is the DOMAIN verdict and is
 // authoritative: an agent that finishes normally while reporting a blocking
 // review or a failed verification MUST return 'blocked'/'failed' here. The
-// top-level orchestrator reads these and performs every cyboflow write itself.
+// orchestrator reads these back and performs every cyboflow write itself.
 const RESULT_SCHEMA = {
   type: 'object',
   properties: {
@@ -237,14 +305,16 @@ const RESULT_SCHEMA = {
   required: ['outcome', 'summary'],
 }
 
-const STAGE_ID = ${lit(inner.id)}
-const AGENT_TYPE = ${lit(agentType)}
-const STAGE_LABEL = ${lit(label)}
+const STAGES = [
+${stageTable}
+]
 
-${'/'}** Compose the per-item prompt. \`item\` is supplied by the orchestrator. *${'/'}
-function buildPrompt(item) {
+const MAX_ATTEMPTS = ${MAX_ITEM_ATTEMPTS}
+
+${'/'}** Compose the per-stage prompt for one item. *${'/'}
+function buildPrompt(stage, item, trail, attempt) {
   const lines = [
-    'You are running the ' + STAGE_LABEL + ' stage for ONE item of a cyboflow fan-out.',
+    'You are running the ' + stage.label + ' stage for ONE item of a cyboflow fan-out.',
     '',
     'Item id: ' + String(item && item.id),
   ]
@@ -254,71 +324,111 @@ function buildPrompt(item) {
   if (item && item.expectedFiles && item.expectedFiles.length > 0) {
     lines.push('', 'Expected files: ' + item.expectedFiles.join(', '))
   }
-  if (item && item.priorSummary) {
-    lines.push('', 'Result of the previous stage for this item:', String(item.priorSummary))
+  if (attempt > 1) lines.push('', 'This is attempt ' + attempt + ' for this item.')
+  if (trail.length > 0) {
+    lines.push('', 'Earlier stages for this item:')
+    for (const entry of trail) {
+      lines.push('- ' + entry.id + ' [' + entry.outcome + ']: ' + String(entry.summary || ''))
+    }
   }
   lines.push(
     '',
     'Work ONLY on this item, in the shared worktree. Do NOT commit, do NOT touch',
-    'cyboflow state, and do NOT start work belonging to another stage or item.',
+    'cyboflow state, and do NOT start work belonging to another item.',
     'Return the structured result: set outcome to the DOMAIN verdict (a blocking',
     'review or a failed check is "blocked", not "ok"), and list every file you wrote.',
   )
   return lines.join('\\n')
 }
 
+${'/'}**
+ * Walk ONE item through the whole batch. Sequential across stages for this item,
+ * but every item runs its own copy of this loop concurrently — so no item waits
+ * on a sibling. A blocked/failed required stage jumps back to its loopback target
+ * and re-runs, bounded by MAX_ATTEMPTS; an optional one is skipped.
+ *${'/'}
+async function runItem(item) {
+  const trail = []
+  let i = 0
+  let attempt = 1
+
+  while (i < STAGES.length) {
+    const stage = STAGES[i]
+    const result = await agent(buildPrompt(stage, item, trail, attempt), {
+      label: stage.id + ':' + String(item.id),
+      phase: stage.label,
+      schema: RESULT_SCHEMA,
+      agentType: stage.agentType,
+    })
+
+    // A null result means the agent died or was skipped — treat it as a failure
+    // of this stage rather than dropping it silently.
+    const entry = result && result.outcome
+      ? { id: stage.id, ...result }
+      : { id: stage.id, outcome: 'failed', summary: 'agent produced no result' }
+    trail.push(entry)
+
+    if (entry.outcome === 'ok' || entry.outcome === 'not_applicable') {
+      i += 1
+      continue
+    }
+
+    if (stage.optional) {
+      trail.push({ id: stage.id, outcome: 'not_applicable', summary: 'optional stage skipped after failure' })
+      i += 1
+      continue
+    }
+
+    if (attempt >= MAX_ATTEMPTS) {
+      return { itemId: item.id, outcome: 'failed', failedStage: stage.id, attempts: attempt, trail }
+    }
+
+    attempt += 1
+    i = stage.loopbackTo
+    log('item ' + String(item.id) + ': ' + stage.id + ' ' + entry.outcome + ' — retrying from ' + STAGES[i].id + ' (attempt ' + attempt + ')')
+  }
+
+  return { itemId: item.id, outcome: 'ok', attempts: attempt, trail }
+}
+
 const items = Array.isArray(args) ? args.filter((it) => it && it.id !== undefined) : []
 if (items.length === 0) {
   log('no items in this wave — nothing to dispatch')
-  return { stage: STAGE_ID, results: [] }
+  return { stages: STAGES.map((s) => s.id), results: [] }
 }
 
-log(STAGE_LABEL + ': dispatching ' + items.length + ' item(s)')
+log('dispatching ' + items.length + ' item(s) through ' + STAGES.length + ' stage(s)')
 
-// The wave is already sized to the fan-out cap by the orchestrator, so this
-// barrier is the whole point of a stage-major dispatch: every item's result is
-// reconciled together before the next stage is chosen.
-const settled = await parallel(
-  items.map((item) => () =>
-    agent(buildPrompt(item), {
-      label: STAGE_ID + ':' + String(item.id),
-      phase: STAGE_LABEL,
-      schema: RESULT_SCHEMA,
-      agentType: AGENT_TYPE,
-    }).then((result) => ({ itemId: item.id, ...(result || {}) })),
-  ),
-)
+const settled = await parallel(items.map((item) => () => runItem(item)))
 
-// A null slot means the agent died or was skipped — surface it as a failed item
-// rather than dropping it, so the orchestrator can loop it back or fail the lane.
 const results = settled.map((entry, i) =>
-  entry && entry.outcome
-    ? entry
-    : { itemId: items[i].id, outcome: 'failed', summary: 'agent produced no result' },
+  entry || { itemId: items[i].id, outcome: 'failed', attempts: 0, trail: [], failedStage: STAGES[0].id },
 )
 
-return { stage: STAGE_ID, results }
+return { stages: STAGES.map((s) => s.id), results }
 `;
 }
 
 /**
- * Render every scriptable stage of a resolved definition's fan-out steps.
+ * Render every batch script for a resolved definition's fan-out steps.
  *
- * Returns one entry per rendered stage, keyed by the LOGICAL bundle name (the
- * writer adds the `cyboflow-` prefix). Host-owned and unslug-able stages are
- * skipped silently — they stay on the prose path.
+ * Returns one entry per BATCH, keyed by the LOGICAL bundle name (the writer adds
+ * the `cyboflow-` prefix). Firm gates produce no script — they stay with the
+ * orchestrator — and an unslug-able batch is skipped silently, falling back to
+ * the prose path for those stages.
  */
-export function renderFanOutStageScripts(
+export function renderFanOutBatchScripts(
   workflowName: string,
   steps: ReadonlyArray<WorkflowStep>,
 ): Array<{ name: string; content: string }> {
   const out: Array<{ name: string; content: string }> = [];
   for (const step of steps) {
-    const fanOut = step.fanOut;
+    const fanOut: FanOutSpec | undefined = step.fanOut;
     if (fanOut === undefined) continue;
-    for (const inner of fanOut.inner) {
-      const content = renderFanOutStageScript(workflowName, step, fanOut, inner);
-      const logical = fanOutStageLogicalName(workflowName, step.id, inner.id);
+    for (const segment of segmentFanOutInner(fanOut.inner)) {
+      if (segment.kind !== 'batch') continue;
+      const content = renderFanOutBatchScript(workflowName, step, segment.steps);
+      const logical = fanOutBatchLogicalName(workflowName, step.id, segment.steps[0].id);
       if (content === null || logical === null) continue;
       out.push({ name: logical, content });
     }

--- a/main/src/orchestrator/runExecutor.ts
+++ b/main/src/orchestrator/runExecutor.ts
@@ -687,6 +687,16 @@ export class RunExecutor {
      * invariant. When absent the resolver floors to its own 'default'.
      */
     private readonly getDefaultAgentPermissionMode?: () => PermissionMode,
+    /**
+     * Optional dynamic-workflow liveness probe. When injected, the interactive
+     * event-driven REST seam skips resting a run whose agent is currently
+     * yielding to a BACKGROUND Claude Code dynamic workflow (the `Workflow`
+     * tool) — see registerTurnEndRest. A plain function type (no tracker import)
+     * keeps this module free of the dynamicWorkflows dependency and lets tests
+     * drive both arms without the singleton. When absent, rest behaviour is
+     * byte-identical to before this seam existed.
+     */
+    private readonly hasRunningDynamicWorkflow?: (runId: string) => boolean,
   ) {}
 
   /**
@@ -1224,6 +1234,32 @@ export class RunExecutor {
       if (typeof payload !== 'object' || payload === null || !('runId' in payload)) return;
       const evt = payload as { runId: string };
       if (evt.runId !== runId) return;
+      // A turn-end that lands while a dynamic workflow is still RUNNING for this
+      // run is the agent yielding to a background `Workflow` task, not the turn
+      // finishing its work — the CLI re-invokes it on the completion
+      // notification, and THAT turn's end rests the run. Resting here is not the
+      // benign no-op the drained comment describes: onLifecycleTransition runs
+      // its side effects (task-stage derivation, usage rollup, compound
+      // findings close-out) EVEN WHEN the status transition is rejected as a
+      // race (see the comment at its `catch`), and the compound close-out clears
+      // `selected` on still-pending seeded findings.
+      //
+      // Best-effort by construction, and deliberately NOT timer-deferred: the
+      // launch is observed by a 1s-poll filesystem watcher, so a turn-end
+      // arriving within that window still rests. Closing that window needs a
+      // deferred re-check, which needs a per-run execution epoch + turn
+      // generation to be safe (a naive timer can fire after the human answered a
+      // question gate and park a run that is mid-turn again — `restAwaitingReview`
+      // is guarded on status='running', which such a run once again satisfies).
+      // That machinery belongs with the change that makes workflow dispatch
+      // routine; until then this guard covers the ad-hoc case without adding a
+      // stale-timer hazard of its own.
+      if (this.hasRunningDynamicWorkflow?.(runId) === true) {
+        this.logger.debug('[RunExecutor] turn-end with a live dynamic workflow — deferring rest', {
+          runId,
+        });
+        return;
+      }
       // Rest the run in awaiting_review WITHOUT resolving the spawn promise.
       // Fire-and-forget: the transition is fail-soft (a rejected rest is
       // swallowed inside onLifecycleTransition), so a rejected promise here is

--- a/main/src/orchestrator/workflowDefinitionSchema.ts
+++ b/main/src/orchestrator/workflowDefinitionSchema.ts
@@ -54,6 +54,10 @@ const fanOutInnerStepSchema = z.object({
   optional: z.boolean().optional(),
   loopback: z.string().optional(),
   name: z.string().optional(),
+  // Firm gate: the orchestrator must regain control before an item advances past
+  // this stage, so it can never be folded into a delegated batch. See
+  // FanOutInnerStep.firmGate.
+  firmGate: z.boolean().optional(),
 });
 
 /**

--- a/main/src/orchestrator/workflows/__tests__/workflowBundle.test.ts
+++ b/main/src/orchestrator/workflows/__tests__/workflowBundle.test.ts
@@ -63,13 +63,13 @@ describe('resolveWorkflowBundle', () => {
   });
 
   it('(d) fail-soft empty bundle for null / empty / no-sibling-dir', () => {
-    expect(resolveWorkflowBundle(null)).toEqual({ commands: [], agents: [] });
-    expect(resolveWorkflowBundle('')).toEqual({ commands: [], agents: [] });
-    expect(resolveWorkflowBundle('   ')).toEqual({ commands: [], agents: [] });
+    expect(resolveWorkflowBundle(null)).toEqual({ commands: [], agents: [], scripts: [] });
+    expect(resolveWorkflowBundle('')).toEqual({ commands: [], agents: [], scripts: [] });
+    expect(resolveWorkflowBundle('   ')).toEqual({ commands: [], agents: [], scripts: [] });
 
     // A .md that exists but has no sibling bundle dir.
     const lonely = path.join(root, 'custom.md');
     fs.writeFileSync(lonely, '# custom', 'utf8');
-    expect(resolveWorkflowBundle(lonely)).toEqual({ commands: [], agents: [] });
+    expect(resolveWorkflowBundle(lonely)).toEqual({ commands: [], agents: [], scripts: [] });
   });
 });

--- a/main/src/orchestrator/workflows/workflowBundle.ts
+++ b/main/src/orchestrator/workflows/workflowBundle.ts
@@ -43,10 +43,19 @@ export interface WorkflowBundleFile {
 export interface WorkflowBundle {
   commands: WorkflowBundleFile[];
   agents: WorkflowBundleFile[];
+  /**
+   * Dynamic-workflow stage scripts (`.claude/workflows/cyboflow-<name>.js`).
+   *
+   * Unlike commands/agents these are NOT read from app assets — they are
+   * RENDERED per run from the fan-out spec (`fanOutStageScript.ts`) and attached
+   * by the install seam, so `resolveWorkflowBundle` always leaves this empty.
+   * Present on the type so the writer has one uniform bundle to place + reconcile.
+   */
+  scripts: WorkflowBundleFile[];
 }
 
 /** An empty bundle — the fail-soft result when no sibling bundle dir exists. */
-const EMPTY_BUNDLE: WorkflowBundle = { commands: [], agents: [] };
+const EMPTY_BUNDLE: WorkflowBundle = { commands: [], agents: [], scripts: [] };
 
 /**
  * Resolve the command + agent bundle co-located with a workflow's prose `.md`.
@@ -67,6 +76,8 @@ export function resolveWorkflowBundle(workflowPath: string | null | undefined): 
   return {
     commands: readBundleDir(join(bundleRoot, 'commands')),
     agents: readBundleDir(join(bundleRoot, 'agents')),
+    // Rendered per run by the install seam, never read from assets — see the type.
+    scripts: [],
   };
 }
 

--- a/main/src/services/__tests__/configManagerFanOutDispatch.test.ts
+++ b/main/src/services/__tests__/configManagerFanOutDispatch.test.ts
@@ -1,0 +1,78 @@
+/**
+ * ConfigManager.getFanOutDispatch coverage — the global fan-out dispatch mode
+ * for orchestrated INTERACTIVE runs ('prose' = today's agent-driven lanes,
+ * 'workflow' = stage-major dispatch to installed dynamic-workflow scripts).
+ *
+ * Mirrors configManagerExecutionModel.test.ts. The contract that matters is the
+ * FLOOR: this feature must be inert until deliberately switched on, so an absent
+ * key, an absent config.json, and a bogus persisted value all read 'prose'.
+ *
+ * Hermetic: each test points ConfigManager at a unique temp dir via
+ * setCyboflowDirectory(), so the real ~/.cyboflow config is never touched.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { ConfigManager } from '../configManager';
+import { setCyboflowDirectory } from '../../utils/cyboflowDirectory';
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cyboflow-fanoutdispatch-test-'));
+  setCyboflowDirectory(tempDir);
+});
+
+afterEach(async () => {
+  await fs.rm(tempDir, { recursive: true, force: true });
+});
+
+describe('ConfigManager.getFanOutDispatch', () => {
+  it("floors to 'prose' on a fresh instance (before initialize)", () => {
+    const mgr = new ConfigManager('/tmp/test-git-path');
+    expect(mgr.getFanOutDispatch()).toBe('prose');
+  });
+
+  it('is NOT seeded into the constructor defaults (config.json stays byte-identical)', () => {
+    const mgr = new ConfigManager('/tmp/test-git-path');
+    expect(mgr.getConfig().fanOutDispatch).toBeUndefined();
+    expect(mgr.getFanOutDispatch()).toBe('prose');
+  });
+
+  it("reads 'prose' from a config.json with no fanOutDispatch key", async () => {
+    await fs.writeFile(
+      path.join(tempDir, 'config.json'),
+      JSON.stringify({ gitRepoPath: '/some/repo' }, null, 2),
+    );
+
+    const mgr = new ConfigManager('/tmp/test-git-path');
+    await mgr.initialize();
+
+    expect(mgr.getConfig().fanOutDispatch).toBeUndefined();
+    expect(mgr.getFanOutDispatch()).toBe('prose');
+  });
+
+  it("round-trips an explicit 'workflow' through a fresh initialize()", async () => {
+    const mgr = new ConfigManager('/tmp/test-git-path');
+    await mgr.initialize();
+    await mgr.updateConfig({ fanOutDispatch: 'workflow' });
+
+    const reopened = new ConfigManager('/tmp/test-git-path');
+    await reopened.initialize();
+
+    expect(reopened.getFanOutDispatch()).toBe('workflow');
+  });
+
+  it("floors a BOGUS persisted value to 'prose' rather than trusting it", async () => {
+    await fs.writeFile(
+      path.join(tempDir, 'config.json'),
+      JSON.stringify({ gitRepoPath: '/some/repo', fanOutDispatch: 'ultracode' }, null, 2),
+    );
+
+    const mgr = new ConfigManager('/tmp/test-git-path');
+    await mgr.initialize();
+
+    expect(mgr.getFanOutDispatch()).toBe('prose');
+  });
+});

--- a/main/src/services/configManager.ts
+++ b/main/src/services/configManager.ts
@@ -22,6 +22,11 @@ import { type CliSubstrate, DEFAULT_SUBSTRATE, isCliSubstrate } from '../../../s
 import type { PermissionMode } from '../../../shared/types/workflows';
 import { type ExecutionModel, isExecutionModel } from '../../../shared/types/executionModel';
 import {
+  DEFAULT_FAN_OUT_DISPATCH,
+  isFanOutDispatch,
+  type FanOutDispatch,
+} from '../../../shared/types/fanOutDispatch';
+import {
   type QuickSessionWorktreeMode,
   DEFAULT_QUICK_SESSION_WORKTREE_MODE,
   isQuickSessionWorktreeMode,
@@ -553,6 +558,23 @@ export class ConfigManager extends EventEmitter {
   getDefaultExecutionModel(): ExecutionModel {
     const value = this.config.defaultExecutionModel;
     return isExecutionModel(value) ? value : 'programmatic';
+  }
+
+  /**
+   * Global fan-out dispatch mode for orchestrated INTERACTIVE runs: whether a
+   * fan-out step's inner chain is driven by the agent as prose, or dispatched
+   * stage-by-stage to pre-installed dynamic-workflow scripts.
+   *
+   * Floors to the shared DEFAULT ('prose' — today's behavior) when unset OR when
+   * the persisted value is not a valid mode (config.json is user-editable). The
+   * resolved value is snapshotted ONCE per spawn and threaded to both prompt
+   * composition and bundle installation, so a mid-run config flip can never
+   * leave a run whose prompt and on-disk scripts disagree. NOT seeded into the
+   * constructor defaults, so existing config.json files stay byte-identical.
+   */
+  getFanOutDispatch(): FanOutDispatch {
+    const value = this.config.fanOutDispatch;
+    return isFanOutDispatch(value) ? value : DEFAULT_FAN_OUT_DISPATCH;
   }
 
   /**

--- a/main/src/services/panels/claude/__tests__/interactiveClaudeManager.completion.test.ts
+++ b/main/src/services/panels/claude/__tests__/interactiveClaudeManager.completion.test.ts
@@ -138,7 +138,11 @@ function createMockSessionManager(): SessionManager {
 }
 
 function createMockConfigManager(): ConfigManager {
-  return { getConfig: vi.fn(() => ({})) } as unknown as ConfigManager;
+  return {
+    getConfig: vi.fn(() => ({})),
+    // Fan-out dispatch mode, read once per spawn (floors to 'prose').
+    getFanOutDispatch: vi.fn(() => 'prose'),
+  } as unknown as ConfigManager;
 }
 
 function createLogger(): import('../../../../utils/logger').Logger {

--- a/main/src/services/panels/claude/__tests__/interactiveClaudeManager.test.ts
+++ b/main/src/services/panels/claude/__tests__/interactiveClaudeManager.test.ts
@@ -265,6 +265,8 @@ function createMockConfigManager(
     // Global 4-mode default consumed by resolveSessionAgentPermissionMode (the
     // quick/legacy-session seam mirrored from the SDK twin).
     getDefaultAgentPermissionMode: vi.fn(() => defaultAgentPermissionMode),
+    // Fan-out dispatch mode, read once per spawn (floors to 'prose').
+    getFanOutDispatch: vi.fn(() => 'prose'),
   } as unknown as ConfigManager;
 }
 

--- a/main/src/services/panels/claude/__tests__/interactiveStepTracking.integration.test.ts
+++ b/main/src/services/panels/claude/__tests__/interactiveStepTracking.integration.test.ts
@@ -217,6 +217,8 @@ function createMockSessionManager(
 function createMockConfigManager(): ConfigManager {
   return {
     getConfig: vi.fn(() => ({ claudeExecutablePath: undefined })),
+    // Fan-out dispatch mode, read once per spawn (floors to 'prose').
+    getFanOutDispatch: vi.fn(() => 'prose'),
   } as unknown as ConfigManager;
 }
 

--- a/main/src/services/panels/claude/__tests__/workflowBundleInstall.test.ts
+++ b/main/src/services/panels/claude/__tests__/workflowBundleInstall.test.ts
@@ -60,7 +60,7 @@ vi.mock('child_process', async (importOriginal) => {
 import { installWorkflowBundle } from '../workflowBundleInstall';
 import { installAgentOverlay } from '../agentOverlayWriter';
 import { WorkflowBundleWriter } from '../workflowBundleWriter';
-import { fanOutStageWorkflowName } from '../../../../orchestrator/prompts/fanOutStageScript';
+import { fanOutBatchWorkflowName } from '../../../../orchestrator/prompts/fanOutStageScript';
 import type { WorkflowBundle } from '../../../../orchestrator/workflows/workflowBundle';
 import { makeSpyLogger } from '../../../../orchestrator/__test_fixtures__/loggerLikeSpy';
 
@@ -320,11 +320,11 @@ describe('workflowBundleInstall — fan-out stage scripts', () => {
 
     installWorkflowBundle(db, new WorkflowBundleWriter(), 'run-1', worktree, undefined, 'workflow');
 
+    // ONE script for the whole non-gated run of stages (implement + write-tests),
+    // named for the batch's first stage. visual-verify is a firm gate, so it ends
+    // the batch and is never scripted.
     const written = fs.readdirSync(workflowsDir()).sort();
-    expect(written).toEqual([
-      'cyboflow-sprint-execute-tasks-implement.js',
-      'cyboflow-sprint-execute-tasks-write-tests.js',
-    ]);
+    expect(written).toEqual(['cyboflow-sprint-execute-tasks-implement.js']);
     expect(fs.readFileSync(excludePath(worktree), 'utf8')).toContain(SCRIPT_GLOB);
   });
 
@@ -333,7 +333,7 @@ describe('workflowBundleInstall — fan-out stage scripts', () => {
 
     installWorkflowBundle(db, new WorkflowBundleWriter(), 'run-1', worktree, undefined, 'workflow');
 
-    const invocable = fanOutStageWorkflowName('sprint', 'execute-tasks', 'implement');
+    const invocable = fanOutBatchWorkflowName('sprint', 'execute-tasks', 'implement');
     expect(invocable).not.toBeNull();
     expect(fs.existsSync(path.join(workflowsDir(), `${invocable as string}.js`))).toBe(true);
     // ...and the meta the tracker reads back agrees with both.

--- a/main/src/services/panels/claude/__tests__/workflowBundleInstall.test.ts
+++ b/main/src/services/panels/claude/__tests__/workflowBundleInstall.test.ts
@@ -28,6 +28,17 @@ import type Database from 'better-sqlite3';
 vi.mock('../agentOverlayWriter', () => ({ installAgentOverlay: vi.fn() }));
 
 /**
+ * resolveRunFrozenSpec is mocked so the stage-script tests can pin the run's
+ * EFFECTIVE (frozen / variant) spec independently of the live workflows row —
+ * that distinction is the point of one of them. `frozen.value` is null by
+ * default, which is the "no frozen revision" fallback the real helper returns.
+ */
+const frozen = vi.hoisted(() => ({ value: null as { workflowName: string; specJson: string | null } | null }));
+vi.mock('../../../../orchestrator/runFrozenSpec', () => ({
+  resolveRunFrozenSpec: () => frozen.value,
+}));
+
+/**
  * child_process is mocked ONLY so a single test can force a git failure that is
  * NOT "not a git repository" (the one class ensureBundleExcluded still warns
  * about). `impl` is null everywhere else, in which case the real execFileSync
@@ -49,6 +60,7 @@ vi.mock('child_process', async (importOriginal) => {
 import { installWorkflowBundle } from '../workflowBundleInstall';
 import { installAgentOverlay } from '../agentOverlayWriter';
 import { WorkflowBundleWriter } from '../workflowBundleWriter';
+import { fanOutStageWorkflowName } from '../../../../orchestrator/prompts/fanOutStageScript';
 import type { WorkflowBundle } from '../../../../orchestrator/workflows/workflowBundle';
 import { makeSpyLogger } from '../../../../orchestrator/__test_fixtures__/loggerLikeSpy';
 
@@ -235,5 +247,133 @@ describe('workflowBundleInstall — installWorkflowBundle fail-soft', () => {
       (c) => c.level === 'warn' && c.message.includes('workflow_path lookup failed'),
     );
     expect(warned).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fan-out stage scripts (dispatch === 'workflow')
+// ---------------------------------------------------------------------------
+
+/** The canonical sprint-ish fan-out spec, as a workflows.spec_json string. */
+function fanOutSpecJson(innerIds: string[]): string {
+  return JSON.stringify({
+    id: 'sprint',
+    phases: [
+      {
+        id: 'execute',
+        label: 'Execute',
+        color: '#c96442',
+        steps: [
+          {
+            id: 'execute-tasks',
+            name: 'Execute tasks',
+            agent: 'implement',
+            mcps: [],
+            retries: 0,
+            fanOut: {
+              over: 'tasks',
+              inner: innerIds.map((id) => ({ id, agent: id, name: id })),
+            },
+          },
+        ],
+      },
+    ],
+  });
+}
+
+/** DB stub that answers BOTH the workflow_path lookup and the name/spec lookup. */
+function makeSpecDbStub(name: string, specJson: string): Database.Database {
+  return {
+    prepare: (sql: string) => ({
+      get: () =>
+        sql.includes('workflow_path')
+          ? { workflowPath: null }
+          : { name, specJson },
+    }),
+  } as unknown as Database.Database;
+}
+
+describe('workflowBundleInstall — fan-out stage scripts', () => {
+  let worktree: string;
+  const workflowsDir = () => path.join(worktree, '.claude', 'workflows');
+  const SCRIPT_GLOB = '.claude/workflows/cyboflow-*.js';
+
+  beforeEach(() => {
+    execFileSyncOverride.impl = null;
+    frozen.value = null;
+    worktree = tmpDir('cyboflow-stage-scripts-');
+    initGitRepo(worktree);
+    vi.clearAllMocks();
+  });
+
+  it('writes NOTHING and adds no exclude glob in the default prose mode', () => {
+    const db = makeSpecDbStub('sprint', fanOutSpecJson(['implement', 'write-tests']));
+
+    installWorkflowBundle(db, new WorkflowBundleWriter(), 'run-1', worktree);
+
+    expect(fs.existsSync(workflowsDir())).toBe(false);
+    expect(fs.readFileSync(excludePath(worktree), 'utf8')).not.toContain(SCRIPT_GLOB);
+  });
+
+  it('renders one script per scriptable stage and excludes them from git', () => {
+    const db = makeSpecDbStub('sprint', fanOutSpecJson(['implement', 'write-tests', 'visual-verify']));
+
+    installWorkflowBundle(db, new WorkflowBundleWriter(), 'run-1', worktree, undefined, 'workflow');
+
+    const written = fs.readdirSync(workflowsDir()).sort();
+    expect(written).toEqual([
+      'cyboflow-sprint-execute-tasks-implement.js',
+      'cyboflow-sprint-execute-tasks-write-tests.js',
+    ]);
+    expect(fs.readFileSync(excludePath(worktree), 'utf8')).toContain(SCRIPT_GLOB);
+  });
+
+  it('the on-disk basename matches the name the prompt will invoke (drift guard)', () => {
+    const db = makeSpecDbStub('sprint', fanOutSpecJson(['implement']));
+
+    installWorkflowBundle(db, new WorkflowBundleWriter(), 'run-1', worktree, undefined, 'workflow');
+
+    const invocable = fanOutStageWorkflowName('sprint', 'execute-tasks', 'implement');
+    expect(invocable).not.toBeNull();
+    expect(fs.existsSync(path.join(workflowsDir(), `${invocable as string}.js`))).toBe(true);
+    // ...and the meta the tracker reads back agrees with both.
+    const source = fs.readFileSync(path.join(workflowsDir(), `${invocable as string}.js`), 'utf8');
+    expect(source).toContain(`name: ${JSON.stringify(invocable)}`);
+  });
+
+  it('renders from the FROZEN variant spec, not the live workflows row', () => {
+    // Live row says the chain is [implement]; the run's frozen variant says [beta].
+    const db = makeSpecDbStub('sprint', fanOutSpecJson(['implement']));
+    frozen.value = { workflowName: 'sprint', specJson: fanOutSpecJson(['beta']) };
+
+    installWorkflowBundle(db, new WorkflowBundleWriter(), 'run-1', worktree, undefined, 'workflow');
+
+    expect(fs.readdirSync(workflowsDir())).toEqual(['cyboflow-sprint-execute-tasks-beta.js']);
+  });
+
+  it('an unparseable spec falls back to the built-in definition rather than rendering nothing', () => {
+    // resolveWorkflowDefinition treats spec_json as an OVERRIDE of the built-in
+    // seed, so a broken spec for a real flow name still resolves the seed graph —
+    // which is the correct floor: the run walks that graph, so its scripts must
+    // match it. (A run whose prompt cites scripts that were never written is the
+    // failure mode this guards against.)
+    const db = makeSpecDbStub('sprint', 'not json at all');
+
+    installWorkflowBundle(db, new WorkflowBundleWriter(), 'run-1', worktree, makeSpyLogger(), 'workflow');
+
+    const written = fs.readdirSync(workflowsDir());
+    expect(written.length).toBeGreaterThan(0);
+    expect(written.every((f) => f.startsWith('cyboflow-sprint-') && f.endsWith('.js'))).toBe(true);
+    // The host-owned visual gate is never scripted, whatever the source of the graph.
+    expect(written.some((f) => f.includes('visual-verify'))).toBe(false);
+  });
+
+  it('renders nothing for a workflow with no resolvable definition', () => {
+    const db = makeSpecDbStub('not-a-real-flow', '{}');
+
+    installWorkflowBundle(db, new WorkflowBundleWriter(), 'run-1', worktree, makeSpyLogger(), 'workflow');
+
+    expect(fs.existsSync(workflowsDir())).toBe(false);
+    expect(fs.readFileSync(excludePath(worktree), 'utf8')).not.toContain(SCRIPT_GLOB);
   });
 });

--- a/main/src/services/panels/claude/__tests__/workflowBundleWriter.test.ts
+++ b/main/src/services/panels/claude/__tests__/workflowBundleWriter.test.ts
@@ -31,6 +31,7 @@ const BUNDLE: WorkflowBundle = {
     { name: 'tasks', content: '---\ndescription: tasks\n---\nTasks phase.' },
   ],
   agents: [{ name: 'researcher', content: '---\nname: researcher\ndescription: r\n---\nResearch.' }],
+  scripts: [],
 };
 
 describe('WorkflowBundleWriter', () => {
@@ -77,7 +78,7 @@ describe('WorkflowBundleWriter', () => {
     expect(fs.existsSync(path.join(commandsDir(worktree), 'cyboflow-tasks.md'))).toBe(true);
 
     // Re-write a SMALLER bundle (tasks dropped).
-    writer.write(worktree, { commands: [BUNDLE.commands[0]], agents: [] });
+    writer.write(worktree, { commands: [BUNDLE.commands[0]], agents: [], scripts: [] });
 
     expect(fs.existsSync(path.join(commandsDir(worktree), 'cyboflow-context.md'))).toBe(true);
     expect(fs.existsSync(path.join(commandsDir(worktree), 'cyboflow-tasks.md'))).toBe(false);
@@ -99,12 +100,86 @@ describe('WorkflowBundleWriter', () => {
   });
 
   it('(e) an empty bundle writes nothing and returns null', () => {
-    const result = new WorkflowBundleWriter().write(worktree, { commands: [], agents: [] });
+    const result = new WorkflowBundleWriter().write(worktree, { commands: [], agents: [], scripts: [] });
     expect(result).toBeNull();
     expect(fs.existsSync(path.join(worktree, '.claude'))).toBe(false);
   });
 
   it('remove is a no-op when the worktree has no .claude dir', () => {
     expect(() => new WorkflowBundleWriter().remove(worktree)).not.toThrow();
+  });
+
+  // -------------------------------------------------------------------------
+  // Dynamic-workflow stage scripts (.claude/workflows/cyboflow-*.js)
+  // -------------------------------------------------------------------------
+
+  const workflowsDir = (wt: string) => path.join(wt, '.claude', 'workflows');
+
+  it('writes stage scripts as cyboflow-<name>.js', () => {
+    const result = new WorkflowBundleWriter().write(worktree, {
+      commands: [],
+      agents: [],
+      scripts: [{ name: 'sprint-execute-implement', content: 'export const meta = {}\n' }],
+    });
+
+    const target = path.join(workflowsDir(worktree), 'cyboflow-sprint-execute-implement.js');
+    expect(fs.existsSync(target)).toBe(true);
+    expect(result?.scriptPaths).toEqual([target]);
+  });
+
+  it('remove strips generated .js but preserves a user script and a user .md in the same dir', () => {
+    const writer = new WorkflowBundleWriter();
+    writer.write(worktree, {
+      commands: [],
+      agents: [],
+      scripts: [{ name: 'gen', content: 'export const meta = {}\n' }],
+    });
+
+    const userJs = path.join(workflowsDir(worktree), 'mine.js');
+    const userMd = path.join(workflowsDir(worktree), 'cyboflow-notes.md');
+    fs.writeFileSync(userJs, 'user script');
+    fs.writeFileSync(userMd, 'user notes');
+
+    writer.remove(worktree);
+
+    expect(fs.existsSync(path.join(workflowsDir(worktree), 'cyboflow-gen.js'))).toBe(false);
+    expect(fs.readFileSync(userJs, 'utf8')).toBe('user script');
+    // Extension-scoped: the .md remove pass targets commands/agents dirs, so a
+    // cyboflow-*.md sitting in the workflows dir is not ours to delete.
+    expect(fs.readFileSync(userMd, 'utf8')).toBe('user notes');
+  });
+
+  it('an empty bundle still clears a previously-written script (no stale resolution)', () => {
+    const writer = new WorkflowBundleWriter();
+    writer.write(worktree, {
+      commands: [],
+      agents: [],
+      scripts: [{ name: 'stale', content: 'export const meta = {}\n' }],
+    });
+    expect(fs.existsSync(path.join(workflowsDir(worktree), 'cyboflow-stale.js'))).toBe(true);
+
+    // Dispatch switched off -> empty bundle. The prior set MUST be reconciled
+    // away; otherwise the CLI keeps resolving the stale script by name.
+    const result = writer.write(worktree, { commands: [], agents: [], scripts: [] });
+
+    expect(result).toBeNull();
+    expect(fs.existsSync(path.join(workflowsDir(worktree), 'cyboflow-stale.js'))).toBe(false);
+  });
+
+  it('refuses a logical name that would escape its target directory', () => {
+    const writer = new WorkflowBundleWriter();
+    writer.write(worktree, {
+      commands: [],
+      agents: [],
+      scripts: [
+        { name: '../../escaped', content: 'nope' },
+        { name: 'ok', content: 'export const meta = {}\n' },
+      ],
+    });
+
+    expect(fs.existsSync(path.join(worktree, '.claude', 'workflows', 'cyboflow-ok.js'))).toBe(true);
+    // Nothing landed above the workflows dir.
+    expect(fs.existsSync(path.join(worktree, 'cyboflow-../../escaped.js'))).toBe(false);
+    expect(fs.readdirSync(worktree).filter((e) => e.endsWith('.js'))).toEqual([]);
   });
 });

--- a/main/src/services/panels/claude/claudeCodeManager.ts
+++ b/main/src/services/panels/claude/claudeCodeManager.ts
@@ -1538,7 +1538,13 @@ export class ClaudeCodeManager extends AbstractCliManager {
       const priorRefcount = this.trackerRefcountByRunId.get(runId) ?? 0;
       this.trackerRefcountByRunId.set(runId, priorRefcount + 1);
       if (priorRefcount === 0) {
-        DynamicWorkflowTracker.tryGetInstance()?.attachToRouter(router, { runId, sessionId });
+        // worktreePath explicitly (see the interactive sibling): a flow run has no
+        // `sessions` row, so the tracker's sessions-keyed fallback resolves nothing.
+        DynamicWorkflowTracker.tryGetInstance()?.attachToRouter(router, {
+          runId,
+          sessionId,
+          worktreePath: options.worktreePath,
+        });
       }
 
       // Abort controller for cancellation.

--- a/main/src/services/panels/claude/claudeCodeManager.ts
+++ b/main/src/services/panels/claude/claudeCodeManager.ts
@@ -1500,7 +1500,19 @@ export class ClaudeCodeManager extends AbstractCliManager {
       // lifetime), decremented once at process-death by removeBundleForSession — a
       // warm turn re-writes the bundle (driveWarmTurn) but does NOT re-bump.
       if (!dbSession?.in_place) {
-        installWorkflowBundle(this.db, this.bundleWriter, runId, options.worktreePath, makeLoggerLike(this.logger));
+        // 'prose' EXPLICITLY: this install seam is substrate-shared, but the SDK
+        // path composes its prompt through workflowPromptReaderAdapter (which
+        // never emits the workflow-dispatch chain), so stage scripts written
+        // here would be inert files in an SDK worktree. Pinned rather than
+        // defaulted so the intent survives a change to the default.
+        installWorkflowBundle(
+          this.db,
+          this.bundleWriter,
+          runId,
+          options.worktreePath,
+          makeLoggerLike(this.logger),
+          'prose',
+        );
         this.bundleWorktrees.set(sessionId, options.worktreePath);
         this.bundleRefcountBySession.set(sessionId, (this.bundleRefcountBySession.get(sessionId) ?? 0) + 1);
       }

--- a/main/src/services/panels/claude/interactiveClaudeManager.ts
+++ b/main/src/services/panels/claude/interactiveClaudeManager.ts
@@ -28,6 +28,10 @@ import { InteractiveMcpEnabler } from './interactiveMcpEnabler';
 import type { LoggerLike } from '../../../orchestrator/types';
 import { buildStepReportingAppend } from '../../../orchestrator/prompts/step-reporting-instructions';
 import { buildFanOutAppend } from '../../../orchestrator/prompts/fan-out-instructions';
+import {
+  DEFAULT_FAN_OUT_DISPATCH,
+  type FanOutDispatch,
+} from '../../../../../shared/types/fanOutDispatch';
 import { QUICK_WORKFLOW_NAME } from '../../../orchestrator/workflowRegistry';
 import { resolveRunFrozenSpec } from '../../../orchestrator/runFrozenSpec';
 import { resolveGateRunId } from '../../../orchestrator/chatSentinelProvider';
@@ -1106,8 +1110,20 @@ export class InteractiveClaudeManager extends AbstractCliManager {
     // Gated for in-place sessions (mirrors the SDK sibling): a quick session has
     // no sibling bundle so this is fail-soft anyway, but the gate keeps the
     // user's real `.claude/` untouchable by construction, not by coincidence.
+    // ONE snapshot of the fan-out dispatch mode for this whole spawn: the same
+    // value gates stage-script installation below and the prompt's per-stage
+    // chain in composePromptBody, so the two can never disagree for this run.
+    const fanOutDispatch = this.resolveFanOutDispatch();
+
     if (!inPlaceSession) {
-      installWorkflowBundle(this.db, this.bundleWriter, runId, worktreePath, this.toLoggerLike(this.logger));
+      installWorkflowBundle(
+        this.db,
+        this.bundleWriter,
+        runId,
+        worktreePath,
+        this.toLoggerLike(this.logger),
+        fanOutDispatch,
+      );
     }
 
     // Write the per-run interactive MCP config (the path buildCommandArgs points
@@ -1145,7 +1161,7 @@ export class InteractiveClaudeManager extends AbstractCliManager {
     // variadic flags (--mcp-config, --add-dir, …) precede it. Verified against a
     // real worktree spawn: the `--` form removes the Invalid-MCP-config error
     // while keeping the prompt as the operand claude engages.
-    const composedPrompt = this.composePromptBody(runId, options.prompt);
+    const composedPrompt = this.composePromptBody(runId, options.prompt, fanOutDispatch);
     if (composedPrompt.length > 0) {
       args.push('--', composedPrompt);
     }
@@ -1375,12 +1391,43 @@ export class InteractiveClaudeManager extends AbstractCliManager {
    * broken/empty `spec_json` resolves to a `null` definition → both builders return
    * `''` → the prompt is sent UNCHANGED. Nothing is ever prepended as garbage.
    */
-  private composePromptBody(runId: string, prompt: string): string {
+  private composePromptBody(runId: string, prompt: string, dispatch: FanOutDispatch): string {
     const def = this.resolveRunEffectiveDefinition(runId);
-    const append = [buildStepReportingAppend(def), buildFanOutAppend(def)]
+    // The workflow NAME (not the definition's id) is what the install seam
+    // rendered stage-script names from — pass the same value so the names the
+    // prompt cites and the files on disk cannot drift. Fail-soft to the def id.
+    const workflowName = this.resolveRunWorkflowName(runId) ?? def?.id ?? '';
+    const append = [
+      buildStepReportingAppend(def),
+      buildFanOutAppend(def, { dispatch, workflowName }),
+    ]
       .filter((part) => part.length > 0)
       .join('\n\n');
     return append.length > 0 ? `${append}\n\n${prompt}` : prompt;
+  }
+
+  /**
+   * The run's `workflows.name` from its FROZEN spec row — the identity stage
+   * scripts are named from. `null` fail-soft (missing row / DB error), which
+   * degrades the prompt to the definition id.
+   */
+  private resolveRunWorkflowName(runId: string): string | null {
+    try {
+      return resolveRunFrozenSpec(this.db, runId)?.workflowName ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * The run's effective fan-out dispatch mode, snapshotted ONCE per spawn.
+   *
+   * Resolved here rather than read at each use so a mid-run config flip cannot
+   * leave a run whose PROMPT cites stage scripts its worktree does not carry (or
+   * vice versa) — installation and prompt composition consume this one value.
+   */
+  private resolveFanOutDispatch(): FanOutDispatch {
+    return this.configManager?.getFanOutDispatch() ?? DEFAULT_FAN_OUT_DISPATCH;
   }
 
   /**

--- a/main/src/services/panels/claude/interactiveClaudeManager.ts
+++ b/main/src/services/panels/claude/interactiveClaudeManager.ts
@@ -1032,7 +1032,15 @@ export class InteractiveClaudeManager extends AbstractCliManager {
     // Passive dynamic-workflow detection: watch this run's normalized event
     // stream for Workflow-tool launches. Fail-soft when the tracker singleton
     // is not initialized (unit tests / early boot).
-    DynamicWorkflowTracker.tryGetInstance()?.attachToRouter(router, { runId, sessionId });
+    // worktreePath is passed EXPLICITLY: a flow run has no `sessions` row (see the
+    // gate-vehicle discriminator above — getDbSession is undefined for it), so the
+    // tracker's sessions-keyed fallback resolves nothing and its launch watcher
+    // would never start for this run.
+    DynamicWorkflowTracker.tryGetInstance()?.attachToRouter(router, {
+      runId,
+      sessionId,
+      worktreePath: options.worktreePath,
+    });
 
     // The PreToolUse `'*'` shell-approval hook is delivered INLINE via the
     // `--settings '<json>'` flag assembled in buildCommandArgs (see the parity

--- a/main/src/services/panels/claude/workflowBundleInstall.ts
+++ b/main/src/services/panels/claude/workflowBundleInstall.ts
@@ -22,6 +22,13 @@ import * as path from 'path';
 import type Database from 'better-sqlite3';
 import type { LoggerLike } from '../../../orchestrator/types';
 import { resolveWorkflowBundle } from '../../../orchestrator/workflows/workflowBundle';
+import { resolveWorkflowDefinition } from '../../../../../shared/types/workflows';
+import {
+  DEFAULT_FAN_OUT_DISPATCH,
+  type FanOutDispatch,
+} from '../../../../../shared/types/fanOutDispatch';
+import { renderFanOutStageScripts } from '../../../orchestrator/prompts/fanOutStageScript';
+import { resolveRunFrozenSpec } from '../../../orchestrator/runFrozenSpec';
 import type { WorkflowBundleWriter } from './workflowBundleWriter';
 import { installAgentOverlay } from './agentOverlayWriter';
 
@@ -38,6 +45,16 @@ const CYBOFLOW_EXCLUDE_PATTERNS = [
   '.claude/agents/cyboflow-*.md',
   '.claude/commands/cyboflow-*.md',
 ];
+
+/**
+ * Exclude pattern for RENDERED dynamic-workflow stage scripts. Kept OUT of the
+ * always-applied list above and appended only when scripts are actually being
+ * installed: `ensureBundleExcluded` runs on every spawn, so folding this in
+ * unconditionally would mutate `.git/info/exclude` in every worktree even for
+ * runs that never render a script — breaking the "dispatch off ⇒ nothing on
+ * disk changes" floor.
+ */
+const CYBOFLOW_SCRIPT_EXCLUDE_PATTERN = '.claude/workflows/cyboflow-*.js';
 
 /**
  * True when a failed `git` invocation failed *because the cwd is not a git
@@ -69,7 +86,8 @@ function isNotAGitRepositoryError(err: unknown): boolean {
  * nothing to exclude. That case is logged at debug and returns; every OTHER git
  * or fs failure still warns, because those are real and worth seeing.
  */
-function ensureBundleExcluded(worktreePath: string, logger?: LoggerLike): void {
+function ensureBundleExcluded(worktreePath: string, extraPatterns: string[], logger?: LoggerLike): void {
+  const patterns = [...CYBOFLOW_EXCLUDE_PATTERNS, ...extraPatterns];
   try {
     const raw = execFileSync('git', ['rev-parse', '--git-path', 'info/exclude'], {
       cwd: worktreePath,
@@ -90,7 +108,7 @@ function ensureBundleExcluded(worktreePath: string, logger?: LoggerLike): void {
       /* file absent — created below */
     }
     const lines = existing.split(/\r?\n/);
-    const missing = CYBOFLOW_EXCLUDE_PATTERNS.filter((p) => !lines.includes(p));
+    const missing = patterns.filter((p) => !lines.includes(p));
     if (missing.length === 0) return;
 
     const parts: string[] = [];
@@ -142,6 +160,54 @@ function getRunWorkflowPath(db: Database.Database, runId: string, logger?: Logge
 }
 
 /**
+ * Render the run's fan-out STAGE scripts from its EFFECTIVE workflow definition.
+ *
+ * Resolves through `resolveRunFrozenSpec` — the run's frozen A/B variant graph,
+ * falling back to the live spec — deliberately NOT the live `workflows.spec_json`
+ * join used for `workflow_path`. The prompt side resolves the frozen spec too
+ * (interactiveClaudeManager.resolveRunEffectiveDefinition); reading the live row
+ * here would let a variant run install scripts for a DIFFERENT inner chain than
+ * the one its prompt walks, and the mismatch would surface only as the agent
+ * naming a workflow that does not exist.
+ *
+ * Fail-soft to `[]` on any DB/resolve error — a missing script degrades to the
+ * prose path, which is the correct floor.
+ */
+function resolveStageScripts(
+  db: Database.Database,
+  runId: string,
+  logger?: LoggerLike,
+): Array<{ name: string; content: string }> {
+  try {
+    const row = db
+      .prepare(
+        `SELECT w.name AS name, w.spec_json AS specJson
+           FROM workflow_runs r
+           JOIN workflows w ON w.id = r.workflow_id
+          WHERE r.id = ?`,
+      )
+      .get(runId) as { name?: unknown; specJson?: unknown } | undefined;
+    if (typeof row?.name !== 'string') return [];
+
+    const frozen = resolveRunFrozenSpec(db, runId)?.specJson;
+    const specJson = typeof frozen === 'string'
+      ? frozen
+      : (typeof row.specJson === 'string' ? row.specJson : '{}');
+
+    const def = resolveWorkflowDefinition(row.name, specJson);
+    if (def === null) return [];
+
+    const steps = def.phases.flatMap((phase) => phase.steps);
+    return renderFanOutStageScripts(row.name, steps);
+  } catch (err) {
+    logger?.warn(
+      `[WorkflowBundleInstall] stage-script render failed for runId=${runId}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return [];
+  }
+}
+
+/**
  * Resolve + install the run's co-located command/agent bundle into `worktreePath`.
  * No-op (writes nothing) when the run has no resolvable `workflow_path` or no
  * sibling bundle dir. Never throws — a bundle failure must not break a spawn.
@@ -152,14 +218,26 @@ export function installWorkflowBundle(
   runId: string,
   worktreePath: string,
   logger?: LoggerLike,
+  dispatch: FanOutDispatch = DEFAULT_FAN_OUT_DISPATCH,
 ): void {
   try {
-    // Keep the generated cyboflow-*.md files out of git (run diff + commits)
-    // BEFORE writing them, so they never flicker into a diff poll.
-    ensureBundleExcluded(worktreePath, logger);
+    // Stage scripts for the fan-out steps — ONLY in 'workflow' dispatch. The
+    // mode is a threaded ARGUMENT, not a global config read: this seam is
+    // substrate-shared (the SDK manager calls it too) and the SDK consumes no
+    // scripts, so reading a global here would litter SDK worktrees.
+    const scripts = dispatch === 'workflow' ? resolveStageScripts(db, runId, logger) : [];
+
+    // Keep the generated cyboflow files out of git (run diff + commits) BEFORE
+    // writing them, so they never flicker into a diff poll. The scripts glob is
+    // added only when scripts are actually being installed.
+    ensureBundleExcluded(
+      worktreePath,
+      scripts.length > 0 ? [CYBOFLOW_SCRIPT_EXCLUDE_PATTERN] : [],
+      logger,
+    );
 
     const workflowPath = getRunWorkflowPath(db, runId, logger);
-    const bundle = resolveWorkflowBundle(workflowPath);
+    const bundle = { ...resolveWorkflowBundle(workflowPath), scripts };
     writer.write(worktreePath, bundle);
     // Overlay the project's FULL effective agent set (built-ins + agent_overrides)
     // on top of the flow bundle, so a custom/quick flow still gets the project's

--- a/main/src/services/panels/claude/workflowBundleInstall.ts
+++ b/main/src/services/panels/claude/workflowBundleInstall.ts
@@ -27,7 +27,7 @@ import {
   DEFAULT_FAN_OUT_DISPATCH,
   type FanOutDispatch,
 } from '../../../../../shared/types/fanOutDispatch';
-import { renderFanOutStageScripts } from '../../../orchestrator/prompts/fanOutStageScript';
+import { renderFanOutBatchScripts } from '../../../orchestrator/prompts/fanOutStageScript';
 import { resolveRunFrozenSpec } from '../../../orchestrator/runFrozenSpec';
 import type { WorkflowBundleWriter } from './workflowBundleWriter';
 import { installAgentOverlay } from './agentOverlayWriter';
@@ -198,7 +198,7 @@ function resolveStageScripts(
     if (def === null) return [];
 
     const steps = def.phases.flatMap((phase) => phase.steps);
-    return renderFanOutStageScripts(row.name, steps);
+    return renderFanOutBatchScripts(row.name, steps);
   } catch (err) {
     logger?.warn(
       `[WorkflowBundleInstall] stage-script render failed for runId=${runId}: ${err instanceof Error ? err.message : String(err)}`,

--- a/main/src/services/panels/claude/workflowBundleWriter.ts
+++ b/main/src/services/panels/claude/workflowBundleWriter.ts
@@ -32,14 +32,25 @@ import type { WorkflowBundle } from '../../../orchestrator/workflows/workflowBun
 /** The cyboflow filename namespace. Every written file is `cyboflow-<name>.md`. */
 const CYBOFLOW_PREFIX = 'cyboflow-';
 
-/** The two `.claude/` subdirectories a bundle writes into. */
+/** The `.claude/` subdirectories a bundle writes into, with their file extension. */
 const COMMANDS_DIR = ['.claude', 'commands'] as const;
 const AGENTS_DIR = ['.claude', 'agents'] as const;
+/**
+ * Dynamic-workflow stage scripts. `.js`, NOT `.md` — which is why the
+ * write/remove helpers take the extension as a parameter instead of hardcoding
+ * it: a remove scoped to `.md` would leave generated scripts behind forever,
+ * and one scoped to "any cyboflow-* file" could delete a user's own.
+ */
+const WORKFLOWS_DIR = ['.claude', 'workflows'] as const;
+
+const MARKDOWN_EXT = '.md';
+const SCRIPT_EXT = '.js';
 
 /** Absolute paths written by a single `write` call (for logging / assertions). */
 export interface WorkflowBundleWriteResult {
   commandPaths: string[];
   agentPaths: string[];
+  scriptPaths: string[];
 }
 
 export class WorkflowBundleWriter {
@@ -56,23 +67,32 @@ export class WorkflowBundleWriter {
    * the bundle is empty (nothing to install — no dirs are created).
    */
   write(worktreePath: string, bundle: WorkflowBundle): WorkflowBundleWriteResult | null {
-    if (bundle.commands.length === 0 && bundle.agents.length === 0) {
-      this.logger?.debug('[Cyboflow WorkflowBundle] empty bundle — nothing to install', { worktreePath });
+    // Reconcile FIRST, unconditionally — including for an empty bundle. An early
+    // return before remove() would strand the previous run's cyboflow files on
+    // disk whenever the bundle went non-empty -> empty (e.g. stage-script
+    // dispatch switched off, or a flow edited down to no fan-out), leaving a
+    // stale `.claude/workflows/cyboflow-*.js` that the CLI would still resolve
+    // by name. The on-disk cyboflow set must always equal the CURRENT bundle.
+    this.remove(worktreePath);
+
+    if (bundle.commands.length === 0 && bundle.agents.length === 0 && bundle.scripts.length === 0) {
+      this.logger?.debug('[Cyboflow WorkflowBundle] empty bundle — prior set cleared, nothing to install', {
+        worktreePath,
+      });
       return null;
     }
 
-    // Clear any prior cyboflow set first so the on-disk bundle == the current one.
-    this.remove(worktreePath);
-
-    const commandPaths = this.writeFiles(worktreePath, COMMANDS_DIR, bundle.commands);
-    const agentPaths = this.writeFiles(worktreePath, AGENTS_DIR, bundle.agents);
+    const commandPaths = this.writeFiles(worktreePath, COMMANDS_DIR, bundle.commands, MARKDOWN_EXT);
+    const agentPaths = this.writeFiles(worktreePath, AGENTS_DIR, bundle.agents, MARKDOWN_EXT);
+    const scriptPaths = this.writeFiles(worktreePath, WORKFLOWS_DIR, bundle.scripts, SCRIPT_EXT);
 
     this.logger?.debug('[Cyboflow WorkflowBundle] installed bundle', {
       worktreePath,
       commands: commandPaths.length,
       agents: agentPaths.length,
+      scripts: scriptPaths.length,
     });
-    return { commandPaths, agentPaths };
+    return { commandPaths, agentPaths, scriptPaths };
   }
 
   /**
@@ -82,7 +102,9 @@ export class WorkflowBundleWriter {
    */
   remove(worktreePath: string): void {
     const removed =
-      this.removeFiles(worktreePath, COMMANDS_DIR) + this.removeFiles(worktreePath, AGENTS_DIR);
+      this.removeFiles(worktreePath, COMMANDS_DIR, MARKDOWN_EXT) +
+      this.removeFiles(worktreePath, AGENTS_DIR, MARKDOWN_EXT) +
+      this.removeFiles(worktreePath, WORKFLOWS_DIR, SCRIPT_EXT);
     if (removed > 0) {
       this.logger?.debug('[Cyboflow WorkflowBundle] removed bundle files', { worktreePath, removed });
     }
@@ -96,6 +118,7 @@ export class WorkflowBundleWriter {
     worktreePath: string,
     dirParts: readonly string[],
     files: WorkflowBundle['commands'],
+    ext: string,
   ): string[] {
     if (files.length === 0) return [];
     const dir = path.join(worktreePath, ...dirParts);
@@ -103,15 +126,30 @@ export class WorkflowBundleWriter {
 
     const written: string[] = [];
     for (const file of files) {
-      const target = path.join(dir, `${CYBOFLOW_PREFIX}${file.name}.md`);
+      const target = path.join(dir, `${CYBOFLOW_PREFIX}${file.name}${ext}`);
+      // Containment check: a logical name is caller-supplied and, for rendered
+      // stage scripts, derives from free-form workflow/step ids. A name carrying
+      // a separator or `..` would place the file outside its `.claude` dir (or
+      // over a user file elsewhere in the tree). Skip rather than throw — one bad
+      // name must not abort the whole bundle install.
+      if (path.dirname(path.resolve(target)) !== path.resolve(dir)) {
+        this.logger?.warn(
+          `[Cyboflow WorkflowBundle] refusing to write outside ${dirParts.join('/')}: ${file.name}`,
+        );
+        continue;
+      }
       fs.writeFileSync(target, file.content, 'utf8');
       written.push(target);
     }
     return written;
   }
 
-  /** Unlink every `cyboflow-*.md` in the dir. Returns the count removed. Fail-soft. */
-  private removeFiles(worktreePath: string, dirParts: readonly string[]): number {
+  /**
+   * Unlink every `cyboflow-*<ext>` in the dir. Returns the count removed. Fail-soft.
+   * The extension is scoped so a user's own `.js` beside our `.md` (or vice
+   * versa) is never touched, and so generated scripts are actually reclaimed.
+   */
+  private removeFiles(worktreePath: string, dirParts: readonly string[], ext: string): number {
     const dir = path.join(worktreePath, ...dirParts);
     let entries: string[];
     try {
@@ -122,7 +160,7 @@ export class WorkflowBundleWriter {
 
     let removed = 0;
     for (const entry of entries) {
-      if (!entry.startsWith(CYBOFLOW_PREFIX) || path.extname(entry).toLowerCase() !== '.md') continue;
+      if (!entry.startsWith(CYBOFLOW_PREFIX) || path.extname(entry).toLowerCase() !== ext) continue;
       try {
         fs.unlinkSync(path.join(dir, entry));
         removed += 1;

--- a/main/src/types/config.ts
+++ b/main/src/types/config.ts
@@ -3,6 +3,7 @@ import type { AssistantContextRetention } from '../../../shared/types/agentThrea
 import type { CliSubstrate } from '../../../shared/types/substrate';
 import type { PermissionMode } from '../../../shared/types/workflows';
 import type { ExecutionModel } from '../../../shared/types/executionModel';
+import type { FanOutDispatch } from '../../../shared/types/fanOutDispatch';
 import type { QuickSessionWorktreeMode } from '../../../shared/types/worktreeMode';
 import type { VisualVerifyConfig } from '../../../shared/types/visualVerification';
 import type { RunTypeDefaults } from '../../../shared/types/sessionDefaults';
@@ -103,6 +104,13 @@ export interface AppConfig {
   // (which hard-pins 'orchestrated'). NOT seeded into the constructor defaults, so existing
   // config.json files stay byte-identical.
   defaultExecutionModel?: ExecutionModel;
+  // Fan-out dispatch mode for orchestrated INTERACTIVE runs ('prose' | 'workflow').
+  // 'workflow' dispatches each inner stage of a wave to a pre-installed dynamic
+  // workflow script instead of the agent driving lanes by hand; the orchestrator
+  // stays the single writer either way. Floors to 'prose' when unset, and is NOT
+  // seeded into the constructor defaults so existing config.json files stay
+  // byte-identical.
+  fanOutDispatch?: FanOutDispatch;
   // Global default for where QUICK sessions work ('worktree' | 'in-place').
   // Read via getQuickSessionWorktreeMode() (floor 'worktree') by the
   // sessions:create-quick handler when the request omits worktreeMode. NOT
@@ -253,6 +261,13 @@ export interface UpdateConfigRequest {
   defaultAgentPermissionMode?: PermissionMode;
   // Global default execution model for new SDK workflow runs ('orchestrated' | 'programmatic').
   defaultExecutionModel?: ExecutionModel;
+  // Fan-out dispatch mode for orchestrated INTERACTIVE runs ('prose' | 'workflow').
+  // 'workflow' dispatches each inner stage of a wave to a pre-installed dynamic
+  // workflow script instead of the agent driving lanes by hand; the orchestrator
+  // stays the single writer either way. Floors to 'prose' when unset, and is NOT
+  // seeded into the constructor defaults so existing config.json files stay
+  // byte-identical.
+  fanOutDispatch?: FanOutDispatch;
   // Global default for where QUICK sessions work (see AppConfig.quickSessionWorktreeMode).
   quickSessionWorktreeMode?: QuickSessionWorktreeMode;
   // Global default CLI substrate for new QUICK sessions (see AppConfig.quickSessionDefaultSubstrate).

--- a/shared/types/fanOutDispatch.ts
+++ b/shared/types/fanOutDispatch.ts
@@ -1,0 +1,35 @@
+/**
+ * Fan-out dispatch mode — HOW an orchestrated run executes a fan-out step's
+ * inner chain.
+ *
+ * - `prose` — the orchestrator agent drives each lane itself via Agent-tool
+ *   subagents, following the instruction block `fan-out-instructions.ts`
+ *   renders. Today's behavior, and the floor.
+ * - `workflow` — the orchestrator dispatches ONE inner stage of ONE wave at a
+ *   time to a pre-installed Claude Code dynamic workflow
+ *   (`.claude/workflows/cyboflow-*.js`, rendered by `fanOutStageScript.ts`),
+ *   reads back structured per-item results, and performs every cyboflow write
+ *   itself between stages. Stage-major, so single-writer, the host-owned visual
+ *   merge-gate, and live wave re-resolution all survive.
+ *
+ * Lives in `shared/` rather than beside either AppConfig because BOTH the main
+ * and frontend `AppConfig` declarations carry the field and must stay in parity
+ * (docs/CODE-PATTERNS.md → IPC / type-parity rules).
+ *
+ * INTERACTIVE-ONLY in practice: the SDK substrate composes its prompt through
+ * `workflowPromptReaderAdapter` and its spawn passes `prose` explicitly. The
+ * install seam is substrate-shared, so the mode is threaded to it as an argument
+ * rather than read from global config inside it — otherwise SDK worktrees would
+ * accrue scripts nothing consumes.
+ */
+
+/** How a fan-out step's inner chain is executed. */
+export type FanOutDispatch = 'prose' | 'workflow';
+
+/** The floor: today's agent-driven prose behavior. */
+export const DEFAULT_FAN_OUT_DISPATCH: FanOutDispatch = 'prose';
+
+/** Runtime guard — config.json is user-editable, so reads are validated. */
+export function isFanOutDispatch(value: unknown): value is FanOutDispatch {
+  return value === 'prose' || value === 'workflow';
+}

--- a/shared/types/workflows.ts
+++ b/shared/types/workflows.ts
@@ -429,6 +429,26 @@ export interface FanOutInnerStep {
   loopback?: string;
   /** Human-readable name for prompts/UI; falls back to id when absent. */
   name?: string;
+  /**
+   * When true this stage is a FIRM GATE: the orchestrator must regain control
+   * before the item may advance past it, so the stage can never be folded into a
+   * batch of stages delegated elsewhere.
+   *
+   * Only meaningful under `fanOutDispatch: 'workflow'`, where consecutive
+   * NON-gated stages are dispatched to a single dynamic workflow that runs each
+   * item's whole sub-chain (implement → tests → verify) without returning to the
+   * orchestrator between stages. That is the efficiency of the workflow path,
+   * and the deliberate trade is that lane `current_step` does not tick per stage
+   * inside a batch — the orchestrator backfills the stage trail from the
+   * returned results.
+   *
+   * A firm gate ENDS such a batch. `visual-verify` is the canonical one: it has
+   * no subagent at all (the orchestrator fires `cyboflow_request_verification`
+   * and parks the lane on an async external verdict), so it is both unscriptable
+   * and a real gate. Absent ⇒ not a gate ⇒ batchable, which is the default for
+   * ordinary implementation stages.
+   */
+  firmGate?: boolean;
 }
 
 /**
@@ -873,6 +893,11 @@ export const WORKFLOW_DEFINITIONS: Readonly<Record<CyboflowWorkflowName, Workflo
                   name: 'Visual check',
                   optional: true,
                   loopback: 'implement',
+                  // The ONLY firm gate in the implementation chain: it has no
+                  // subagent (the orchestrator fires the verification request and
+                  // parks the lane on an async verdict), so it can never be folded
+                  // into a delegated batch. Every stage before it is batchable.
+                  firmGate: true,
                 },
               ],
             },
@@ -1167,6 +1192,11 @@ export const WORKFLOW_DEFINITIONS: Readonly<Record<CyboflowWorkflowName, Workflo
                   name: 'Visual check',
                   optional: true,
                   loopback: 'implement',
+                  // The ONLY firm gate in the implementation chain: it has no
+                  // subagent (the orchestrator fires the verification request and
+                  // parks the lane on an async verdict), so it can never be folded
+                  // into a delegated batch. Every stage before it is batchable.
+                  firmGate: true,
                 },
               ],
             },


### PR DESCRIPTION
Stacked on #7 (`perf/main-process-cpu`) — retarget to `main` once that merges.

Answers "can PTY workflow runs trigger their fan-out as Claude Code dynamic workflows instead of the manual orchestrator prose?" **Yes** — built, verified against the real CLI, and **off by default** (`fanOutDispatch` unset ⇒ prompts, spawn args, and worktree contents byte-identical to today).

## Two live defects fixed on the way

Both found by adversarial review, both independent of the feature:

1. **The tracker could not see workflow runs at all.** It resolved its launch watcher's worktree path only via `SELECT worktree_path FROM sessions`, and a flow run has no `sessions` row (`panelId === runId === sessionId`; `getDbSession` is undefined for it). No watcher ever started, so a dynamic workflow launched inside a PTY workflow run was invisible. `DynamicWorkflowRunContext` now carries the spawn's authoritative `worktreePath`.
2. **Quick sessions completed while a workflow was still running.** The turn-end listener flipped `sessions.status` to `'completed'` on the turn-end following a `Workflow` launch — reachable today via the Ultracode wizard card, which launches quick PTY sessions with exactly the setting that makes the agent fan out.

Plus a guard on `RunExecutor`'s interactive rest seam. Deliberately **no defer timer**: review showed a naive one can fire after a question gate is answered and park a run that is mid-turn again, and that a rejected rest is *not* a no-op — `onLifecycleTransition` runs its side effects anyway, including the compound close-out that clears finding selection.

## The design: batched, host-controlled dispatch

The first plan (one `Workflow` call swallowing a whole per-item lane chain) was **rejected by both reviewers**. It cannot preserve single-writer: lane moves, `attempt` bookkeeping, findings, and the per-task commit all sit *between* inner steps, and workflow subagents carry no cyboflow MCP tools by design. It also had nowhere to put `visual-verify`, which has no subagent at all.

What shipped instead:

- `FanOutInnerStep.firmGate` marks stages where the orchestrator must regain control. Consecutive non-gated stages dispatch as **one** workflow, and each item walks that whole sub-chain (`implement → write-tests → code-review → task-verify`) inside it, concurrently with other items, retrying its own loopback (bounded, 3 attempts). One dispatch instead of four, no barrier between stages.
- **Only `visual-verify` is a firm gate**, structurally: the orchestrator fires `cyboflow_request_verification` and parks the lane on an async external verdict. `ALWAYS_GATED_INNER_IDS` keeps it gated even if the flag is cleared.
- **Accepted trade:** lane `current_step` no longer ticks per stage inside a batch. Each result carries the item's full `trail`; the orchestrator backfills on return. The prompt states this explicitly.
- Results are schema'd with an explicit **domain outcome**, so a `code-review` that returns normally while reporting `REVIEW: BLOCKING` is not read as success.
- Rendering resolves `resolveRunFrozenSpec` (the variant graph the prompt walks), free-form ids are slugged and every emitted literal is `JSON.stringify`'d (path traversal + injection), and tests compile the output with `vm.Script` — `parseScriptMeta` is a fail-soft regex scanner and would accept broken source.

## Verified against claude 2.1.231

Probed empirically, not assumed:

- ✅ `Workflow` is available **without** the `ultracode` setting.
- ✅ A worktree-local `.claude/workflows/` **does** resolve by name.
- ✅ A completion notification **does** re-wake a yielded agent — the cycle the whole design rests on.
- ✅ The on-disk artifact contract matches the tracker exactly, and the completion record carries the script's return value.

## ⚠️ Before enabling

Dispatch is **permission-gated** (`"Review dynamic workflow before running"`). Only `agentPermissionMode === 'auto'` is verified end-to-end. `default`/`acceptEdits` is **untested** — whether cyboflow's PreToolUse `allow` pre-empts that gate is unknown. `dontAsk` is a trap: cyboflow documents it as "unrestricted", which holds for the SDK path but not the CLI flag of the same name, and on the interactive substrate it leaves the CLI's own gate prompting in a terminal with cyboflow's approval plumbing switched off.

Recommend gating the feature to `auto` until that case is probed.

## Gate

`pnpm typecheck` · `pnpm lint` (0 errors) · `pnpm test:integration` (25) · `pnpm test:unit` (8947 main + 3752 frontend, 0 failures). 58 new tests.

Design record: `docs/proposals/pty-dynamic-workflow-orchestration.md` (feasibility) and `pty-dynamic-workflow-implementation-plan.md` (v2, post-review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
