### PR TITLE
feat(omp): OMP fleet supervisor runtime (DCO-signed rebase of #10 onto 0.2.6)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,6 +51,14 @@ jobs:
       - name: Install Playwright (no browser download needed for Electron)
         run: pnpm exec playwright install-deps || true
 
+      # The launched app needs the ELECTRON ABI. postinstall normally leaves
+      # it there, but a restored pnpm store can carry a host-ABI
+      # better_sqlite3.node — then _electron.launch throws NMV 127-vs-136 on
+      # load and every spec times out in setup with no app-side error. Flip
+      # deterministically (cached file copy, no recompile).
+      - name: Ensure Electron ABI for better-sqlite3
+        run: node scripts/ensure-sqlite-abi.mjs electron
+
       # Blocking since 2026-08-14 (41/41 green nightlies). Drive the smoke tier
       # only — the 7-test minimal config with a proven CI track record.
       - name: Run smoke tier

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -86,7 +86,10 @@ jobs:
       run: pnpm test:unit
       env:
         CI: true
-      timeout-minutes: 10
+      # The chain is main suite + frontend suite + schema parity + release
+      # scripts + ABI + build tests. On ubuntu runners the two vitest legs
+      # alone approach 10 minutes; 10 was a timeout, not a pass.
+      timeout-minutes: 25
 
   # Blocking mocked-SDK integration tier (Tier-3). Runs in PARALLEL with `test`
   # (both only need `quality-checks`), so the PR critical path stays at

--- a/build/afterSign.test.js
+++ b/build/afterSign.test.js
@@ -954,12 +954,22 @@ async function caseV() {
   await caseC();
   await caseD();
   await caseE();
-  await caseF();
-  await caseG();
-  await caseH();
-  await caseI();
-  await caseJ();
-  await caseK();
+  if (process.platform === 'darwin') {
+    // Cases F–K exercise REAL macOS `codesign`/`lipo` against Mach-O
+    // fixtures (and dlopen a host-ABI addon); on Linux CI they can only fail
+    // for platform reasons, which proves nothing about the verification
+    // logic they exist to pin.
+    await caseF();
+    await caseG();
+    await caseH();
+    await caseI();
+    await caseJ();
+    await caseK();
+  } else {
+    console.log(
+      `SKIP: cases F-K are darwin-only (host is ${process.platform}); codesign/lipo/Mach-O probes cannot run here.`,
+    );
+  }
   await caseL();
   await caseM();
   await caseN();

--- a/docs/proposals/omp-phase3-command-adr.md
+++ b/docs/proposals/omp-phase3-command-adr.md
@@ -1,0 +1,165 @@
+# ADR: OMP Phase 3 — transport reality check, supervisor identity, and the apply go/no-go
+
+Status: **NO-GO for Phase 3 command implementation.** The transport prerequisite
+does not exist in the producer today. This ADR records the decision, the
+falsification test that would re-open it, and the identity + gating rules that
+apply once it re-opens.
+
+It settles the three prerequisites `docs/proposals/omp-substrate-plan.md`
+§Phase 3 names as blocking — transport, supervisor identity, PASS-bound apply —
+and corrects two errors in that section (a speculative transport surface that
+does not exist, and an apply/discard gating asymmetry).
+
+---
+
+## 1. Verified ground truth (producer repo, read this session)
+
+| Surface | Reality (verified against `OMP-fleet-management`) |
+|---|---|
+| `fleet_*` tools (`fleet_spawn`, `fleet_proposal_*`, `fleet_verification_*`) | **In-session only.** Production `extensions/fleet/index.ts:712+` calls `pi.registerTool({ name, parameters, execute })` to register each tool into the OMP session's ExtensionAPI; tests merely supply mock `ExtensionAPI`s to invoke them. The narrow, provable claim from this repo: **Fleet itself implements no external listener, framing, handshake, or auth transport** — no MCP server, no `@modelcontextprotocol`/fastmcp integration, no HTTP tool endpoint, no Unix-socket RPC exposing the Fleet controller. Whether the OMP **core** re-exposes these in-session tools over an external transport is unverified from this side. |
+| herdr Unix-socket JSON-RPC (`extensions/fleet/socket-client.ts`) | **Pane lifecycle only** (split/read/focus/pane spawn). Never reaches proposal apply, discard, or verification proof. Not a supervisor transport. |
+| one-shot `omp -p` (`extensions/fleet/client.ts:180`) | **Prompt-mediated spawn.** No apply/discard/verify. Nondeterministic framing for a privileged mutation. |
+| `omp --mode rpc` host-tools / `set_subagent_subscription` | **Does not exist.** Speculative text in the plan doc; no such surface in the producer. |
+| Observability HTTP server (`extensions/observability/dashboard.ts`) | Localhost-only, **no auth**, read-only dashboard. Not a control-plane transport. |
+
+**Conclusion of §1:** there is **no externally-callable, authenticated,
+structured control-plane transport** in the producer. The `fleet_*` tools exist
+only inside an OMP session, reachable by that session's agent — not by a
+separate process such as Cyboflow's main.
+
+If such an endpoint exists in the OMP **core** (a separate repo, not
+`OMP-fleet-management`), it is unverified and undocumented from this side, which
+is equivalent to "does not exist" for planning a consumer. We do not build
+against an assumed surface.
+
+---
+
+## 2. Non-negotiables (carried from producer, unchanged)
+
+1. Workers never write the host repo. `May[GitRepo, ReadWrite]` on the host
+   belongs only to the apply controller.
+2. Apply is privileged and separate from spawn/kill/verify.
+3. A signed, unexpired PASS binds the exact proposal, worker, run, trace, base
+   revision, normalized changed paths, Shepherd `candidate_head`, policy,
+   profile, and verifier version. The builder cannot mint its own PASS
+   (`ARCH.md:11`).
+4. `proposal_ready` ≠ done.
+5. **Discard never requires PASS** — unsafe work must always remain discardable
+   (`ARCH.md:13`).
+6. **Shadow is not enforcement** — shadow may allow apply for rollout
+   compatibility with an explicit warning, never silent authorization
+   (`ARCH.md:14`).
+7. Callers pass only `proposal_id` (plus `reason` for apply/discard). Cyboflow
+   never supplies gate argv or proof blobs; the producer resolves and binds both.
+8. Audit fail-closed: no sink → refuse; every attempt records redacted
+   attempted + completed (including forbidden and thrown), one `operationId`
+   throughout.
+
+---
+
+## 3. Decision 1 — transport: NO-GO
+
+**Decision:** Phase 3 command implementation does **not** proceed. Cyboflow
+does **not** invent a control-plane transport.
+
+**Why.** Every command surface that matters (`spawn`, `kill`,
+`fleet_proposal_apply`, `fleet_proposal_discard`, `fleet_verification_*`) is
+producer-side. §1 shows none is externally callable today. Any of the apparent
+options collapses on inspection:
+
+- **In-session `fleet_*` tools** — not reachable by an external process; there is
+  no listener, framing, handshake, or auth to consume.
+- **herdr socket** — wrong layer (pane lifecycle, bypasses the Fleet controller's
+  scope/authority logic entirely).
+- **`omp -p`** — prompt-mediated and nondeterministic; and it never reaches
+  apply/discard/verify at all.
+- **Build our own endpoint in Cyboflow** — would fork the producer's authority
+  model and give the machine-local app worker-equivalent authority, the exact
+  collapse the producer forbids.
+
+**Re-opening gate (what must become true):** the producer ships a documented,
+authenticated, structured external control-plane endpoint (MCP server or RPC)
+that exposes `fleet_*` with per-caller identity, and states its auth model.
+Until that lands, "OMP-capable" remains honestly unclaimed. The renderer stays
+read-only (`cyboflow.omp.fleetSnapshot`), and the command router stays stubbed.
+
+---
+
+## 4. Decision 2 — supervisor identity (design intent, deferred until transport exists)
+
+**Decision:** when transport exists, the `omp:supervise` capability is granted
+**only** to an out-of-process supervisor child; Electron main never holds it,
+main is a proxy.
+
+**Why.** Cyboflow's main process is itself a worker substrate — it runs workflow
+agents, and its renderer is worker-reachable. If main held the supervisor
+credential, any renderer escalation lands on supervisor authority. The
+producer's model ("workers submit-only; spawn/kill/verify/apply supervisor-only")
+demands the authority live where a worker cannot escalate into it.
+
+**Shape (for when it re-opens, not now):** a small `omp-supervisor` child owns
+the OMP session/credential; main talks to it over a local authenticated Unix
+socket with per-connection auth and a pinned process; the child enforces
+capability. `hasSupervise(ctx.principal)` in `trpc/routers/ompCommand.ts` stays
+the renderer-facing gate, but its v1 source of truth becomes "the supervisor
+child accepted the principal", not `ctx.userId === 'local'`. v1 default remains
+**supervise off**.
+
+**Rejected:** granting `omp:supervise` to Electron main directly (collapses
+"local app = worker authority"); to the renderer (immediate no).
+
+This decision is recorded now so the transport choice is *not* revisited in a
+way that silently grants main the credential; it is not executed until §3's
+gate clears.
+
+---
+
+## 5. Decision 3 — apply vs discard vs lifecycle/verification
+
+Once transport exists (§3 gate), the surfaces gate **differently**. The plan doc
+and the prior stub lumped them together; that was wrong.
+
+| Surface | Gate (after transport exists) |
+|---|---|
+| `spawn`, `kill` | Supervisor-authorized + audited + idempotent. Proceed. |
+| `fleet_verification_candidate` / `run` / `status` / `proof` | Supervisor-authorized + audited. Candidate-bound (Cyboflow passes `proposal_id` only). Proceed. |
+| `fleet_proposal_discard` | Supervisor-authorized + audited + idempotent. **No PASS required, no enforce-mode requirement** — `ARCH.md:13`. Proceed once transport exists, else Cyboflow can create retained proposals it cannot clean up. |
+| `fleet_proposal_apply` | **Hard-disabled** until *all* of: (1) transport exists; (2) producer reports **enforce** mode active (not `off`, not `shadow`) — `ARCH.md:10` denies enforce outright until Shepherd supplies an expected-candidate-head settlement guard; (3) an exact candidate-bound PASS is the only path to settlement. |
+
+**Never treat shadow success as authorization** (`ARCH.md:14`). A shadow "apply"
+is a disclosed proof gap, not a green light; Cyboflow's apply stays unavailable
+until enforce is real, at which point a real adapter may surface a producer
+`blocked`/`shadow` verification outcome verbatim.
+
+**Rejected:** shipping apply behind shadow; a Cyboflow-side proof check
+substituted for the producer's candidate-bound re-inspection (inverts the trust
+boundary); gating discard on PASS (violates `ARCH.md:13` and strands retained
+proposals).
+
+---
+
+## 6. Consequences
+
+- **Now:** no Phase 3 command code. The `ompCommand` router remains stubbed, and
+  the stub keeps returning `unavailable` for **every** method while no transport
+  exists. `blocked`/`shadow` are producer verification outcomes
+  (`shared/types/ompCommand.ts:88-92`: "a BLOCKED candidate is not a PASS"), not
+  transport states, so a stub returning `blocked` for "transport absent" would
+  misreport producer policy. A real adapter may surface `blocked` only after an
+  actual enforce/PASS gate denial. The read-only visibility surface
+  (§Phase 0–1) is unchanged and already shipped.
+- **The deliverable from this ADR is the go/no-go, not code.** The next action
+  is producer-side: identify or build the authenticated external control-plane
+  endpoint. Cyboflow-side work resumes only after §3's gate is demonstrated.
+- **Riskiest assumption, restated:** that a machine-local Electron app can reach
+  the OMP control plane as a supervisor without granting worker-equivalent
+  authority. It is currently **unfalsifiable** because the transport to test it
+  does not exist; the ADR refuses to proceed on assumption.
+
+## 7. Out of scope (later ADRs)
+
+- The coexistence decision (whether a workflow run executes *on OMP as a
+  substrate* — `AgentProvider`/`AbstractCliManager` widening). Follows this ADR,
+  never precedes it.
+- Auxiliary read sources (Shepherd traces, proofs, observability, beads,
+  reverie) — separate interfaces, Phase 4.

--- a/docs/proposals/omp-phase4-coexistence-adr.md
+++ b/docs/proposals/omp-phase4-coexistence-adr.md
@@ -1,0 +1,181 @@
+# ADR: OMP Phase 4 — coexistence: OMP as a remote runtime beside the process seam
+
+Status: **GO for v1 (quick-session scope).** OMP becomes a first-class runtime in the
+quick-session agent-runtime picker, backed by a separate `OmpSessionManager` that sits
+**beside** the `AbstractCliManager` family and is **fail-closed** on the Phase-3 bridge
+config. Workflow-step execution on OMP is a named follow-up increment, not v1.
+
+This is the coexistence decision `omp-substrate-plan.md` §Phase 4 gates: whether
+`AgentProvider`/`AbstractCliManager` can be extended so a Cyboflow session *runs on OMP
+as a substrate*. It follows the Phase-3 ADR and does not re-open its transport decision —
+it records that the Phase-3 gate has now cleared on the consumer side.
+
+---
+
+## 1. Transport reality (the Phase-3 gate has cleared, consumer-side)
+
+The Phase-3 ADR (`omp-phase3-command-adr.md` §3) declared **NO-GO** because the producer
+exposed no externally-callable, authenticated, structured control-plane transport. That
+premise has changed: the **OMP Prime bridge** now ships exactly the surface the ADR asked
+for — an externally-callable, bearer-token-authenticated, structured MCP endpoint
+(`POST /mcp/v1/sessions/<sessionId>`), already implemented and verified in this repo:
+
+- `main/src/orchestrator/omp/ompBridgeClient.ts` — `OmpBridgeHttpClient.callTool`
+  (JSON-RPC 2.0 `tools/call`, bearer auth, loopback-only URL, structured content out).
+- `main/src/orchestrator/omp/ompBridgeConfig.ts` — `resolveOmpBridgeCommandConfig`
+  (loopback URL + 0600 token file + session id; `undefined` when any piece is missing).
+- `main/src/orchestrator/omp/ompBridgeCommandAdapter.ts` — already maps
+  `spawn → fleet_spawn`, `kill → fleet_kill` (plus apply/discard/verify) with the
+  snake_case↔camelCase translation owned here, never by callers.
+
+**Consequence:** the "no transport" blocker is gone. The remaining Phase-3
+non-negotiables are unchanged and still hold: `omp:supervise` is granted **only** when
+`CYBOFLOW_OMP_SUPERVISE` is truthy (`ompPrincipal.ts`); audit is fail-closed; a BLOCKED
+candidate is not a PASS; shadow is not enforcement; Cyboflow never passes gate argv or
+proof blobs.
+
+## 2. Non-negotiables (carried, unchanged)
+
+1. **Do NOT widen `AbstractCliManager`.** It is the process-stream seam for *local*
+   child processes (PTY/SDK). An OMP session is a **remote** OMP worker; Cyboflow
+   supervises it over the bridge — it has no local child process, no PTY, no
+   stdout stream. Winding it through the 1220-line `AbstractCliManager` base would
+   force a fake `CliProcess` stub and mis-model the lifecycle. OMP sits **beside** it.
+2. **Workers submit-only; spawn/kill/verify/apply are privileged, supervisor-only**,
+   with identity + audit. Cyboflow-as-substrate is a supervisor. Every OMP runtime call
+   goes through the `OmpCommandAdapter` behind the `hasSupervise` capability, never a
+   worker-reachable path.
+3. **Fail-closed availability.** When `resolveOmpBridgeCommandConfig()` is `undefined`
+   (no bridge / token / session id) **or** the `omp` provider access toggle is off, the
+   OMP runtime is **hidden** from the picker and any attempt to launch it returns a
+   clear `unavailable` — never a silent no-op, never a fallback to a local provider.
+4. **No `AgentProvider` widening until this ADR exists.** This document is that gate.
+   The `agentRuntime.ts` changes land *with* this ADR as increment 1.
+
+## 3. Decision — OMP as a runtime, beside the process seam
+
+**Decision:** add `AgentProvider = 'omp'` and `AgentRuntime = 'omp-fleet'`, driven by a
+new `OmpSessionManager` (a **sibling**, not a subclass, of the four
+`AbstractCliManager` managers). It implements the narrow chat surface the IPC layer
+consumes — `spawn`, `sendInput`, `stop`, `isPanelRunning`, and `output`/`exit` events —
+by mapping onto the fleet lifecycle, with **no** child process:
+
+| Chat lifecycle (IPC surface) | Fleet tool | Notes |
+|---|---|---|
+| `spawn(panelId, …, prompt)` | `fleet_spawn` { task: prompt, workspace, model, execution_mode } | returns worker id; stored on the panel |
+| `sendInput(panelId, text)` | `fleet_send` { worker_id, message } | follow-up turns steer the same worker |
+| `output` (poll) | `fleet_read` { worker_id } | new output since last read, emitted as `output` events |
+| liveness / exit detection | `fleet_state` { worker_id } | leaves `running` ⇒ emit `exit` (terminal) |
+| `stop(panelId)` | `fleet_kill` { worker_id } | deliberate termination |
+
+One panel ≙ one OMP worker. The first message spawns; subsequent `sendInput` calls steer
+the same worker; the panel emits the same `output`/`exit` event shapes the UI already
+consumes for the other runtimes.
+
+**Rejected:**
+- **`OmpCliManager extends AbstractCliManager`** — forces a fake `CliProcess` and models
+  a remote worker as a local process; the ADR forbids widening the process seam.
+- **A 5th `PanelLane` (provider × substrate)** — OMP is not a substrate axis; it is a
+  whole different transport. A dedicated manager + dispatch branch is the honest shape.
+- **Routing OMP through the existing 4 managers** — none of them has a bridge transport;
+  inventing one inside a manager would fork the Phase-3 authority model.
+
+## 4. Scope — v1 is quick-session only
+
+**v1:** the **quick-session** runtime picker (`SubstrateSelector.RUNTIME_OPTIONS` and
+`SessionAgentRuntime`) offers **OMP Fleet**, gated by availability (§2.3). That is the
+surface in the user's screenshot ("agent runtime dropdown got no omp") and the minimal
+real, verifiable slice.
+
+**Named follow-up increment (NOT v1):** the **workflow-step** runtime picker
+(`WorkflowAgentRuntime` / step inspector / global Agents editor) and `spawnStepRunner`
+dispatch. Workflow steps carry richer lifecycle needs (step-scoped reporting, handoff,
+deterministic run bookends) that a separate increment must design; shipping them in v1
+would enlarge the highest-risk change (the dispatch file) without the design work.
+`AgentRuntime` therefore keeps `'omp-fleet'` as a session runtime; workflow inclusion is
+the documented next step.
+
+## 5. Availability + gating (concrete)
+
+- **Aria mode is the grant + the flavor switch.** `AppConfig.ariaMode`
+  (Settings → Advanced Options → OMP Runtime) answers both "does this install
+  supervise a REMOTE fleet or run OMP locally" and "is Cyboflow authorized to
+  drive it". `omp-fleet` and `omp-sdk`/`omp-pty` are ALTERNATIVES — a panel is
+  either a local OMP process or a supervised remote worker — so the picker
+  offers one flavor or the other, never both. `CYBOFLOW_OMP_SUPERVISE` remains
+  an override for headless/CI hosts with no Settings UI; the two are OR-ed.
+  Requiring a shell variable to switch on a desktop feature was a real usability
+  failure, not a security property: reachability of the bridge and authorization
+  to drive it stay separate questions, but the operator answers the second one
+  by clicking, not by exporting.
+- **Fail-closed config:** `OmpSessionManager` is constructed **only** when
+  `resolveOmpBridgeCommandConfig()` resolves **and** the boot principal holds
+  `omp:supervise`. Either one missing ⇒ no manager instance ⇒ dispatch returns
+  `unavailable` and the picker omits the entry. A half-configured bridge must never
+  silently authorize a session, and a *fully* configured one must not either: config
+  says the fleet is REACHABLE, the capability says this operator authorized Cyboflow to
+  drive it. Those are different questions and both have to answer yes.
+- **Provider access toggle:** `AGENT_PROVIDERS` gains `'omp'`, so the existing
+  `AgentProviderAccess` toggle system works for OMP with zero new gating code. The OMP
+  entry is visible **only if** `isAgentProviderEnabled(access, 'omp')` **AND** the bridge
+  config resolved.
+- **`cyboflow.omp.availability` reports the manager, not the config.** It asks whether
+  the boot-built `OmpSessionManager` EXISTS rather than re-deriving
+  `resolveOmpBridgeCommandConfig()`. Re-deriving would let the picker offer OMP fleet the
+  instant Aria mode is toggled while dispatch still answered "the bridge is not
+  configured" until the next launch; asking the manager keeps the picker and the dispatch
+  seam telling one story. `ariaMode` rides the same probe and IS live, because the flavor
+  split is pure presentation.
+- **Capability:** enforcement is **structural, not by convention**. Every adapter handed
+  to a caller — the tRPC context's and the session manager's alike — is wrapped in
+  `OmpSupervisedAdapter`, which capability-checks all eight verbs and audits the six
+  mutating ones (ATTEMPTED + COMPLETED, correlated on `operationId`). The two read-only
+  poll verbs are gated but deliberately unaudited: at `OMP_DEFAULT_POLL_MS` per live
+  panel they would bury the mutation trail.
+
+  This replaces an earlier arrangement in which only the `ompCommand` router checked
+  `hasSupervise`. `OmpSessionManager` drives the SAME privileged surface from the panel
+  seams, so a bare adapter put the product's actual path outside the authorization model:
+  spawn and kill ran unchecked and unaudited while the router answered FORBIDDEN for the
+  same verbs. Wrapping is what makes "workers never receive the supervise surface" a
+  property of the type rather than a rule each new seam has to remember.
+- **Loopback is checked by parsed hostname**, not string prefix. The config carries a
+  bearer token the client sends to whatever host it names, and
+  `startsWith('http://127.0.0.1')` accepts `http://127.0.0.1.evil.example/`. The token
+  file's owner-only mode is enforced rather than assumed.
+- **Teardown is explicit.** OMP workers are REMOTE: nothing about a panel closing, a
+  session being dismissed, or the app quitting stops them. Dismiss and `before-quit` both
+  call into the fleet manager directly, because `resolvePanelLane` maps these
+  `'claude'`-typed panels onto the `omp-sdk` lane whose manager never spawned them.
+
+## 6. Consequences / increments
+
+**Storage:** the `omp-fleet` runtime is admitted on `sessions.agent_runtime` and
+`workflow_runs.agent_runtime` by migration **105**, which reuses 103's additive
+DROP/re-ADD-column recipe. It is deliberately NOT a table rebuild: the migration ledger
+is keyed by filename, so a new file numbered into a gap below an already-released
+migration runs LAST on an upgraded DB, and a hardcoded `CREATE TABLE sessions` there
+drops every column it fails to list (`status_message`, added imperatively by
+`database.ts`, is the live example) and restates 103's CHECK lists from memory —
+un-widening `omp-sdk`/`omp-pty` on exactly the installs that use them.
+
+**Status:** increment 1 (types) and increment 2 (adapter `send`/`read`/`state`) are
+landed and gate-green. Increments 3-5 are pending.
+
+- **Increment 1 (this ADR + types):** land `agentRuntime.ts` widening (provider `omp`,
+  session runtime `omp-fleet`, label, `providerForRuntime`, disabled-pattern) *together*
+  with this document. No behavior yet — pure types, so the full gate stays green.
+- **Increment 2 (adapter):** extend `OmpCommandAdapter` + `OmpBridgeCommandAdapter` with
+  `send`/`read`/`state` (the chat-lifecycle tools), verified against the live bridge
+  response shapes.
+- **Increment 3 (manager):** `OmpSessionManager` beside the four managers.
+- **Increment 4 (wiring + picker):** dispatch lane + quick-session picker entry,
+  gated by availability.
+- **Increment 5 (tests + full gate).**
+
+## 7. Out of scope
+
+- Workflow-step execution on OMP (named follow-up, §4).
+- Auxiliary read sources (Shepherd, proofs, observability, beads, reverie) — separate
+  interfaces.
+- Granting `omp:supervise` to anything other than the Phase-3 principal model.

--- a/docs/proposals/omp-substrate-plan.md
+++ b/docs/proposals/omp-substrate-plan.md
@@ -1,0 +1,264 @@
+# Cyboflow → OMP-aware → OMP-capable: implementation plan
+
+Status: **ready to begin the rebuild, NOT ready to claim capability.**
+The four read-adapter files exist and are verified but are untracked and unwired.
+This plan sequences the work so every phase is independently reviewable and
+shippable, with the authority model settled before any command is implemented.
+
+## Ground truth (verified against the live tree)
+
+- OMP producer (`OMP-fleet-management`) has a merged versioned registry
+  contract; `parseRegistrySnapshot` returns `ok | unsupported-version | malformed`
+  and the producer sanctions consumer copies.
+- Cyboflow has four untracked files: `shared/types/omp.ts`,
+  `main/src/orchestrator/omp/registryContract.ts`,
+  `main/src/orchestrator/omp/fleetRegistryReader.ts`,
+  `main/src/orchestrator/omp/fleetRegistryReader.test.ts`.
+- Seams:
+  - `main/src/orchestrator/types.ts` → `OrchestratorDeps` (narrow, constructor-injected).
+  - `main/src/orchestrator/trpc/trpc.ts` → `router`, `publicProcedure`,
+    `protectedProcedure` (asserts `ctx.userId`).
+  - `main/src/orchestrator/trpc/context.ts` → `createContext(deps)`; every dep is
+    an optional narrow `*Like` interface or closure, injected from
+    `main/src/index.ts` (the composition root) to preserve the standalone invariant.
+  - `main/src/orchestrator/trpc/router.ts` → `appRouter` combines sub-routers
+    under `cyboflow.*`; sub-routers live in `routers/*.ts` and import only
+    `../trpc`, pure functions, and `shared/types`.
+  - `main/src/ipc/types.ts` → `AppServices` bag.
+  - `shared/types/agentRuntime.ts` → `AgentProvider = 'claude' | 'codex'` (do NOT widen).
+  - `main/src/services/panels/cli/AbstractCliManager.ts` → process-stream seam (do NOT widen).
+- Standalone invariant (`docs/ARCHITECTURE.md:73-75`): `main/src/orchestrator/**`
+  must not value-import `electron`, `better-sqlite3`, or `services/*`.
+  `node:fs` is allowed (precedent: `verify/depPreparer.ts`, `verify/snapshotProvisioner.ts`,
+  `verify/verdictDelivery.ts`, `design/designHandoffService.ts`).
+
+## Non-negotiable constraints
+
+1. **Authority model** (from the OMP producer): workers are submit-only;
+   `spawn`/`kill`/`verify`/`apply` are privileged, supervisor-only, with
+   authenticated identity + audit. Cyboflow-as-substrate is a supervisor.
+2. **No `AgentProvider` widening, no `AbstractCliManager` widening** until a
+   separate lifecycle/capability interface exists. It coexists beside, never
+   stretches, the transcript seam.
+3. **Read surfaces** use `publicProcedure`/`protectedProcedure`; **command
+   surfaces** use `protectedProcedure` + explicit identity/audit and are never
+   reachable from a worker path.
+4. Auxiliary read sources (Shepherd, proofs, observability, beads, reverie) are
+   later optional increments, not a gate before capability work.
+
+---
+
+## Phase 0 — commit the read adapter (unblocks everything)
+
+Goal: get the four verified files out of "untracked" and onto a branch.
+
+- `git add shared/types/omp.ts main/src/orchestrator/omp/`
+- `git commit -m "feat(omp): add read-only fleet-registry adapter"`
+- Verify: `npx tsc --noEmit` (main), `npx vitest run src/orchestrator/omp` (16/16).
+
+Acceptance: a commit exists; the four files are tracked; scoped gates green.
+Riskiest thing here is only hygiene (the files are already double-reviewed).
+
+## Phase 1 — wire the reader (finish "aware", read-only)
+
+Goal: instantiate `FleetRegistryReader` as a service and expose one read-only
+tRPC procedure so the renderer can display a fleet snapshot.
+
+New files:
+- `main/src/orchestrator/omp/ompService.ts` — thin `OmpService` that owns the
+  `OmpControlPlaneAdapter` instance and caches the last snapshot (optional:
+  plain pass-through first, caching later).
+- `main/src/orchestrator/trpc/routers/omp.ts` — `ompRouter`.
+
+`ompRouter` (sketch):
+```ts
+import { router, protectedProcedure } from '../trpc';
+import type { OmpSnapshotResult } from '../../../../../shared/types/omp';
+
+export const ompRouter = router({
+  fleetSnapshot: protectedProcedure.query(async ({ ctx }): Promise<OmpSnapshotResult> => {
+    const omp = ctx.omp; // narrow OmpControlPlaneAdapter | undefined
+    if (!omp) {
+      return { ok: false, error: 'unavailable', detail: 'OMP adapter not configured' };
+    }
+    return omp.getFleetSnapshot();
+  }),
+});
+```
+
+Touched existing files:
+- `context.ts`: add `omp?: OmpControlPlaneAdapterLike` to `ContextDeps` and
+  `createContext` (narrow interface: `{ getFleetSnapshot(): Promise<OmpSnapshotResult> }`).
+- `router.ts`: add `omp: ompRouter` under `cyboflow`.
+- `main/src/index.ts` (composition root): construct `new FleetRegistryReader()`
+  and pass it into `createContext({ omp })`.
+- `shared/types/trpc.ts` (or the inferred `AppRouter`): picks up the new
+  procedure automatically; add the renderer query hook type.
+
+Acceptance: renderer can call `cyboflow.omp.fleetSnapshot` and receive the
+discriminated result; missing file → `unavailable`, not a crash.
+Verify: `pnpm typecheck`, `npx vitest run src/orchestrator/omp src/orchestrator/trpc`.
+
+Note: `getFleetSnapshot` is the ONLY surface exposed. No mutation. This is the
+end of "OMP-aware" for the registry.
+
+## Phase 2 — the capability/lifecycle interface (declared, authoritative, STUBBED)
+
+Goal: declare the privileged command surface as TYPES that mirror the
+producer's ACTUAL tool surface, with a real per-caller principal + capability
+check and redacted audit. This is a declared contract, NOT capability —
+reworded: a stub makes the contract type-checkable; it does not make Cyboflow
+"capable."
+
+### Producer command inventory (verified — this is the contract Cyboflow mirrors)
+
+Lifecycle (read + lifecycle, lower privilege):
+- `fleet_spawn` — { model, task, label?, target?, workspace?, cwd?, timeout?,
+  execution_mode?, intent?, scope? } → worker id
+- `fleet_list` / `fleet_state` / `fleet_read` / `fleet_wait` / `fleet_kill` —
+  read/observe/terminate workers
+
+Proposal (the privileged surface, supervisor-only):
+- `fleet_proposal_list` / `fleet_proposal_read` / `fleet_proposal_diff` (read)
+- `fleet_proposal_apply` — { proposal_id, reason } — canonical-authority + scope
+  + CAS + candidate-bound proof checked by the producer
+- `fleet_proposal_discard` — { proposal_id, reason } — first-class unprivileged
+  mutation; unsafe work is always discardable
+
+Verification (candidate-bound; the builder cannot mint its own PASS):
+- `fleet_verification_candidate` → canonical candidate digest
+- `fleet_verification_run` → signed PASS/FAIL/BLOCKED (argv from host policy only)
+- `fleet_verification_status` / `fleet_verification_proof`
+
+There is NO `fleet_verify` or `fleet_apply` tool. Verify is
+`fleet_verification_*`; apply is `fleet_proposal_apply`. Callers pass only
+`proposal_id` (plus a `reason` for apply/discard); the producer resolves and
+binds the candidate digest/proof — Cyboflow never passes arbitrary gate argv
+or proof blobs.
+
+### Identity — the unfalsifiable-authority fix
+
+`ctx.userId` is hardcoded `'local'` today (`trpc.ts`/`context.ts`). A
+`protectedProcedure` + `ctx.supervisor` presence check would therefore authorize
+every local caller — the exact collapse the producer forbids. Phase 2 must add
+an immutable principal + capability, not rely on presence:
+
+```ts
+// shared/types/ompCommand.ts
+export interface OmpPrincipal {
+  readonly userId: string;                 // immutable per request
+  readonly capabilities: ReadonlySet<string>;
+}
+export function hasSupervise(p: OmpPrincipal): boolean {
+  return p.capabilities.has('omp:supervise');
+}
+```
+
+`createContext` gains `principal?: OmpPrincipal`; the command router asserts
+`hasSupervise(ctx.principal)` and throws `FORBIDDEN` otherwise — independent of
+`ctx.userId === 'local'`. In v1 this is gated behind a config flag (supervise
+capability off by default); v2 populates it from a real session token.
+
+### Command contract (typed against the real surface)
+
+```ts
+export interface OmpCommandAdapter {
+  readonly authority: 'supervise';
+  // lifecycle
+  spawn(req: OmpSpawnRequest): Promise<OmpCommandResult>;
+  kill(req: OmpKillRequest): Promise<OmpCommandResult>;
+  // proposal (privileged)
+  apply(req: OmpApplyRequest): Promise<OmpCommandResult>;   // { proposalId, reason }
+  discard(req: OmpDiscardRequest): Promise<OmpCommandResult>;
+  // verification (candidate-bound)
+  verifyRun(req: OmpVerifyRequest): Promise<OmpCommandResult>; // { proposalId }
+}
+
+export type OmpCommandResult =
+  | { ok: true; operationId: string; detail: string }
+  | { ok: false; error: 'unavailable' | 'forbidden' | 'conflict' | 'blocked' | 'shadow'; detail: string };
+```
+
+Notes: every result carries an `operationId` for idempotency/correlation;
+`blocked` and `shadow` are distinct (a BLOCKED candidate is not a PASS; shadow
+is not enforcement). `timeout`/cancel live on the request types (spawn/kill)
+and are threaded to the producer, not dropped.
+
+### Audit (redacted, attempted + completed)
+
+- `audit('omp.spawn', { principal: ctx.principal.userId, input })` — ATTEMPTED,
+  input redacted (task text, scope paths scrubbed).
+- `audit('omp.spawn', { principal, operationId, result })` — COMPLETED, result
+  detail redacted.
+
+The audit surface must be an existing narrow interface, not a new "TBD" —
+locate the concrete service in `main/src/services` during Phase 2; if none
+exists, Phase 2 scopes to a local in-memory ring buffer and names the real
+surface as a Phase 2.5 dependency, not a silent gap.
+
+New files: `shared/types/ompCommand.ts`, `main/src/orchestrator/omp/ompCommandStub.ts`,
+`main/src/orchestrator/trpc/routers/ompCommand.ts`.
+Touched: `context.ts` (principal + command adapter + audit), `router.ts`, `index.ts`.
+
+Acceptance: command router is protected by `hasSupervise` (not presence); every
+call is audited (attempted + completed, redacted); all methods are stubbed
+`unavailable` + `operationId`. NO real command runs.
+Verify: `pnpm typecheck`; router unit tests assert (a) a non-supervise principal
+is rejected FORBIDDEN, (b) audit records both events, (c) stubs return
+`unavailable`.
+
+## Phase 3 — command implementations (SEPARATE ADR; do not start from this doc)
+
+Goal: implement the real command surface behind `OmpCommandAdapter`. This is
+deliberately NOT scheduled here — it is its own ADR with its own go/no-go.
+That ADR exists: `docs/proposals/omp-phase3-command-adr.md`.
+
+**Current status (from the ADR): NO-GO.** There is no externally-callable,
+authenticated, structured control-plane transport in the producer today — the
+`fleet_*` tools are in-session only (`pi.registerTool`), the herdr socket is
+pane-lifecycle only, and `omp -p` is prompt-mediated spawn. The earlier "one of
+(a) MCP fleet_* / (b) `omp --mode rpc` / (c) `omp -p`" framing was wrong:
+`omp --mode rpc` and `set_subagent_subscription` do not exist, and neither
+herdr nor `omp -p` reaches apply/discard/verify. The ADR records the
+re-opening gate (a producer-owned authenticated endpoint) and the identity +
+gating rules that apply once it lands.
+
+Non-negotiables carried from the producer (unchanged): workers never write the
+host repo; apply is privileged and separate; a PASS is candidate-bound; the
+builder cannot mint its own PASS; `proposal_ready` ≠ done; **discard never
+requires PASS**; shadow is not enforcement.
+
+## Phase 4 — auxiliary read sources + the coexistence decision
+
+Goal: fill in the remaining read surfaces behind SEPARATE interfaces (not
+`OmpControlPlaneAdapter`, which only exposes `getFleetSnapshot`), aggregated by
+an OmpAwarenessService. Then decide whether `AgentProvider`/`AbstractCliManager`
+coexistence is worth it.
+
+- Each source is its own adapter + its own increment, behind its own narrow
+  interface, aggregated by `OmpAwarenessService`:
+  - Shepherd project store (traces)
+  - verifications proofs (candidate-bound PASS/FAIL/BLOCKED)
+  - observability `catalog.db`
+  - beads (work state)
+  - reverie (compact learnings)
+- The coexistence decision: given the `OmpCommandAdapter` (Phase 2) exists
+  beside `AbstractCliManager`, decide whether a workflow run can *execute on
+  OMP as a substrate*. This is a design decision (an ADR), not a code sprint,
+  and it follows the Phase 3 ADR, not precedes it.
+
+Acceptance: each read source lands as its own reviewed, tested increment behind
+its own interface; the coexistence decision is written down before any
+`AgentProvider` change.
+
+## Riskiest assumption
+
+That the OMP control-plane command surface (`fleet_spawn`/`fleet_kill`/
+`fleet_verification_*`/`fleet_proposal_apply`/`fleet_proposal_discard`) can be
+invoked from Cyboflow's main process without granting worker-equivalent
+authority to a machine-local Electron app. It is first tested in the **Phase 3
+ADR** — specifically by proving a non-supervise principal is rejected by the
+`hasSupervise` capability check before any apply reaches the producer, and that
+apply is candidate-bound (the producer resolves the digest/proof; Cyboflow never
+passes gate argv or proof blobs). If that cannot be demonstrated cleanly,
+Phases 3-4 stay behind a go/no-go and "capable" remains honestly unclaimed.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,7 @@ import { useDesignModeStore } from './stores/designModeStore';
 import { AgentRail, shouldShowAgentRail } from './components/agentRail/AgentRail';
 import { useAgentThreadStore } from './stores/agentThreadStore';
 import { useMcpHealthStore } from './stores/mcpHealthStore';
+import { useOmpFleetStore } from './stores/ompFleetStore';
 import { useReviewQueueSlice } from './stores/reviewQueueSlice';
 import { useReviewQueueStore } from './stores/reviewQueueStore';
 import { useReviewItemsSlice } from './stores/reviewItemsSlice';
@@ -129,6 +130,13 @@ function App() {
     const unsubscribe = subscribeToMcpHealth();
     return unsubscribe;
   }, [subscribeToMcpHealth]);
+
+  // Start the OMP fleet polling subscription on mount (read-only awareness).
+  const subscribeToOmpFleet = useOmpFleetStore((s) => s.subscribeToOmpFleet);
+  useEffect(() => {
+    const unsubscribe = subscribeToOmpFleet();
+    return unsubscribe;
+  }, [subscribeToOmpFleet]);
 
   // Subscribe to stuck-run events so RunStatusMap stays current for the lifetime
   // of the app shell (not just while ReviewQueueView is mounted).

--- a/frontend/src/components/OmpFleetIndicator.tsx
+++ b/frontend/src/components/OmpFleetIndicator.tsx
@@ -1,0 +1,153 @@
+/**
+ * OmpFleetIndicator — colored dot reflecting OMP fleet awareness.
+ *
+ * Dot colors:
+ *   available → green  (bg-status-success)  — registry parsed, N workers
+ *   absent    → gray   (bg-text-muted)      — no registry (OMP never ran here)
+ *   error     → red    (bg-status-error)    — malformed / unsupported-version
+ *   checking  → yellow (bg-status-warning)  — transport failure, snapshot stale
+ *
+ * Clicking opens a popover with worker count / error kind / detail.
+ * Read-only by construction: the renderer has no command surface; this only
+ * renders the snapshot the read adapter already validated.
+ *
+ * Renders NOTHING unless Aria mode is on (Settings → Advanced Options → OMP
+ * Runtime). The dot reports FLEET health, which is meaningless on an install
+ * that runs OMP locally or not at all — and OMP ships disabled by default, so
+ * an always-present "OMP" chip in every user's status bar would label a
+ * provider most of them never enabled. The store floors `ariaMode` to false on
+ * a cold mount and on any probe failure, so the failure direction is hidden
+ * rather than an unexplainable dot.
+ */
+import { useState, useRef, useEffect } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { cn } from '../utils/cn';
+import { useOmpFleetStore } from '../stores/ompFleetStore';
+import type { OmpFleetUiStatus } from '../stores/ompFleetStore';
+
+const DOT_COLOR: Record<OmpFleetUiStatus, string> = {
+  available: 'bg-status-success',
+  absent: 'bg-text-muted',
+  error: 'bg-status-error',
+  checking: 'bg-status-warning',
+};
+
+const STATUS_LABEL: Record<OmpFleetUiStatus, string> = {
+  available: 'Fleet available',
+  absent: 'No fleet (never ran)',
+  error: 'Fleet error',
+  checking: 'Checking',
+};
+
+const ERROR_LABEL: Record<string, string> = {
+  unavailable: 'OMP unavailable',
+  missing: 'No fleet (never ran)',
+  malformed: 'Malformed registry',
+  'unsupported-version': 'Unsupported registry version',
+};
+
+export function OmpFleetIndicator() {
+  const { ariaMode, status, workerCount, errorKind, detail } = useOmpFleetStore(
+    useShallow((s) => ({
+      ariaMode: s.ariaMode,
+      status: s.status,
+      workerCount: s.workerCount,
+      errorKind: s.errorKind,
+      detail: s.detail,
+    })),
+  );
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Aria mode can flip off while the popover is open (the store re-probes every
+  // tick). Collapse it, so re-enabling later does not re-open a stale dialog.
+  useEffect(() => {
+    if (!ariaMode) setOpen(false);
+  }, [ariaMode]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleOutside);
+    return () => document.removeEventListener('mousedown', handleOutside);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [open]);
+
+  // After every hook — an early return above them would break the hook order on
+  // the render where Aria mode flips.
+  if (!ariaMode) return null;
+
+  return (
+    <div ref={containerRef} className="relative flex items-center">
+      <button
+        type="button"
+        aria-label={`OMP fleet status: ${STATUS_LABEL[status]}`}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex items-center gap-1.5 rounded px-1.5 py-0.5 hover:bg-bg-hover focus:outline-none focus-visible:ring-1 focus-visible:ring-interactive/30 transition-colors"
+      >
+        <span
+          className={cn('w-2 h-2 rounded-full', DOT_COLOR[status], status === 'checking' && 'animate-pulse')}
+          data-status={status}
+        />
+        <span className="text-xs text-text-muted leading-none">OMP</span>
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-label="OMP fleet diagnostics"
+          className={cn(
+            'absolute bottom-full right-0 mb-2 z-50',
+            'w-64 rounded-md border border-border-primary bg-bg-secondary shadow-lg',
+            'p-3 text-xs text-text-primary',
+          )}
+        >
+          <p className="font-semibold mb-2 text-text-primary">OMP Fleet</p>
+
+          <div className="space-y-1">
+            <div className="flex justify-between">
+              <span className="text-text-muted">Status</span>
+              <span>{STATUS_LABEL[status]}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-text-muted">Workers</span>
+              <span>{workerCount !== null ? String(workerCount) : '—'}</span>
+            </div>
+          </div>
+
+          {status === 'checking' && (
+            <div className="mt-2 pt-2 border-t border-border-primary">
+              <p className="font-mono text-status-warning break-all text-[10px] leading-tight">
+                Last snapshot is stale — IPC unavailable.
+              </p>
+            </div>
+          )}
+
+          {errorKind && (
+            <div className="mt-2 pt-2 border-t border-border-primary">
+              <p className="text-text-muted mb-1">Error</p>
+              <p className="font-mono text-status-error break-all text-[10px] leading-tight">
+                {ERROR_LABEL[errorKind] ?? errorKind}
+                {detail ? `: ${detail}` : ''}
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -60,6 +60,12 @@ export function Settings({ isOpen, onClose, initialTab }: SettingsProps) {
   // DEV-ONLY: forces the next AskUserQuestion gate to fail so the durable recovery
   // gate can be exercised live. Hidden in the stable DMG; inert in packaged builds.
   const [forceAskUserQuestionGateFailure, setForceAskUserQuestionGateFailure] = useState(false);
+  // Aria mode: supervise a REMOTE OMP fleet instead of running OMP locally.
+  // Enforced per command (OmpSupervisedAdapter holds the principal THUNK), so a
+  // change lands on the next call — no relaunch. Pickers read the flavor from
+  // the config store (useOmpAvailability), so they swap on save without a
+  // remount either.
+  const [ariaMode, setAriaMode] = useState(false);
   const [demoMode, setDemoMode] = useState(false);
   // demoMode is read once at app startup, so the saved value only takes effect
   // after a relaunch — track the loaded value to detect a toggle on save.
@@ -204,6 +210,7 @@ export function Settings({ isOpen, onClose, initialTab }: SettingsProps) {
       setClaudeExecutablePath(data.claudeExecutablePath || '');
       setDevMode(data.devMode || false);
       setForceAskUserQuestionGateFailure(data.forceAskUserQuestionGateFailure ?? false);
+      setAriaMode(data.ariaMode ?? false);
       setDemoMode(data.demoMode || false);
       setInitialDemoMode(data.demoMode || false);
       setEnableCyboflowFooter(data.enableCyboflowFooter !== false); // Default to true
@@ -276,6 +283,9 @@ export function Settings({ isOpen, onClose, initialTab }: SettingsProps) {
         claudeExecutablePath,
         devMode,
         forceAskUserQuestionGateFailure,
+        // Explicit boolean, never undefined — updateConfig merges partials, so
+        // an undefined value would fail to overwrite a stored `true`.
+        ariaMode,
         demoMode,
         enableCyboflowFooter,
         // Empty ('App default') → undefined so getAssistantModel() floors to
@@ -651,6 +661,29 @@ export function Settings({ isOpen, onClose, initialTab }: SettingsProps) {
                     </p>
                   </div>
                 )}
+              </SettingsSection>
+
+              <SettingsSection
+                title="OMP Runtime"
+                description="Choose how this machine runs OMP"
+                icon={<FileText className="w-4 h-4" />}
+              >
+                <Checkbox
+                  label="Aria mode"
+                  checked={ariaMode}
+                  onChange={(e) => setAriaMode(e.target.checked)}
+                />
+                <p className="text-xs text-text-tertiary mt-1">
+                  Supervise a remote OMP fleet over the Prime bridge instead of running OMP locally.
+                  On, the runtime picker offers <strong>OMP fleet</strong>; off, it offers <strong>OMP</strong> and{' '}
+                  <strong>OMP (CLI)</strong>. The two are alternatives, so only one appears at a time.
+                </p>
+                <p className="text-xs text-text-tertiary mt-1">
+                  Turning this on also authorizes Cyboflow to spawn and stop remote workers on your behalf.
+                  It needs the OMP provider enabled in Integrations and a configured bridge
+                  (<code>OMP_BRIDGE_TOKEN_FILE</code> and <code>OMP_BRIDGE_SESSION_ID</code>); without those,
+                  OMP fleet stays hidden. Changes take effect right away — no restart needed.
+                </p>
               </SettingsSection>
 
               <SettingsSection

--- a/frontend/src/components/StatusBar.tsx
+++ b/frontend/src/components/StatusBar.tsx
@@ -11,6 +11,7 @@
  * bottom without shrinking the main content.
  */
 import { McpHealthIndicator } from './McpHealthIndicator';
+import { OmpFleetIndicator } from './OmpFleetIndicator';
 
 export function StatusBar() {
   return (
@@ -24,6 +25,7 @@ export function StatusBar() {
       {/* Right side: status indicators */}
       <div className="flex items-center gap-2">
         <McpHealthIndicator />
+        <OmpFleetIndicator />
       </div>
     </footer>
   );

--- a/frontend/src/components/__tests__/OmpFleetIndicator.test.tsx
+++ b/frontend/src/components/__tests__/OmpFleetIndicator.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * OmpFleetIndicator — the Aria gate on the status-bar dot.
+ *
+ * The indicator reports FLEET health, which means nothing on an install that
+ * runs OMP locally or not at all. OMP also ships disabled by default, so an
+ * always-present "OMP" chip would label a provider most users never enabled.
+ * These tests pin that it renders only under Aria mode, and that the failure
+ * direction is hidden rather than an unexplainable dot.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { OmpFleetIndicator } from '../OmpFleetIndicator';
+import { useOmpFleetStore, type OmpFleetState } from '../../stores/ompFleetStore';
+
+/**
+ * Partial state write inside act(). Typed as Partial<OmpFleetState> rather than
+ * the store's own setState parameter, whose first overload demands the whole
+ * state object (actions included).
+ */
+function setState(partial: Partial<OmpFleetState>) {
+  act(() => {
+    useOmpFleetStore.setState(partial);
+  });
+}
+
+beforeEach(() => {
+  useOmpFleetStore.setState({
+    ariaMode: false,
+    status: 'absent',
+    workerCount: null,
+    errorKind: null,
+    detail: null,
+    lastCheckedAt: null,
+  });
+});
+
+describe('OmpFleetIndicator — Aria gating', () => {
+  it('renders nothing when Aria mode is off', () => {
+    const { container } = render(<OmpFleetIndicator />);
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText('OMP')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing on a cold mount, before any probe has answered', () => {
+    // The store floors ariaMode to false, so there is no frame where a
+    // non-fleet install flashes an OMP chip.
+    const { container } = render(<OmpFleetIndicator />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the dot once Aria mode is on', () => {
+    setState({ ariaMode: true, status: 'available', workerCount: 3 });
+    render(<OmpFleetIndicator />);
+
+    expect(screen.getByText('OMP')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /OMP fleet status/i })).toBeInTheDocument();
+  });
+
+  it('disappears when Aria mode is switched off while mounted', () => {
+    setState({ ariaMode: true, status: 'available', workerCount: 3 });
+    const { container } = render(<OmpFleetIndicator />);
+    expect(screen.getByText('OMP')).toBeInTheDocument();
+
+    setState({ ariaMode: false });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not leave an open popover behind when Aria mode flips off', () => {
+    setState({ ariaMode: true, status: 'available', workerCount: 3 });
+    render(<OmpFleetIndicator />);
+    act(() => {
+      screen.getByRole('button', { name: /OMP fleet status/i }).click();
+    });
+    expect(screen.getByRole('dialog', { name: /OMP fleet diagnostics/i })).toBeInTheDocument();
+
+    setState({ ariaMode: false });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    // Re-enabling must not resurrect the stale dialog.
+    setState({ ariaMode: true });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByText('OMP')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/cyboflow/ABTestLaunchModal.tsx
+++ b/frontend/src/components/cyboflow/ABTestLaunchModal.tsx
@@ -38,6 +38,7 @@ import { useConfigStore } from '../../stores/configStore';
 import type { BacklogTaskItem, Board } from '../../../../shared/types/tasks';
 import type { PermissionMode } from '../../../../shared/types/workflows';
 import { effortLevelsForProvider, type ReasoningEffort } from '../../../../shared/types/reasoningEffort';
+import type { WorkflowAgentRuntime } from '../../../../shared/types/agentRuntime';
 import type { EpicTaskGroup } from './taskGrouping';
 import { flattenGroups, groupTasksByEpic } from './taskGrouping';
 import { EpicGroupedTaskList } from './EpicGroupedTaskList';
@@ -49,11 +50,7 @@ import { SubstrateSelector } from './SubstrateSelector';
 import { ModelSelector, DEFAULT_QUICK_MODEL, DEFAULT_CODEX_MODEL } from './ModelSelector';
 import { AgentPermissionModeSelector } from './AgentPermissionModeSelector';
 import { providerForRuntime, type LaunchAgentRuntime } from './agentRuntimeUi';
-import {
-  isWorkflowRunStorableRuntime,
-  type AgentProvider,
-  type WorkflowRunStorableRuntime,
-} from '../../../../shared/types/agentRuntime';
+import type { AgentProvider, WorkflowRunStorableRuntime } from '../../../../shared/types/agentRuntime';
 import { runtimeSupportsEffort } from '../../../../shared/types/agentCapabilities';
 
 /**
@@ -62,7 +59,7 @@ import { runtimeSupportsEffort } from '../../../../shared/types/agentCapabilitie
  * (substrate/agentProvider are DERIVED from `runtime`, not stored separately).
  */
 interface ArmQuickConfig {
-  runtime: LaunchAgentRuntime;
+  runtime: WorkflowAgentRuntime;
   model: string;
   reasoningEffort: ReasoningEffort | null;
   permissionMode: PermissionMode;
@@ -76,19 +73,25 @@ const DEFAULT_QUICK_ARM_CONFIG: ArmQuickConfig = {
 };
 
 /**
- * The wire-schema `agentRuntime` enum for an experiment quick arm is
- * {@link WORKFLOW_RUN_STORABLE_RUNTIMES} — an A/B arm mints a `workflow_runs`
- * row, so a runtime that row cannot carry (`codex-pty`) has to be clamped; see
- * `experimentArmQuickConfigSchema` in `experiments.ts`. `QuickArmConfigForm`'s
- * `SubstrateSelector` already disables those runtimes via
- * `runtimeScope="workflow"`, so this is unreachable through the UI; clamped here
- * anyway as defense-in-depth + to satisfy the narrower type.
+ * The modal's `ArmQuickConfig.runtime` is the workflow-LAUNCHABLE set — it
+ * excludes `codex-pty`/`omp-pty` (PTY transport, unreachable for a quick arm)
+ * and `omp-fleet` (v1 offers the fleet supervisor as a quick-session runtime
+ * only, never to A/B arms); the wire schema's `agentRuntime` enum is the wider
+ * STORABLE set (see the router's `experimentArmQuickConfigSchema`).
+ * `QuickArmConfigForm`'s `SubstrateSelector` uses `runtimeScope="workflow"`,
+ * so the disabled options can never be picked through the UI; this clamps
+ * anyway — each PTY transport to its provider's SDK equivalent, `omp-fleet`
+ * to the `claude-sdk` launch default — as defense-in-depth and to satisfy the
+ * narrower type.
  */
-function quickArmAgentRuntime(runtime: LaunchAgentRuntime): WorkflowRunStorableRuntime {
-  return isWorkflowRunStorableRuntime(runtime) ? runtime : 'codex-sdk';
+function quickArmAgentRuntime(runtime: LaunchAgentRuntime): WorkflowAgentRuntime {
+  if (runtime === 'codex-pty') return 'codex-sdk';
+  if (runtime === 'omp-pty') return 'omp-sdk';
+  if (runtime === 'omp-fleet') return 'claude-sdk';
+  return runtime;
 }
 
-function substrateForQuickArm(runtime: LaunchAgentRuntime): 'sdk' | 'interactive' | undefined {
+function substrateForQuickArm(runtime: WorkflowAgentRuntime): 'sdk' | 'interactive' | undefined {
   if (runtime === 'claude-sdk') return 'sdk';
   if (runtime === 'claude-interactive') return 'interactive';
   return undefined;
@@ -125,14 +128,15 @@ function applyQuickArmRuntimeChange(
   config: ArmQuickConfig,
   runtime: LaunchAgentRuntime,
 ): ArmQuickConfig {
-  if (runtime === config.runtime) return config;
-  if (providerForRuntime(runtime) === providerForRuntime(config.runtime)) {
-    return { ...config, runtime };
+  const armRuntime = quickArmAgentRuntime(runtime);
+  if (armRuntime === config.runtime) return config;
+  if (providerForRuntime(armRuntime) === providerForRuntime(config.runtime)) {
+    return { ...config, runtime: armRuntime };
   }
   return {
     ...config,
-    runtime,
-    model: QUICK_ARM_MODEL_RESET[providerForRuntime(runtime)],
+    runtime: armRuntime,
+    model: QUICK_ARM_MODEL_RESET[providerForRuntime(armRuntime)],
     reasoningEffort: null,
   };
 }
@@ -170,8 +174,8 @@ function QuickArmConfigForm({
       />
       {/* Reasoning-effort select — excluded for a runtime that drops the flag
           (RUNTIME_CAPABILITIES.supportsEffort; mirrors SessionStartWizard), moot
-          here since the runtime choice above already disables codex-pty for a
-          quick arm. */}
+          here since the runtime choice above already disables every effort-less
+          runtime for a quick arm. */}
       {runtimeSupportsEffort(config.runtime) && (
         <div className="flex flex-col gap-1">
           <label

--- a/frontend/src/components/cyboflow/SubstrateSelector.tsx
+++ b/frontend/src/components/cyboflow/SubstrateSelector.tsx
@@ -43,6 +43,7 @@ import {
 import { isRuntimeSelectableInPickers } from '../../../../shared/types/agentCapabilities';
 import { useAgentProviderAccess } from '../../hooks/useAgentProviderAccess';
 import { useForcedSubstrate } from '../../hooks/useForcedSubstrate';
+import { useOmpAvailability, type OmpAvailability } from '../../hooks/useOmpAvailability';
 import {
   workflowRuntimeForLaunch,
   type LaunchAgentRuntime,
@@ -109,10 +110,11 @@ interface SubstrateSelectorProps {
 const RUNTIME_SCOPE_SUFFIXES: Partial<Record<LaunchAgentRuntime, string>> = {
   'claude-sdk': ' (default)',
   'codex-pty': ' — quick sessions only',
+  'omp-fleet': ' — quick sessions only',
 };
 
 const RUNTIME_OPTIONS: readonly { runtime: LaunchAgentRuntime; label: string }[] = (
-  ['claude-sdk', 'claude-interactive', 'codex-sdk', 'codex-pty', 'omp-sdk', 'omp-pty'] as const
+  ['claude-sdk', 'claude-interactive', 'codex-sdk', 'codex-pty', 'omp-sdk', 'omp-pty', 'omp-fleet'] as const
 ).map((runtime) => ({
   runtime,
   label: `${AGENT_RUNTIME_LABELS[runtime]}${RUNTIME_SCOPE_SUFFIXES[runtime] ?? ''}`,
@@ -146,11 +148,55 @@ function isRuntimeDisabled(runtime: LaunchAgentRuntime, scope: NonNullable<Subst
   return false;
 }
 
-/** The options a picker may show, given the provider toggles. */
+/** The LOCAL OMP runtimes — an OMP process this machine runs. */
+const LOCAL_OMP_RUNTIMES: ReadonlySet<LaunchAgentRuntime> = new Set<LaunchAgentRuntime>(['omp-sdk', 'omp-pty']);
+
+/**
+ * The options a picker may show, given the provider toggles + OMP availability.
+ *
+ * The two OMP flavors are ALTERNATIVES, not a stack: a panel is either a local
+ * OMP process or a supervised remote worker. Aria mode picks which one this
+ * install runs, so exactly one of them is ever offered — showing both would
+ * imply a choice the runtime does not actually support, and `omp-fleet` needs a
+ * configured bridge the local runtimes do not.
+ */
+function flavorVisibleOptions(
+  omp: OmpAvailability,
+): readonly { runtime: LaunchAgentRuntime; label: string }[] {
+  return SELECTABLE_RUNTIME_OPTIONS.filter((o) => {
+    // Visible on ARIA MODE ALONE, not on availability. Hiding it when the
+    // bridge is missing removed the last OMP row from an Aria install — the
+    // local runtimes are hidden precisely BECAUSE Aria is on — so the picker
+    // showed no OMP at all while Settings → Integrations still read "on", with
+    // no note explaining it (the hidden-runtimes note counts against THIS
+    // list, so a row removed here is invisible by construction). It is offered
+    // and DISABLED instead: see unavailableReason.
+    if (o.runtime === 'omp-fleet') return omp.ariaMode;
+    if (LOCAL_OMP_RUNTIMES.has(o.runtime)) return !omp.ariaMode;
+    return true;
+  });
+}
+
+/**
+ * Why a VISIBLE runtime cannot be chosen right now, or null when it can.
+ *
+ * Distinct from {@link isRuntimeDisabled}, which is about SCOPE ("this launch
+ * surface can't run it"). This is about the machine's current configuration —
+ * the runtime is right for the surface, but something outside the picker has to
+ * be set up first. Rendering the reason beats removing the row: a user who
+ * turned Aria mode on needs to learn the bridge is missing, not watch OMP
+ * disappear from a picker whose provider toggle still says it is enabled.
+ */
+function unavailableReason(runtime: LaunchAgentRuntime, omp: OmpAvailability): string | null {
+  if (runtime === 'omp-fleet' && !omp.launchable) return 'bridge not configured';
+  return null;
+}
+
 function enabledRuntimeOptions(
   access: AgentProviderAccess,
+  omp: OmpAvailability,
 ): readonly { runtime: LaunchAgentRuntime; label: string }[] {
-  return SELECTABLE_RUNTIME_OPTIONS.filter((o) => isRuntimeProviderEnabled(access, o.runtime));
+  return flavorVisibleOptions(omp).filter((o) => isRuntimeProviderEnabled(access, o.runtime));
 }
 
 function scopeHelp(scope: NonNullable<SubstrateSelectorProps['runtimeScope']>): string {
@@ -200,12 +246,17 @@ export function SubstrateSelector({
 }: SubstrateSelectorProps): React.JSX.Element {
   // Global forced-substrate pin (see file header), mirroring the backend
   // precedence: demo → 'sdk', else interactivePtyOnly → 'interactive', else null.
-  // Reactive read so a config fetch resolving AFTER mount still locks the picker.
   const forced = useForcedSubstrate();
   // Provider toggles (Settings → Integrations / onboarding). A switched-off
   // provider's runtimes leave the picker entirely and can never be submitted.
   const providerAccess = useAgentProviderAccess();
-  const options = enabledRuntimeOptions(providerAccess);
+  const omp = useOmpAvailability();
+  const options = enabledRuntimeOptions(providerAccess, omp);
+  // Baseline for the "…are hidden" note: the rows this OMP FLAVOR can show, not
+  // every selectable runtime. Aria mode always hides one flavor, so counting
+  // against the full list would fire the note permanently and blame the provider
+  // toggles for a row the flavor removed.
+  const flavorOptionCount = flavorVisibleOptions(omp).length;
   const claudeEnabled = isRuntimeProviderEnabled(providerAccess, 'claude-sdk');
 
   // Under the interactive lock, keep the controlled value consistent so the
@@ -228,9 +279,9 @@ export function SubstrateSelector({
   // always name a provider the backend will accept.
   const fallbackRuntime = firstEnabledRuntime(
     providerAccess,
-    SELECTABLE_RUNTIME_OPTIONS.filter((o) => !isRuntimeDisabled(o.runtime, runtimeScope)).map(
-      (o) => o.runtime,
-    ),
+    SELECTABLE_RUNTIME_OPTIONS.filter(
+      (o) => !isRuntimeDisabled(o.runtime, runtimeScope) && unavailableReason(o.runtime, omp) === null,
+    ).map((o) => o.runtime),
   );
   useEffect(() => {
     if (isRuntimeProviderEnabled(providerAccess, value)) return;
@@ -292,6 +343,7 @@ export function SubstrateSelector({
           if (
             (isSessionAgentRuntime(next) || isWorkflowLaunchableRuntime(next)) &&
             !isRuntimeDisabled(next, runtimeScope) &&
+            unavailableReason(next, omp) === null &&
             isRuntimeProviderEnabled(providerAccess, next)
           ) {
             onChange(next);
@@ -300,18 +352,21 @@ export function SubstrateSelector({
         className="w-full rounded-input border border-border-primary bg-bg-primary px-2 py-1 text-sm text-text-primary"
         aria-label="Select agent runtime"
       >
-        {options.map(({ runtime, label: optionLabel }) => (
-          <option
-            key={runtime}
-            value={runtime}
-            disabled={isRuntimeDisabled(runtime, runtimeScope)}
-          >
-            {optionLabel}
-          </option>
-        ))}
+        {options.map(({ runtime, label: optionLabel }) => {
+          const reason = unavailableReason(runtime, omp);
+          return (
+            <option
+              key={runtime}
+              value={runtime}
+              disabled={isRuntimeDisabled(runtime, runtimeScope) || reason !== null}
+            >
+              {reason === null ? optionLabel : `${optionLabel} (${reason})`}
+            </option>
+          );
+        })}
       </select>
       <p className="text-xs text-text-tertiary">
-        {options.length === SELECTABLE_RUNTIME_OPTIONS.length
+        {options.length === flavorOptionCount
           ? scopeHelp(runtimeScope)
           : `${scopeHelp(runtimeScope)} Runtimes for providers turned off in Settings → Integrations are hidden.`}
       </p>

--- a/frontend/src/components/cyboflow/__tests__/SubstrateSelector.test.tsx
+++ b/frontend/src/components/cyboflow/__tests__/SubstrateSelector.test.tsx
@@ -23,6 +23,17 @@ vi.mock('../../../hooks/useForcedSubstrate', () => ({
   useForcedSubstrate: mockUseForcedSubstrate,
 }));
 
+const { mockUseOmpAvailability } = vi.hoisted(() => ({
+  mockUseOmpAvailability: vi.fn<() => { launchable: boolean; ariaMode: boolean }>(() => ({
+    launchable: false,
+    ariaMode: false,
+  })),
+}));
+
+vi.mock('../../../hooks/useOmpAvailability', () => ({
+  useOmpAvailability: mockUseOmpAvailability,
+}));
+
 import { SubstrateSelector } from '../SubstrateSelector';
 import { useConfigStore } from '../../../stores/configStore';
 import type { AppConfig } from '../../../types/config';
@@ -39,6 +50,8 @@ function setProviderAccess(access: AgentProviderAccess | undefined): void {
 beforeEach(() => {
   mockUseForcedSubstrate.mockReset();
   mockUseForcedSubstrate.mockReturnValue(null);
+  mockUseOmpAvailability.mockReset();
+  mockUseOmpAvailability.mockReturnValue({ launchable: false, ariaMode: false });
   useConfigStore.setState({ config: null });
 });
 
@@ -149,6 +162,7 @@ describe('SubstrateSelector — provider access toggles', () => {
 
   it('offers both legacy providers when the toggles were never touched (absent config field)', () => {
     setProviderAccess(undefined);
+    mockUseOmpAvailability.mockReturnValue({ launchable: true, ariaMode: true });
     render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="mixed" />);
 
     expect(screen.getByRole('option', { name: /^Codex SDK$/i })).toBeInTheDocument();
@@ -158,6 +172,69 @@ describe('SubstrateSelector — provider access toggles', () => {
     // user could switch on in Settings → Integrations.
     expect(screen.queryByRole('option', { name: /OMP/i })).not.toBeInTheDocument();
     expect(screen.getByText(/turned off in Settings → Integrations are hidden/i)).toBeInTheDocument();
+  });
+
+  it('hides OMP Fleet when the bridge is not configured (availability false)', () => {
+    setProviderAccess(undefined);
+    mockUseOmpAvailability.mockReturnValue({ launchable: false, ariaMode: false });
+    render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
+
+    expect(screen.queryByRole('option', { name: /OMP Fleet/i })).not.toBeInTheDocument();
+  });
+
+  it('offers OMP Fleet when available and the omp provider is enabled', () => {
+    setProviderAccess({ claude: true, codex: true, omp: true });
+    mockUseOmpAvailability.mockReturnValue({ launchable: true, ariaMode: true });
+    render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
+
+    expect(screen.getByRole('option', { name: /OMP Fleet/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /OMP Fleet/i })).not.toBeDisabled();
+  });
+
+  // The gap that made the feature look broken: Aria mode hides the LOCAL OMP
+  // runtimes by design, so hiding omp-fleet too (for a missing bridge) left an
+  // Aria install with no OMP row at all — and the hidden-runtimes note counts
+  // against the flavor list, so nothing on screen said why.
+  it('offers OMP Fleet DISABLED, naming the reason, when Aria is on but no bridge is configured', () => {
+    setProviderAccess({ claude: true, codex: true, omp: true });
+    mockUseOmpAvailability.mockReturnValue({ launchable: false, ariaMode: true });
+    render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
+
+    const fleet = screen.getByRole('option', { name: /OMP fleet.*\(bridge not configured\)/i });
+    expect(fleet).toBeInTheDocument();
+    expect(fleet).toBeDisabled();
+    // The local runtimes stay hidden — the two flavors are still alternatives.
+    expect(screen.queryByRole('option', { name: /^OMP$/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /OMP \(CLI\)/ })).not.toBeInTheDocument();
+  });
+
+  it('drops the reason once the bridge is configured', () => {
+    setProviderAccess({ claude: true, codex: true, omp: true });
+    mockUseOmpAvailability.mockReturnValue({ launchable: true, ariaMode: true });
+    render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
+
+    const fleet = screen.getByRole('option', { name: /^OMP fleet/ });
+    expect(fleet).not.toBeDisabled();
+    expect(fleet.textContent).not.toMatch(/bridge not configured/);
+  });
+
+  // A disabled row must not become the value the picker snaps to when the
+  // current selection's provider is switched off.
+  it('never falls back to an unavailable runtime', () => {
+    setProviderAccess({ claude: false, codex: false, omp: true });
+    mockUseOmpAvailability.mockReturnValue({ launchable: false, ariaMode: true });
+    const onChange = vi.fn();
+    render(<SubstrateSelector value="claude-sdk" onChange={onChange} runtimeScope="session" />);
+
+    for (const [next] of onChange.mock.calls) expect(next).not.toBe('omp-fleet');
+  });
+
+  it('hides OMP Fleet when the omp provider toggle is off even if the bridge is configured', () => {
+    setProviderAccess({ claude: true, codex: true, omp: false });
+    mockUseOmpAvailability.mockReturnValue({ launchable: true, ariaMode: true });
+    render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
+
+    expect(screen.queryByRole('option', { name: /OMP Fleet/i })).not.toBeInTheDocument();
   });
 
   it('surfaces the PTY-only ⨯ Claude-off conflict instead of a picker with no options', () => {
@@ -195,13 +272,32 @@ describe('SubstrateSelector — demo pin (sdk wins)', () => {
 describe('SubstrateSelector — offers exactly the picker-selectable runtimes', () => {
   beforeEach(() => mockUseForcedSubstrate.mockReturnValue(null));
 
-  it('renders one option per selectable runtime and none for the rest', () => {
-    // All providers on, so the capability tie is the only filter under test.
+  // Aria mode makes the two OMP flavors ALTERNATIVES (a panel is either a local
+  // OMP process or a supervised remote worker), so no single render can offer
+  // every selectable runtime. The capability tie is preserved across the UNION
+  // of both flavors instead: nothing selectable may be unreachable in both
+  // modes, and nothing unselectable may appear in either.
+  it('offers, across both OMP flavors, exactly the selectable runtimes', () => {
     setProviderAccess({ claude: true, codex: true, omp: true });
-    render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
 
-    const offered = screen.getAllByRole('option').map((option) => option.getAttribute('value'));
-    expect(offered).toEqual(runtimesWithCapability('selectableInPickers'));
+    mockUseOmpAvailability.mockReturnValue({ launchable: false, ariaMode: false });
+    const local = render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
+    const localOffered = screen.getAllByRole('option').map((o) => o.getAttribute('value'));
+    local.unmount();
+
+    mockUseOmpAvailability.mockReturnValue({ launchable: true, ariaMode: true });
+    render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
+    const ariaOffered = screen.getAllByRole('option').map((o) => o.getAttribute('value'));
+
+    const selectable = runtimesWithCapability('selectableInPickers');
+    expect([...new Set([...localOffered, ...ariaOffered])].sort()).toEqual([...selectable].sort());
+    // And the flavors are genuinely exclusive, not merely different.
+    expect(localOffered).toContain('omp-sdk');
+    expect(localOffered).toContain('omp-pty');
+    expect(localOffered).not.toContain('omp-fleet');
+    expect(ariaOffered).toContain('omp-fleet');
+    expect(ariaOffered).not.toContain('omp-sdk');
+    expect(ariaOffered).not.toContain('omp-pty');
   });
 
   // The rows exist regardless of access (label and order are decided with the
@@ -254,10 +350,48 @@ describe('SubstrateSelector — offers exactly the picker-selectable runtimes', 
   // would make it fire permanently: codex-exec is always unselectable and its
   // absence must never be reported as a switched-off provider.
   it('does not claim runtimes are hidden when only unselectable ones are absent', () => {
+    // Availability probe ON — without it the selectable omp-fleet row would be
+    // availability-hidden and spuriously read as a provider-toggle removal.
+    mockUseOmpAvailability.mockReturnValue({ launchable: true, ariaMode: true });
     setProviderAccess({ claude: true, codex: true, omp: true });
     render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
 
     expect(screen.queryByText(/are hidden/i)).not.toBeInTheDocument();
+  });
+
+  // The note names the PROVIDER TOGGLES, so the flavor split must not trip it:
+  // Aria mode always hides one OMP flavor, and counting that against the full
+  // selectable list would fire the note permanently with the wrong explanation.
+  it('does not claim runtimes are hidden merely because a flavor is inactive', () => {
+    setProviderAccess({ claude: true, codex: true, omp: true });
+
+    mockUseOmpAvailability.mockReturnValue({ launchable: false, ariaMode: false });
+    const local = render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
+    expect(screen.queryByText(/are hidden/i)).not.toBeInTheDocument();
+    local.unmount();
+
+    mockUseOmpAvailability.mockReturnValue({ launchable: true, ariaMode: true });
+    render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
+    expect(screen.queryByText(/are hidden/i)).not.toBeInTheDocument();
+  });
+
+  // Aria mode ON but the bridge is not usable yet. This case USED to offer no
+  // OMP row at all — the local rows hidden because it is a fleet install, the
+  // fleet row hidden because it would fail closed — which left a picker with no
+  // OMP while Settings → Integrations still reported the provider enabled, and
+  // no note explaining it. The fleet row is now offered and DISABLED, carrying
+  // the reason, so the state is self-describing.
+  it('offers the fleet row disabled, and still no local rows, when the fleet is not launchable', () => {
+    mockUseOmpAvailability.mockReturnValue({ launchable: false, ariaMode: true });
+    setProviderAccess({ claude: true, codex: true, omp: true });
+    render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
+
+    const offered = screen.getAllByRole('option').map((o) => o.getAttribute('value'));
+    expect(offered).toContain('omp-fleet');
+    expect(screen.getByRole('option', { name: /OMP fleet.*\(bridge not configured\)/i })).toBeDisabled();
+    // The flavors are still alternatives — Aria mode means no local OMP.
+    expect(offered).not.toContain('omp-sdk');
+    expect(offered).not.toContain('omp-pty');
   });
 });
 

--- a/frontend/src/components/cyboflow/wizard/SessionStartWizard.tsx
+++ b/frontend/src/components/cyboflow/wizard/SessionStartWizard.tsx
@@ -1760,22 +1760,27 @@ export default function SessionStartWizard(): React.JSX.Element {
                 (→ the claude panel / interactive eager spawn); workflow threads
                 it into runs.start ({ model }) → workflow_runs.model (migration
                 037). Ultracode defaults to Fable when available (the per-key
-                model seed). Fast mode stays QUICK-only. */}
-            <div {...{ [ONBOARDING_ANCHOR_ATTR]: ONBOARDING_ANCHORS.modelSelect }}>
-              <ModelSelector
-                value={model}
-                onChange={(m) => {
-                  // setByUser latches THIS key as touched, so reactive re-seeding
-                  // stops for it (and only for it).
-                  setModelByUser(m);
-                  // Fast mode is Opus-only; drop it when leaving Opus.
-                  if (!isOpusModel(m)) setFastMode(false);
-                }}
-                id="wizard-model"
-                agentProvider={effectiveProvider}
-                agentRuntime={effectiveRuntime}
-              />
-            </div>
+                model seed). Fast mode stays QUICK-only. OMP Fleet has no model
+                picker — it runs on the producer default (DEFAULT_OMP_MODEL), so
+                the control is hidden for that runtime rather than shown as a
+                lie. */}
+            {effectiveRuntime !== 'omp-fleet' && (
+              <div {...{ [ONBOARDING_ANCHOR_ATTR]: ONBOARDING_ANCHORS.modelSelect }}>
+                <ModelSelector
+                  value={model}
+                  onChange={(m) => {
+                    // setByUser latches THIS key as touched, so reactive re-seeding
+                    // stops for it (and only for it).
+                    setModelByUser(m);
+                    // Fast mode is Opus-only; drop it when leaving Opus.
+                    if (!isOpusModel(m)) setFastMode(false);
+                  }}
+                  id="wizard-model"
+                  agentProvider={effectiveProvider}
+                  agentRuntime={effectiveRuntime}
+                />
+              </div>
+            )}
             {/* Reasoning-effort select — QUICK, every effort-capable runtime.
                 Shown for Claude (SDK Options.effort / interactive --effort) AND
                 codex-sdk (startCodexSdkTurn → buildCodexAppServerTurnOptions maps
@@ -2161,10 +2166,12 @@ export default function SessionStartWizard(): React.JSX.Element {
               />
               <SummaryRow label="Permission" value={permissionLabel} />
               <SummaryRow label="Runtime" value={AGENT_RUNTIME_LABELS[effectiveRuntime]} />
-              <SummaryRow
-                label="Model"
-                value={effectiveProvider === 'codex' ? model : modelDisplayLabel(model)}
-              />
+              {effectiveRuntime !== 'omp-fleet' && (
+                <SummaryRow
+                  label="Model"
+                  value={effectiveProvider === 'codex' ? model : modelDisplayLabel(model)}
+                />
+              )}
 
               {selection.kind === 'quick' && runtimeSupportsFastMode(effectiveRuntime) && isOpusModel(model) && (
                 <SummaryRow label="Fast mode" value={fastMode ? 'On' : 'Off'} />

--- a/frontend/src/components/cyboflow/wizard/__tests__/SessionStartWizard.test.tsx
+++ b/frontend/src/components/cyboflow/wizard/__tests__/SessionStartWizard.test.tsx
@@ -22,6 +22,17 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // tRPC mock — the wizard fetches workflows.list + runs.list and launches via
 // runs.start.mutate.
 // ---------------------------------------------------------------------------
+const { mockUseOmpAvailability } = vi.hoisted(() => ({
+  mockUseOmpAvailability: vi.fn<() => { launchable: boolean; ariaMode: boolean }>(() => ({
+    launchable: false,
+    ariaMode: false,
+  })),
+}));
+
+vi.mock('../../../../hooks/useOmpAvailability', () => ({
+  useOmpAvailability: mockUseOmpAvailability,
+}));
+
 vi.mock('../../../../trpc/client', () => ({
   trpc: {
     cyboflow: {
@@ -438,6 +449,7 @@ beforeEach(() => {
     // across app restart, so tests start from the same "no active surface"
     // baseline the real app does.
     useDesignModeStore.setState({ activeDesignSessionId: null });
+    mockUseOmpAvailability.mockReturnValue({ launchable: false, ariaMode: false });
   });
   mockRunStart.mockClear();
   mockCreateQuick.mockClear();
@@ -573,6 +585,37 @@ describe('SessionStartWizard — step ③ adaptive controls', () => {
     expect(screen.queryByText('MCP servers')).toBeNull();
     expect(screen.queryByText('Plugins')).toBeNull();
     expect(screen.getByText('Workspace')).toBeInTheDocument();
+  });
+});
+
+describe('SessionStartWizard — OMP Fleet runtime controls', () => {
+  it('hides the Claude model picker + reasoning-effort select when OMP Fleet is selected', async () => {
+    mockUseOmpAvailability.mockReturnValue({ launchable: true, ariaMode: true });
+    // The merged provider registry floors an absent `omp` key to DISABLED (the
+    // back-branch defaulted it enabled, which is why this seed used to be
+    // unnecessary). Without it the picker snaps a fleet selection back to a
+    // default-enabled runtime and the controls under test never hide.
+    act(() => {
+      useConfigStore.setState({
+        config: { agentProviderAccess: { claude: true, codex: true, omp: true } } as unknown as AppConfig,
+      });
+    });
+    await renderLockedWizard();
+    await selectQuickAndConfigure();
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Select agent runtime'), {
+        target: { value: 'omp-fleet' },
+      });
+    });
+
+    // The Claude model + reasoning-effort controls are Claude/Codex-scoped and
+    // must not render for OMP (which runs on the producer default model).
+    expect(screen.queryByLabelText('Select Claude model')).toBeNull();
+    expect(screen.queryByLabelText('Select reasoning effort')).toBeNull();
+    // The launch summary labels the runtime honestly (shared AGENT_RUNTIME_LABELS
+    // wording — sentence case, same family as 'OMP terminal').
+    expect(screen.getByTestId('wizard-launch-summary')).toHaveTextContent('OMP fleet');
   });
 });
 

--- a/frontend/src/components/settings/IntegrationsSettings.test.tsx
+++ b/frontend/src/components/settings/IntegrationsSettings.test.tsx
@@ -10,6 +10,8 @@ import { IntegrationsSettings } from './IntegrationsSettings';
 const detectClaude = vi.fn();
 const detectCodex = vi.fn();
 const detectOmp = vi.fn();
+const { mockUseOmpAvailability } = vi.hoisted(() => ({ mockUseOmpAvailability: vi.fn() }));
+vi.mock('../../hooks/useOmpAvailability', () => ({ useOmpAvailability: mockUseOmpAvailability }));
 
 vi.mock('../../utils/api', () => ({
   API: {
@@ -64,6 +66,8 @@ beforeEach(() => {
   detectCodex.mockReset().mockResolvedValue({ success: true, data: CODEX_CONNECTED });
   detectOmp.mockReset().mockResolvedValue({ success: true, data: OMP_MISSING });
   updateConfig = vi.fn().mockResolvedValue(true);
+  // Default install: OMP runs locally, so the row reports the local binary.
+  mockUseOmpAvailability.mockReset().mockReturnValue({ launchable: false, ariaMode: false });
   useConfigStore.setState({ config: null, error: null, updateConfig });
 });
 
@@ -272,5 +276,50 @@ describe('IntegrationsSettings — OMP card', () => {
     expect(ompSwitch).toBeDisabled();
     fireEvent.click(ompSwitch);
     expect(updateConfig).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Aria mode changes what the OMP row is even ABOUT: it supervises a remote
+ * fleet and never launches the local binary, so reporting the binary there
+ * answers the wrong question — and would report "Detected" for an install that
+ * cannot launch anything.
+ */
+describe('IntegrationsSettings — OMP row under Aria mode', () => {
+  it('reports the FLEET, not the local binary, when Aria mode is on', async () => {
+    // A perfectly good local binary is present and must NOT be what the row claims.
+    detectOmp.mockResolvedValue({ success: true, data: OMP_DETECTED });
+    mockUseOmpAvailability.mockReturnValue({ launchable: true, ariaMode: true });
+
+    render(<IntegrationsSettings />);
+
+    expect(await screen.findByText('Fleet detected')).toBeInTheDocument();
+    // OMP_DETECTED carries version 17.3.3 and a binaryPath; neither may surface.
+    expect(screen.queryByText(/omp 17\.3\.3/i)).not.toBeInTheDocument();
+    expect(screen.queryByText('/usr/local/bin/omp')).not.toBeInTheDocument();
+    expect(screen.getByText(/the local omp binary is not used/i)).toBeInTheDocument();
+  });
+
+  it('says the fleet is missing, and how to fix it, when no bridge is configured', async () => {
+    detectOmp.mockResolvedValue({ success: true, data: OMP_DETECTED });
+    mockUseOmpAvailability.mockReturnValue({ launchable: false, ariaMode: true });
+
+    render(<IntegrationsSettings />);
+
+    expect(await screen.findByText('Fleet not detected')).toBeInTheDocument();
+    // Naming the env vars is the point — this is the state that otherwise reads
+    // as "OMP is broken" while the toggle still says it is on.
+    expect(screen.getByText(/OMP_BRIDGE_TOKEN_FILE/)).toBeInTheDocument();
+    expect(screen.getByText(/OMP_BRIDGE_SESSION_ID/)).toBeInTheDocument();
+  });
+
+  it('still reports the local binary when Aria mode is off', async () => {
+    detectOmp.mockResolvedValue({ success: true, data: OMP_DETECTED });
+    mockUseOmpAvailability.mockReturnValue({ launchable: false, ariaMode: false });
+
+    render(<IntegrationsSettings />);
+
+    expect(await screen.findByText('Detected')).toBeInTheDocument();
+    expect(screen.queryByText(/Fleet (not )?detected/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/settings/IntegrationsSettings.tsx
+++ b/frontend/src/components/settings/IntegrationsSettings.tsx
@@ -5,6 +5,7 @@ import type { AgentProvider, AgentProviderAccess } from '../../../../shared/type
 import { AGENT_PROVIDERS, isAgentProviderEnabled } from '../../../../shared/types/agentRuntime';
 import type { ProviderDetectionResult } from '../../../../shared/types/onboarding';
 import { useAgentProviderAccess } from '../../hooks/useAgentProviderAccess';
+import { useOmpAvailability, type OmpAvailability } from '../../hooks/useOmpAvailability';
 import { useConfigStore } from '../../stores/configStore';
 import { API } from '../../utils/api';
 import { Button } from '../ui/Button';
@@ -221,10 +222,37 @@ function codexView(
   };
 }
 
+/**
+ * The OMP row's status.
+ *
+ * ARIA MODE CHANGES WHAT "DETECTED" MEANS. Off, OMP runs on THIS machine and
+ * the local binary is the thing to find. On, Cyboflow supervises a REMOTE fleet
+ * over the Prime bridge and never launches a local `omp` — so reporting the
+ * local binary there answers a question nobody asked, and reports "Detected"
+ * for an install that cannot actually launch anything. Under Aria mode the row
+ * reports the FLEET instead, which is the resource the runtime needs.
+ */
 function ompView(
   detection: ProviderDetectionResult<'omp'> | null,
   error: string | null,
+  omp: OmpAvailability,
 ): ProviderViewModel {
+  if (omp.ariaMode) {
+    return omp.launchable
+      ? {
+          status: 'connected',
+          label: 'Fleet detected',
+          detail: 'Supervising a remote OMP fleet over the Prime bridge.',
+          metadata: 'Aria mode · the local omp binary is not used',
+        }
+      : {
+          status: 'unavailable',
+          label: 'Fleet not detected',
+          detail:
+            'Aria mode is on, but no OMP Prime bridge was found. Set OMP_BRIDGE_TOKEN_FILE and OMP_BRIDGE_SESSION_ID, then restart Cyboflow.',
+          metadata: 'Aria mode · the local omp binary is not used',
+        };
+  }
   if (error) {
     return { status: 'unavailable', label: 'Check failed', detail: error };
   }
@@ -338,7 +366,8 @@ export function IntegrationsSettings(): React.JSX.Element {
 
   const claude = claudeView(claudeDetection, claudeError);
   const codex = codexView(codexDetection, codexError);
-  const omp = ompView(ompDetection, ompError);
+  const ompAvailability = useOmpAvailability();
+  const omp = ompView(ompDetection, ompError, ompAvailability);
 
   // Provider access — the toggles below write AppConfig.agentProviderAccess,
   // the same field the onboarding Connect step writes, so the two surfaces are
@@ -441,7 +470,7 @@ export function IntegrationsSettings(): React.JSX.Element {
             onToggle={(next) => void setProviderEnabled('omp', next)}
             toggleDisabledReason={toggleReason('omp', ompEnabled)}
             toggleTestId="provider-toggle-omp"
-            action={ompDetection?.state === 'unavailable' && ompDetection.binaryPath === null ? (
+            action={!ompAvailability.ariaMode && ompDetection?.state === 'unavailable' && ompDetection.binaryPath === null ? (
               <Button
                 type="button"
                 variant="secondary"

--- a/frontend/src/components/settings/RunTypeOverrideDetail.tsx
+++ b/frontend/src/components/settings/RunTypeOverrideDetail.tsx
@@ -40,11 +40,13 @@ import { ChevronLeft, RotateCcw } from 'lucide-react';
 import { useConfigStore } from '../../stores/configStore';
 import { useCodexModelCatalog } from '../../stores/codexModelCatalogStore';
 import { useOmpModelCatalog } from '../../stores/ompModelCatalogStore';
+import { useOmpAvailability, type OmpAvailability } from '../../hooks/useOmpAvailability';
 import {
   RUN_TYPE_EFFORT_OPTIONS,
   RUN_TYPE_MODEL_OPTIONS,
   RUN_TYPE_FIELD_LABELS,
-  agentRuntimeOptions,
+  agentRuntimePickerOptions,
+  runtimeUnavailableReason,
   baselineValueFor,
   coerceDraftForModel,
   coerceDraftForRuntime,
@@ -190,6 +192,11 @@ export function RunTypeOverrideDetail({
     });
   };
 
+  // Which OMP flavor this install runs (Aria mode) — the runtime picker offers
+  // the remote fleet OR the local runtimes, never both. Same source the launch
+  // picker reads, so the two surfaces cannot disagree.
+  const omp = useOmpAvailability();
+
   const draftValue = (field: RunTypeFieldId): string | null => draft[field];
 
   const cardIsOn = (card: KnobCard): boolean => card.fields.some((f) => draftValue(f) !== null);
@@ -218,7 +225,7 @@ export function RunTypeOverrideDetail({
     if (field !== 'model') return fromBaseline;
     const coerced = coerceDraftForModel(draft, fromBaseline, baseline).model;
     if (coerced !== null) return coerced;
-    const offered = fieldOptions(field, runTypeKey, provider, codexModelOptions, ompModelOptions);
+    const offered = fieldOptions(field, runTypeKey, provider, codexModelOptions, ompModelOptions, omp, draftValue('agentRuntime'));
     return offered[0]?.id ?? null;
   };
 
@@ -277,7 +284,7 @@ export function RunTypeOverrideDetail({
     const base = baselineValueFor(field, baseline);
     const changed = value !== null && value !== base;
     const selectId = `run-type-${field}`;
-    const options = fieldOptions(field, runTypeKey, provider, codexModelOptions, ompModelOptions);
+    const options = fieldOptions(field, runTypeKey, provider, codexModelOptions, ompModelOptions, omp, draftValue('agentRuntime'));
     // "Follow defaults" is unavailable for a CODEX model, exactly as on the
     // launch pickers: an omitted model member resolves to the always-Claude
     // floor, so offering it here would BE the cross-family pair rather than an
@@ -441,6 +448,12 @@ interface FieldOption {
   id: string;
   label: string;
   /**
+   * Offered but not selectable on this machine — the label already names why
+   * (e.g. an omp-fleet row with no bridge configured). Distinct from an absent
+   * option: the row exists so the setting explains itself.
+   */
+  disabled?: boolean;
+  /**
    * Optional section heading. Only OMP sets it — its catalog fronts many
    * vendors (495 rows across anthropic / openai-codex / openrouter on the
    * author's host), so a flat list is unnavigable. Consecutive options sharing
@@ -458,7 +471,7 @@ function renderFieldOptions(options: readonly FieldOption[]): React.JSX.Element[
     if (group === undefined) {
       const option = options[index]!;
       nodes.push(
-        <option key={option.id} value={option.id}>
+        <option key={option.id} value={option.id} disabled={option.disabled === true}>
           {option.label}
         </option>,
       );
@@ -473,7 +486,7 @@ function renderFieldOptions(options: readonly FieldOption[]): React.JSX.Element[
     nodes.push(
       <optgroup key={group} label={group}>
         {run.map((option) => (
-          <option key={option.id} value={option.id}>
+          <option key={option.id} value={option.id} disabled={option.disabled === true}>
             {option.label}
           </option>
         ))}
@@ -507,6 +520,8 @@ function fieldOptions(
   provider: AgentProvider,
   codexModels: readonly CodexModelOption[],
   ompModels: readonly OmpModelOption[],
+  omp: OmpAvailability,
+  currentRuntime: string | null,
 ): readonly FieldOption[] {
   switch (field) {
     case 'model':
@@ -520,7 +535,13 @@ function fieldOptions(
     case 'substrate':
       return provider === 'claude' ? labelled(field, ['sdk', 'interactive']) : [];
     case 'agentRuntime':
-      return labelled(field, agentRuntimeOptions(runTypeKey));
+      return agentRuntimePickerOptions(runTypeKey, omp, currentRuntime).map((runtime) => {
+        const reason = runtimeUnavailableReason(runtime, omp);
+        const base = runTypeValueLabel(field, runtime);
+        return reason === null
+          ? { id: runtime, label: base }
+          : { id: runtime, label: `${base} (${reason})`, disabled: true };
+      });
     case 'permissionMode':
       return labelled(field, PERMISSION_MODE_OPTIONS.map((o) => o.id));
   }

--- a/frontend/src/components/settings/__tests__/RunTypeOverridesSection.test.tsx
+++ b/frontend/src/components/settings/__tests__/RunTypeOverridesSection.test.tsx
@@ -90,11 +90,22 @@ function workflowsForProject(entries: WorkflowFixtureEntry[], projectId: number)
 // `config:*` IPC fake (real configStore, fake transport).
 // ---------------------------------------------------------------------------
 
+/**
+ * The OMP flavor probe the runtime picker reads (`useOmpAvailability`). Hoisted
+ * so the `vi.mock` factory can close over it and a test can swap the answer;
+ * `beforeEach` resets it to the local-OMP flavor (Aria off), which is what a
+ * default install reports.
+ */
+const { ompAvailabilityMock } = vi.hoisted(() => ({ ompAvailabilityMock: vi.fn() }));
+
 vi.mock('../../../trpc/client', () => ({
   trpc: {
     cyboflow: {
       workflows: {
         list: { query: vi.fn() },
+      },
+      omp: {
+        availability: { query: () => ompAvailabilityMock() },
       },
     },
   },
@@ -245,6 +256,9 @@ beforeEach(() => {
   workflowsListQuery.mockReset();
   projectsGetAll.mockReset();
   forcedApplyError = null;
+  // Default install: OMP runs locally, no remote fleet.
+  ompAvailabilityMock.mockReset();
+  ompAvailabilityMock.mockResolvedValue({ launchable: false, ariaMode: false });
   useConfigStore.setState({ config: null, error: null, isLoading: false });
   useWorkflowsStore.setState({ projectFilter: null, workflows: [] });
 });
@@ -969,6 +983,10 @@ describe('RunTypeOverridesSection — detail screen', () => {
 
     const card = screen.getByTestId('knob-card-runtime');
     fireEvent.click(within(card).getByRole('switch'));
+    // The session-scope set for the LOCAL OMP flavor (Aria off, the default):
+    // every selectableInPickers runtime except the remote fleet supervisor. The
+    // two OMP flavors are alternatives, so `omp-fleet` is absent here — see the
+    // Aria-mode test below for the other half.
     expect(
       within(within(card).getByLabelText('Agent runtime')).getAllByRole('option').map((o) => o.textContent),
     ).toEqual([
@@ -980,6 +998,57 @@ describe('RunTypeOverridesSection — detail screen', () => {
       'OMP',
       'OMP (CLI)',
     ]);
+
+    // The stored value is untouched by the flavor filter: nothing was saved
+    // here, so the control still reads "Follow defaults" for the pick above.
+  });
+
+  // Aria mode is the ONE switch that decides which OMP this install runs, and it
+  // has to reach every surface that names a runtime — otherwise Settings offers
+  // a flavor the launch picker refuses.
+  it('swaps the local OMP runtimes for the fleet supervisor under Aria mode', async () => {
+    // ariaMode is the user's SETTING, so it rides the config store; the query
+    // only supplies `launchable` (whether a bridge is actually reachable).
+    ompAvailabilityMock.mockResolvedValue({ launchable: true, ariaMode: true });
+    await openDetail('Quick session', { ariaMode: true });
+
+    const card = screen.getByTestId('knob-card-runtime');
+    fireEvent.click(within(card).getByRole('switch'));
+
+    await waitFor(() =>
+      expect(
+        within(within(card).getByLabelText('Agent runtime')).getAllByRole('option').map((o) => o.textContent),
+      ).toEqual([
+        'Follow defaults',
+        'Claude SDK',
+        'Claude Interactive (CLI)',
+        'Codex SDK',
+        'Codex (CLI)',
+        'OMP fleet',
+      ]),
+    );
+  });
+
+  // Flipping the toggle changes what you can PICK, never what is already
+  // stored. A <select> whose list omits its own value renders blank and would
+  // rewrite the stored override on the next save of any other field.
+  it('keeps a stored runtime the flavor would hide in its own dropdown', async () => {
+    ompAvailabilityMock.mockResolvedValue({ launchable: true, ariaMode: true });
+    await openDetail('Quick session', {
+      ariaMode: true,
+      runTypeDefaults: { quick: { agentRuntime: 'omp-sdk' } },
+    });
+
+    const card = screen.getByTestId('knob-card-runtime');
+    await waitFor(() => {
+      const labels = within(within(card).getByLabelText('Agent runtime'))
+        .getAllByRole('option')
+        .map((o) => o.textContent);
+      // Both the flavor's runtime AND the stored one the flavor hides.
+      expect(labels).toContain('OMP fleet');
+      expect(labels).toContain('OMP');
+    });
+    expect(within(card).getByLabelText('Agent runtime')).toHaveValue('omp-sdk');
   });
 
   it('omits the session-only PTY runtimes on a workflow screen (the LAUNCHABLE set)', async () => {

--- a/frontend/src/components/settings/__tests__/runTypeOverrides.test.ts
+++ b/frontend/src/components/settings/__tests__/runTypeOverrides.test.ts
@@ -12,6 +12,8 @@ import {
   QUICK_RUN_TYPE_KEY,
   RUN_TYPE_FIELD_ORDER,
   agentRuntimeOptions,
+  agentRuntimePickerOptions,
+  runtimeUnavailableReason,
   baselineValueFor,
   buildRunTypeGroups,
   coerceDraftForModel,
@@ -363,6 +365,66 @@ describe('keys', () => {
     expect(isQuickRunTypeKey(QUICK_RUN_TYPE_KEY)).toBe(true);
     expect(workflowRunTypeKey('wf-1')).toBe('workflow:wf-1');
     expect(isQuickRunTypeKey(workflowRunTypeKey('quick'))).toBe(false);
+  });
+});
+
+const LOCAL_FLAVOR = { launchable: false, ariaMode: false };
+const ARIA_FLAVOR = { launchable: true, ariaMode: true };
+
+describe('agentRuntimePickerOptions', () => {
+  // The two OMP flavors are ALTERNATIVES — an install either supervises a
+  // remote fleet or runs OMP locally. Offering both would let Settings store a
+  // runtime the launch picker refuses to show.
+  it('offers the local OMP runtimes and hides the fleet supervisor by default', () => {
+    const offered = agentRuntimePickerOptions(QUICK_RUN_TYPE_KEY, LOCAL_FLAVOR);
+    expect(offered).toContain('omp-sdk');
+    expect(offered).toContain('omp-pty');
+    expect(offered).not.toContain('omp-fleet');
+  });
+
+  it('swaps to the fleet supervisor under Aria mode', () => {
+    const offered = agentRuntimePickerOptions(QUICK_RUN_TYPE_KEY, ARIA_FLAVOR);
+    expect(offered).toContain('omp-fleet');
+    expect(offered).not.toContain('omp-sdk');
+    expect(offered).not.toContain('omp-pty');
+  });
+
+  // Aria mode ALONE offers the row. Requiring `launchable` too used to leave an
+  // Aria install with no OMP row at all — the local runtimes are hidden
+  // precisely because Aria is on — so the setting silently lost its whole
+  // family. The caller renders it disabled with the reason instead.
+  it('offers the fleet supervisor under Aria mode even when nothing is launchable', () => {
+    expect(
+      agentRuntimePickerOptions(QUICK_RUN_TYPE_KEY, { launchable: false, ariaMode: true }),
+    ).toContain('omp-fleet');
+  });
+
+  it('names why an offered fleet row cannot be selected', () => {
+    expect(runtimeUnavailableReason('omp-fleet', { launchable: false, ariaMode: true })).toBe(
+      'bridge not configured',
+    );
+    expect(runtimeUnavailableReason('omp-fleet', { launchable: true, ariaMode: true })).toBeNull();
+    // Nothing else is ever gated this way.
+    expect(runtimeUnavailableReason('omp-sdk', { launchable: false, ariaMode: false })).toBeNull();
+  });
+
+  // Flipping the toggle changes what you can PICK, never what is stored: a
+  // <select> whose list omits its own value renders blank and would rewrite the
+  // override on the next save.
+  it('keeps the currently-stored runtime offered even when the flavor hides it', () => {
+    expect(agentRuntimePickerOptions(QUICK_RUN_TYPE_KEY, ARIA_FLAVOR, 'omp-sdk')).toContain('omp-sdk');
+    expect(agentRuntimePickerOptions(QUICK_RUN_TYPE_KEY, LOCAL_FLAVOR, 'omp-fleet')).toContain('omp-fleet');
+  });
+
+  // The flavor filter rides ON TOP of the launch-kind narrowing; it must not
+  // widen a workflow key into runtimes that key could never launch.
+  it('never widens the launch-kind set it filters', () => {
+    for (const flavor of [LOCAL_FLAVOR, ARIA_FLAVOR]) {
+      const base = agentRuntimeOptions('workflow:wf-1');
+      for (const runtime of agentRuntimePickerOptions('workflow:wf-1', flavor)) {
+        expect(base).toContain(runtime);
+      }
+    }
   });
 });
 

--- a/frontend/src/components/settings/runTypeOverrides.ts
+++ b/frontend/src/components/settings/runTypeOverrides.ts
@@ -139,6 +139,62 @@ export function agentRuntimeOptions(key: string): readonly AgentRuntime[] {
   return forKind.filter((runtime) => isRuntimeSelectableInPickers(runtime));
 }
 
+/** The OMP runtimes that run OMP on THIS machine, as opposed to supervising a remote fleet. */
+const LOCAL_OMP_RUNTIMES: ReadonlySet<AgentRuntime> = new Set(['omp-sdk', 'omp-pty']);
+
+/**
+ * {@link agentRuntimeOptions} narrowed to the OMP flavor this install actually
+ * runs — the same rule `SubstrateSelector` applies, so Settings and the launch
+ * picker cannot disagree about which OMP exists here.
+ *
+ * The two flavors are ALTERNATIVES: Aria mode supervises a remote fleet
+ * (`omp-fleet`), everything else runs OMP locally (`omp-sdk`/`omp-pty`). Never
+ * both.
+ *
+ * `omp-fleet` is offered on ARIA MODE ALONE. It used to also require
+ * `launchable`, which meant an Aria install with no bridge showed NO OMP row at
+ * all — the local runtimes are hidden precisely because Aria is on. The caller
+ * renders it DISABLED with the reason instead (see
+ * {@link runtimeUnavailableReason}), so the row explains itself rather than
+ * vanishing while the provider toggle still reads "on".
+ *
+ * `current` is preserved unconditionally. A value already stored for this key
+ * must stay in its own dropdown even when the flavor would hide it: a `<select>`
+ * whose list omits its own value renders blank and would rewrite the stored
+ * override the next time any OTHER field on the screen is saved. Flipping the
+ * toggle changes what you can PICK, never what is already stored.
+ *
+ * NOTE: deliberately separate from `agentRuntimeOptions`, which stays the pure
+ * launch-KIND coercion the baseline math depends on (`runTypeBaseline`). Flavor
+ * is a display concern; folding it into the coercion would move baselines — and
+ * therefore every diff chip — when the toggle flips.
+ */
+export function agentRuntimePickerOptions(
+  key: string,
+  omp: { launchable: boolean; ariaMode: boolean },
+  current?: string | null,
+): readonly AgentRuntime[] {
+  return agentRuntimeOptions(key).filter((runtime) => {
+    if (runtime === current) return true;
+    if (runtime === 'omp-fleet') return omp.ariaMode;
+    if (LOCAL_OMP_RUNTIMES.has(runtime)) return !omp.ariaMode;
+    return true;
+  });
+}
+
+/**
+ * Why an OFFERED runtime cannot be selected on this machine, or null when it
+ * can. Mirrors `SubstrateSelector.unavailableReason` so the two pickers give the
+ * same answer for the same install.
+ */
+export function runtimeUnavailableReason(
+  runtime: AgentRuntime,
+  omp: { launchable: boolean; ariaMode: boolean },
+): string | null {
+  if (runtime === 'omp-fleet' && !omp.launchable) return 'bridge not configured';
+  return null;
+}
+
 /** The model aliases the picker offers (single-sourced with the composer pill). */
 export const RUN_TYPE_MODEL_OPTIONS = MODEL_OPTIONS;
 

--- a/frontend/src/hooks/__tests__/useOmpAvailability.test.ts
+++ b/frontend/src/hooks/__tests__/useOmpAvailability.test.ts
@@ -1,0 +1,83 @@
+/**
+ * useOmpAvailability — the OMP flavor probe every runtime picker reads.
+ *
+ * The regression these tests exist for: `ariaMode` used to come from a tRPC
+ * query fired ONCE per mount. A picker already on screen when the toggle
+ * flipped kept the stale flavor, so turning Aria mode OFF left the local OMP
+ * runtimes hidden — the picker offered no OMP at all, and the "runtimes are
+ * hidden" note stayed silent because the component's own baseline was stale
+ * too. It read as "OMP is broken", not "this list is out of date".
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useOmpAvailability } from '../useOmpAvailability';
+import { useConfigStore } from '../../stores/configStore';
+import type { AppConfig } from '../../types/config';
+
+const { availabilityMock } = vi.hoisted(() => ({ availabilityMock: vi.fn() }));
+
+vi.mock('../../trpc/client', () => ({
+  trpc: { cyboflow: { omp: { availability: { query: () => availabilityMock() } } } },
+}));
+
+/** Seed the config store the way a loaded app has it. */
+function setAria(ariaMode: boolean): void {
+  useConfigStore.setState({ config: { ariaMode } as AppConfig, error: null, isLoading: false });
+}
+
+beforeEach(() => {
+  availabilityMock.mockReset();
+  availabilityMock.mockResolvedValue({ launchable: true, ariaMode: true });
+  setAria(false);
+});
+
+describe('useOmpAvailability', () => {
+  it('reports the flavor from the config store, not the query', async () => {
+    // The query still answers `ariaMode: true` — the store is the authority, so
+    // a query that disagrees must not decide the flavor.
+    const { result } = renderHook(() => useOmpAvailability());
+    await waitFor(() => expect(result.current.launchable).toBe(true));
+    expect(result.current.ariaMode).toBe(false);
+  });
+
+  // The bug, exactly: flip the toggle with the hook already mounted.
+  it('swaps flavor on an Aria change without remounting', async () => {
+    const { result } = renderHook(() => useOmpAvailability());
+    await waitFor(() => expect(result.current.launchable).toBe(true));
+    expect(result.current.ariaMode).toBe(false);
+
+    setAria(true);
+
+    await waitFor(() => expect(result.current.ariaMode).toBe(true));
+  });
+
+  // `launchable` ANDs the supervise capability, which Aria mode grants — so the
+  // previous answer is stale by definition once the toggle moves.
+  it('refetches launchable when Aria mode changes', async () => {
+    const { result } = renderHook(() => useOmpAvailability());
+    await waitFor(() => expect(result.current.launchable).toBe(true));
+    expect(availabilityMock).toHaveBeenCalledTimes(1);
+
+    availabilityMock.mockResolvedValue({ launchable: false, ariaMode: true });
+    setAria(true);
+
+    await waitFor(() => expect(availabilityMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(result.current.launchable).toBe(false));
+  });
+
+  it('floors launchable to false when the query fails, keeping the stored flavor', async () => {
+    availabilityMock.mockRejectedValue(new Error('transport down'));
+    setAria(true);
+    const { result } = renderHook(() => useOmpAvailability());
+    await waitFor(() => expect(result.current.launchable).toBe(false));
+    // A dead transport proves nothing about the bridge, but the user's own
+    // setting is still known.
+    expect(result.current.ariaMode).toBe(true);
+  });
+
+  it('floors to unavailable when the omp router is absent (partial trpc mock)', async () => {
+    const { result } = renderHook(() => useOmpAvailability());
+    await waitFor(() => expect(result.current.launchable).toBe(true));
+    expect(result.current).toEqual({ launchable: true, ariaMode: false });
+  });
+});

--- a/frontend/src/hooks/useOmpAvailability.ts
+++ b/frontend/src/hooks/useOmpAvailability.ts
@@ -1,0 +1,74 @@
+/**
+ * useOmpAvailability — what the OMP picker may offer on this install.
+ *
+ * - `launchable`: the main side has a live fleet session manager, so a remote
+ *   worker can actually be spawned.
+ * - `ariaMode`: this install supervises a REMOTE fleet rather than running OMP
+ *   locally. The two OMP flavors are alternatives — the picker shows
+ *   `omp-sdk`/`omp-pty` OR `omp-fleet`, never both.
+ *
+ * Read-only: this drives the SubstrateSelector gating. The provider toggle
+ * (Settings → Integrations) is a SEPARATE gate, ANDed by the caller via
+ * useIsAgentProviderEnabled('omp') — mirroring the two-sided availability in
+ * omp-phase4-coexistence-adr.md §2.3. The renderer read is a courtesy, never
+ * the enforcement: a launch that names a half-configured bridge still fails
+ * closed on the main side.
+ *
+ * A transport failure floors `launchable` to `false` (the honest answer — we
+ * cannot prove anything), never a stale `true`.
+ *
+ * WHY ariaMode COMES FROM THE CONFIG STORE, NOT THE QUERY. Both read the same
+ * config.json, but the query answers ONCE per mount and never refetches — so a
+ * picker that was already on screen when the toggle flipped kept the old flavor
+ * and silently offered the wrong OMP family (or none). Reading the store makes
+ * the swap reactive, because every Settings save already refreshes it.
+ *
+ * `launchable` still has to come from the main side (only it knows whether the
+ * bridge resolved), so it is REFETCHED whenever ariaMode changes — the
+ * supervise capability is derived from Aria mode, so the answer moves with it.
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { trpc } from '../trpc/client';
+import { useConfigStore } from '../stores/configStore';
+
+export interface OmpAvailability {
+  /** A remote worker can actually be spawned right now. */
+  launchable: boolean;
+  /** Remote-fleet install: offer `omp-fleet` instead of the local OMP runtimes. */
+  ariaMode: boolean;
+}
+
+export function useOmpAvailability(): OmpAvailability {
+  // Reactive: the flavor swaps the moment the toggle is saved, on every picker
+  // currently mounted. An unloaded config floors to false — the LOCAL runtimes,
+  // which need no bridge.
+  const ariaMode = useConfigStore((s) => s.config?.ariaMode === true);
+  const [launchable, setLaunchable] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    // Null-safe: a partial `trpc` mock (component tests) may omit `cyboflow.omp`;
+    // a missing router means "cannot prove anything", which is exactly the floor.
+    const availabilityQuery = trpc.cyboflow?.omp?.availability?.query;
+    if (typeof availabilityQuery !== 'function') {
+      setLaunchable(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+    availabilityQuery()
+      .then((res) => {
+        if (!cancelled) setLaunchable(res.launchable === true);
+      })
+      .catch(() => {
+        if (!cancelled) setLaunchable(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // Refetched on an Aria change: `launchable` ANDs the supervise capability,
+    // which Aria mode grants, so the previous answer is stale by definition.
+  }, [ariaMode]);
+
+  return useMemo(() => ({ launchable, ariaMode }), [launchable, ariaMode]);
+}

--- a/frontend/src/stores/__tests__/ompFleetStore.test.ts
+++ b/frontend/src/stores/__tests__/ompFleetStore.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit tests for ompFleetStore.
+ *
+ * Verifies:
+ *   (a) Initial state is { status: 'absent', workerCount: null, ... }.
+ *   (b) A successful snapshot → 'available' + worker count.
+ *   (c) `unavailable` → 'absent'; `malformed`/`unsupported-version` → 'error'.
+ *   (d) A transport/IPC failure downgrades a prior 'available' to 'checking'
+ *       (never stale-green) and bumps lastCheckedAt.
+ *   (e) Aria gating: the registry is read ONLY on a fleet install, the flag
+ *       tracks the toggle live, and leaving a fleet install clears the snapshot.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { OmpFleetViewResult } from '../../../../shared/types/omp';
+
+const { mockFleetSnapshot, mockAvailability } = vi.hoisted(() => ({
+  mockFleetSnapshot: vi.fn<() => Promise<OmpFleetViewResult>>(),
+  mockAvailability: vi.fn<() => Promise<{ launchable: boolean; ariaMode: boolean }>>(),
+}));
+
+vi.mock('../../trpc/client', () => ({
+  trpc: {
+    cyboflow: {
+      omp: {
+        fleetSnapshot: {
+          query: mockFleetSnapshot,
+        },
+        availability: {
+          query: mockAvailability,
+        },
+      },
+    },
+  },
+}));
+
+import { useOmpFleetStore } from '../ompFleetStore';
+
+/** Mirrors the store's own poll cadence (not exported; kept in step by this test). */
+const POLL_INTERVAL_MS = 10000;
+
+const OK_SNAPSHOT: OmpFleetViewResult = {
+  ok: true,
+  snapshot: {
+    version: 1,
+    savedAt: '2026-08-13T00:00:00.000Z',
+    totalWorkers: 2,
+    workers: [],
+  },
+};
+
+function resetStore() {
+  useOmpFleetStore.setState({
+    ariaMode: false,
+    status: 'absent',
+    workerCount: null,
+    errorKind: null,
+    detail: null,
+    lastCheckedAt: null,
+  });
+}
+
+describe('ompFleetStore', () => {
+  beforeEach(() => {
+    resetStore();
+    mockFleetSnapshot.mockReset();
+    mockAvailability.mockReset();
+    // Default: a fleet install, so the pre-existing snapshot tests exercise the
+    // registry path. The Aria-gating cases below override it.
+    mockAvailability.mockResolvedValue({ launchable: true, ariaMode: true });
+  });
+
+  it('starts absent with no worker count', () => {
+    expect(useOmpFleetStore.getState()).toMatchObject({
+      status: 'absent',
+      workerCount: null,
+      errorKind: null,
+      lastCheckedAt: null,
+    });
+  });
+
+  it('setSnapshot maps ok → available with worker count', () => {
+    useOmpFleetStore.getState().setSnapshot(OK_SNAPSHOT);
+    expect(useOmpFleetStore.getState()).toMatchObject({
+      status: 'available',
+      workerCount: 2,
+      errorKind: null,
+    });
+  });
+
+  it('setSnapshot maps missing → absent, unavailable/malformed → error', () => {
+    const s = useOmpFleetStore.getState();
+
+    s.setSnapshot({ ok: false, error: 'missing', detail: 'x' });
+    expect(useOmpFleetStore.getState().status).toBe('absent');
+
+    s.setSnapshot({ ok: false, error: 'unavailable', detail: 'x' });
+    expect(useOmpFleetStore.getState()).toMatchObject({ status: 'error', errorKind: 'unavailable' });
+
+    s.setSnapshot({ ok: false, error: 'malformed', detail: 'x' });
+    expect(useOmpFleetStore.getState()).toMatchObject({ status: 'error', errorKind: 'malformed' });
+  });
+
+  it('a transport error after a good snapshot downgrades to checking (never stale-green)', () => {
+    useOmpFleetStore.getState().setSnapshot(OK_SNAPSHOT);
+    expect(useOmpFleetStore.getState().status).toBe('available');
+
+    useOmpFleetStore.getState().setTransportError();
+    expect(useOmpFleetStore.getState()).toMatchObject({ status: 'checking' });
+    expect(useOmpFleetStore.getState().lastCheckedAt).not.toBeNull();
+  });
+
+  it('subscribeToOmpFleet polls the query and applies the snapshot', async () => {
+    mockFleetSnapshot.mockResolvedValue(OK_SNAPSHOT);
+    const unsubscribe = useOmpFleetStore.getState().subscribeToOmpFleet();
+
+    await vi.waitFor(() => {
+      expect(useOmpFleetStore.getState().status).toBe('available');
+    });
+
+    unsubscribe();
+  });
+
+  it('never reads the registry on a non-fleet install', async () => {
+    mockAvailability.mockResolvedValue({ launchable: false, ariaMode: false });
+    const unsubscribe = useOmpFleetStore.getState().subscribeToOmpFleet();
+    await vi.waitFor(() => expect(mockAvailability).toHaveBeenCalled());
+
+    // The dot is hidden, so paying a filesystem read per tick for it is waste.
+    expect(mockFleetSnapshot).not.toHaveBeenCalled();
+    expect(useOmpFleetStore.getState().ariaMode).toBe(false);
+    unsubscribe();
+  });
+
+  it('tracks the Aria toggle live on the NEXT tick of one subscription', async () => {
+    // Fake timers so this exercises the real poll interval rather than a second
+    // subscribe() — the point is that ONE live subscription notices the toggle.
+    vi.useFakeTimers();
+    try {
+      mockAvailability.mockResolvedValue({ launchable: false, ariaMode: false });
+      const unsubscribe = useOmpFleetStore.getState().subscribeToOmpFleet();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(useOmpFleetStore.getState().ariaMode).toBe(false);
+      expect(mockFleetSnapshot).not.toHaveBeenCalled();
+
+      // Toggling Aria mode ON must surface the indicator without a relaunch —
+      // the fleet MANAGER needs one, but a status dot does not.
+      mockAvailability.mockResolvedValue({ launchable: true, ariaMode: true });
+      mockFleetSnapshot.mockResolvedValue(OK_SNAPSHOT);
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+      expect(useOmpFleetStore.getState().ariaMode).toBe(true);
+      expect(useOmpFleetStore.getState().status).toBe('available');
+      expect(mockFleetSnapshot).toHaveBeenCalledTimes(1);
+      unsubscribe();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears the snapshot when leaving a fleet install', () => {
+    useOmpFleetStore.getState().setAriaMode(true);
+    useOmpFleetStore.getState().setSnapshot(OK_SNAPSHOT);
+    expect(useOmpFleetStore.getState().workerCount).toBe(2);
+
+    useOmpFleetStore.getState().setAriaMode(false);
+
+    // Otherwise re-enabling Aria mode would flash last week's fleet health
+    // before the first real snapshot lands.
+    const state = useOmpFleetStore.getState();
+    expect(state.status).toBe('absent');
+    expect(state.workerCount).toBeNull();
+    expect(state.errorKind).toBeNull();
+  });
+
+  it('hides rather than guesses when the availability probe fails', async () => {
+    useOmpFleetStore.getState().setAriaMode(true);
+    mockAvailability.mockRejectedValue(new Error('ipc down'));
+    const unsubscribe = useOmpFleetStore.getState().subscribeToOmpFleet();
+    await vi.waitFor(() => expect(useOmpFleetStore.getState().ariaMode).toBe(false));
+
+    expect(mockFleetSnapshot).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+});

--- a/frontend/src/stores/ompFleetStore.ts
+++ b/frontend/src/stores/ompFleetStore.ts
@@ -1,0 +1,170 @@
+/**
+ * ompFleetStore — Zustand store for OMP fleet awareness (read-only).
+ *
+ * Polls `trpc.cyboflow.omp.fleetSnapshot` and collapses the discriminated
+ * `OmpFleetViewResult` into a four-value UI status:
+ *   'available' → green   (registry parsed; worker count shown)
+ *   'absent'    → gray    (no registry / unavailable — OMP never ran here)
+ *   'error'     → red     (malformed or unsupported-version)
+ *   'checking'  → yellow  (transport/IPC failure — last snapshot is STALE)
+ *
+ * A transport failure downgrades to 'checking' and bumps `lastCheckedAt`, so the
+ * indicator NEVER presents old fleet health as current. Polling pauses while
+ * `document.hidden` and refreshes immediately on visibility restore.
+ *
+ * This is READ-ONLY awareness. No command/mutation surface is reachable from
+ * the renderer; the privileged command router is a separate, capability-gated
+ * surface that v1 leaves forbidden by default.
+ *
+ * Cold-mount guarantee: status starts 'absent', never 'available', until a real
+ * snapshot returns ok.
+ *
+ * Aria gating: the indicator is fleet awareness, so it only means anything on a
+ * fleet install. Each tick probes `availability` FIRST and reads the registry
+ * only when `ariaMode` is on — a local-OMP or non-OMP install pays one cheap
+ * in-memory query per interval instead of a filesystem read for a dot nobody
+ * sees. Probing every tick (rather than once at subscribe) is what lets the
+ * indicator appear and disappear as the Settings toggle flips, without the
+ * relaunch the fleet MANAGER needs.
+ */
+import { create } from 'zustand';
+import type { OmpFleetViewResult } from '../../../shared/types/omp';
+import { trpc } from '../trpc/client';
+
+export type OmpFleetUiStatus = 'available' | 'absent' | 'error' | 'checking';
+
+export interface OmpFleetState {
+  /**
+   * Whether this install supervises a remote fleet (Settings → Advanced Options
+   * → Aria mode). Starts false so the indicator is hidden on a cold mount and
+   * on any probe failure — a dot that cannot explain itself is worse than no
+   * dot, and OMP ships disabled by default.
+   */
+  ariaMode: boolean;
+  status: OmpFleetUiStatus;
+  /** Worker count when ok, else null. */
+  workerCount: number | null;
+  /** Error category when !ok, else null. */
+  errorKind: 'unavailable' | 'missing' | 'unsupported-version' | 'malformed' | null;
+  /** Redacted detail for the popover (already flattened by main; not raw registry data). */
+  detail: string | null;
+  lastCheckedAt: number | null;
+}
+
+export interface OmpFleetActions {
+  setSnapshot: (result: OmpFleetViewResult) => void;
+  setTransportError: () => void;
+  setAriaMode: (ariaMode: boolean) => void;
+  /** Start polling; returns an unsubscribe function. */
+  subscribeToOmpFleet: () => () => void;
+}
+
+const POLL_INTERVAL_MS = 10000;
+
+export const useOmpFleetStore = create<OmpFleetState & OmpFleetActions>()((set, get) => ({
+  ariaMode: false,
+  status: 'absent',
+  workerCount: null,
+  errorKind: null,
+  detail: null,
+  lastCheckedAt: null,
+
+  setSnapshot(result) {
+    if (result.ok) {
+      set({
+        status: 'available',
+        workerCount: result.snapshot.totalWorkers,
+        errorKind: null,
+        detail: null,
+        lastCheckedAt: Date.now(),
+      });
+      return;
+    }
+    set({
+      status: result.error === 'missing' ? 'absent' : 'error',
+      workerCount: null,
+      errorKind: result.error,
+      detail: result.detail,
+      lastCheckedAt: Date.now(),
+    });
+  },
+
+  setAriaMode(ariaMode) {
+    // Leaving a fleet install resets the snapshot fields: keeping a stale worker
+    // count around would let the indicator flash last week's fleet health if
+    // Aria mode is switched back on.
+    set((prev) =>
+      prev.ariaMode === ariaMode
+        ? { ariaMode }
+        : { ariaMode, status: 'absent', workerCount: null, errorKind: null, detail: null },
+    );
+  },
+
+  setTransportError() {
+    // Keep the last-known worker count/detail for context, but mark the
+    // snapshot stale — the UI must not show it as current.
+    set((prev) => ({
+      status: 'checking',
+      lastCheckedAt: Date.now(),
+      errorKind: prev.errorKind,
+      detail: prev.detail,
+    }));
+  },
+
+  subscribeToOmpFleet() {
+    let alive = true;
+    let intervalId: ReturnType<typeof setInterval> | undefined;
+
+    const poll = async () => {
+      // Aria first: on a non-fleet install this is the only query per tick, and
+      // the registry is never read.
+      let ariaMode: boolean;
+      try {
+        const availability = await trpc.cyboflow.omp.availability.query();
+        ariaMode = availability.ariaMode === true;
+      } catch {
+        // Cannot prove this is a fleet install ⇒ hide, don't guess.
+        if (alive) get().setAriaMode(false);
+        return;
+      }
+      if (!alive) return;
+      get().setAriaMode(ariaMode);
+      if (!ariaMode) return;
+
+      try {
+        const result: OmpFleetViewResult = await trpc.cyboflow.omp.fleetSnapshot.query();
+        if (alive) get().setSnapshot(result);
+      } catch {
+        if (alive) get().setTransportError();
+      }
+    };
+
+    const start = () => {
+      if (intervalId !== undefined) return;
+      void poll();
+      intervalId = setInterval(() => { void poll(); }, POLL_INTERVAL_MS);
+    };
+
+    const stop = () => {
+      if (intervalId !== undefined) {
+        clearInterval(intervalId);
+        intervalId = undefined;
+      }
+    };
+
+    // Pause while the window is hidden; refresh immediately on restore.
+    const onVisibility = () => {
+      if (document.hidden) stop();
+      else start();
+    };
+
+    start();
+    document.addEventListener('visibilitychange', onVisibility);
+
+    return () => {
+      alive = false;
+      stop();
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  },
+}));

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -138,6 +138,12 @@ export interface AppConfig {
   // the durable recovery gate can be exercised live. Only takes effect in dev
   // (unpackaged) runs; never fires in a packaged release.
   forceAskUserQuestionGateFailure?: boolean;
+  // Aria mode: supervise a REMOTE OMP fleet (`omp-fleet`) over the Prime bridge
+  // instead of running the LOCAL OMP runtimes (`omp-sdk`/`omp-pty`). The two are
+  // alternatives — the runtime picker offers one or the other, never both. Also
+  // the grant of the `omp:supervise` capability. Read at boot when the fleet
+  // session manager is built, so a change takes effect on the next launch.
+  ariaMode?: boolean;
   // Demo mode: throwaway demo database + sandbox repo with scripted agent runs.
   // Read once at startup — toggling relaunches the app.
   demoMode?: boolean;

--- a/main/src/database/__tests__/migration119.test.ts
+++ b/main/src/database/__tests__/migration119.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Migration 119_agent_runtime_omp_fleet.sql — admitting 'omp-fleet'.
+ *
+ * The regression this file exists to prevent: an earlier attempt shipped the
+ * widening as a NEW file numbered 101 (a gap below the already-released 103)
+ * that rebuilt `sessions` from a hardcoded CREATE TABLE. Because the migration
+ * ledger is keyed by FILENAME, that file ran LAST on an already-migrated DB
+ * rather than in its numeric position — against a post-103/104 schema — where
+ * it (a) dropped every column its hardcoded list omitted and (b) restated 103's
+ * CHECK lists from memory, silently UN-widening 'omp-sdk'/'omp-pty'.
+ *
+ * So the tests below run the REAL upgrade a shipped-release user performs: a DB is built
+ * by a DatabaseService whose migrations dir omits 119 ONLY (103 and 104 are
+ * present, exactly as they are on a shipped install), rows are seeded, and a
+ * second DatabaseService pointed at the full dir boots on the same file.
+ *
+ * Proves:
+ *   1. 'omp-fleet' becomes storable on sessions and workflow_runs.
+ *   2. 103's widenings SURVIVE — 'omp-sdk'/'omp-pty' stay storable on sessions.
+ *   3. Every pre-existing row survives verbatim, INCLUDING a seeded omp-sdk
+ *      session (the row shape that made the 101 attempt fail closed forever).
+ *   4. No column is lost — in particular `status_message`, which database.ts
+ *      adds imperatively and no .sql file lists.
+ *   5. Indexes, triggers and FK edges are unchanged and foreign_key_check clean.
+ *   6. The deliberate narrowings hold: omp-fleet is rejected on the two tables
+ *      119 does not widen, and a bogus runtime is still rejected everywhere.
+ *   7. The fresh-install path lands the same constraints.
+ *   8. Re-applying 119 after a cleared ledger marker is a harmless no-op.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type BetterSqlite3 from 'better-sqlite3';
+import { mkdtempSync, rmSync, readdirSync, copyFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseService } from '../database';
+
+const MIGRATIONS_DIR = join(__dirname, '..', 'migrations');
+const MIGRATION_119 = '119_agent_runtime_omp_fleet.sql';
+
+let tmpDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cyboflow-migration119-'));
+  dbPath = join(tmpDir, 'test.db');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/**
+ * A migrations dir holding every real migration EXCEPT 119 — i.e. a shipped
+ * 0.2.3 install, with 103 and 104 already applied. This is the distinction that
+ * matters: excluding everything at-or-above the new file's number (as the 101
+ * attempt's own test did) fabricates a pre-state that no user is ever in.
+ */
+function migrationsDirWithout119(): string {
+  const dir = join(tmpDir, 'migrations-pre-119');
+  mkdirSync(dir);
+  for (const name of readdirSync(MIGRATIONS_DIR)) {
+    if (name === MIGRATION_119) continue;
+    if (!/^\d{3}_.*\.sql$/.test(name)) continue;
+    copyFileSync(join(MIGRATIONS_DIR, name), join(dir, name));
+  }
+  return dir;
+}
+
+function openAt(migrationsDir: string): DatabaseService {
+  const svc = new DatabaseService(dbPath);
+  svc.setMigrationsDirForTesting(migrationsDir);
+  svc.initialize();
+  return svc;
+}
+
+/** Seed the rows a 0.2.3 OMP user actually has, plus the legacy baseline. */
+function seedRows(db: BetterSqlite3.Database): void {
+  db.prepare(`INSERT INTO projects (id, name, path) VALUES (1, 'Proj', '/tmp/p119')`).run();
+  db.prepare(
+    `INSERT INTO workflows (id, project_id, name, spec_json) VALUES ('wf-1', 1, 'sprint', '{}')`,
+  ).run();
+
+  const insertSession = db.prepare(
+    `INSERT INTO sessions (id, name, initial_prompt, worktree_name, worktree_path, project_id,
+                           status_message, agent_provider, agent_runtime)
+     VALUES (?, ?, 'go', ?, ?, 1, ?, ?, ?)`,
+  );
+  insertSession.run('s-claude', 'Claude', 'wt-1', '/tmp/wt-1', 'Waiting', 'claude', 'claude-sdk');
+  insertSession.run('s-codex-pty', 'Codex TUI', 'wt-2', '/tmp/wt-2', null, 'codex', 'codex-pty');
+  // The row that made the 101 attempt fail closed on every boot, forever.
+  insertSession.run('s-omp-sdk', 'OMP', 'wt-3', '/tmp/wt-3', 'Running', 'omp', 'omp-sdk');
+  insertSession.run('s-omp-pty', 'OMP TUI', 'wt-4', '/tmp/wt-4', null, 'omp', 'omp-pty');
+
+  const insertRun = db.prepare(
+    `INSERT INTO workflow_runs (id, workflow_id, project_id, status, permission_mode_snapshot,
+                                agent_provider, agent_runtime)
+     VALUES (?, 'wf-1', 1, 'completed', 'default', ?, ?)`,
+  );
+  insertRun.run('run-claude', 'claude', 'claude-sdk');
+  insertRun.run('run-omp', 'omp', 'omp-sdk');
+}
+
+function allRows(db: BetterSqlite3.Database, table: string): Array<Record<string, unknown>> {
+  return db.prepare(`SELECT * FROM ${table} ORDER BY rowid`).all() as Array<Record<string, unknown>>;
+}
+
+function columnNames(db: BetterSqlite3.Database, table: string): string[] {
+  return (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>)
+    .map((c) => c.name)
+    .sort();
+}
+
+function schemaObjectNames(db: BetterSqlite3.Database, table: string): string[] {
+  return (
+    db
+      .prepare(
+        `SELECT name FROM sqlite_master
+          WHERE tbl_name = ? AND type IN ('index','trigger','view')
+          ORDER BY name`,
+      )
+      .all(table) as Array<{ name: string }>
+  ).map((r) => r.name);
+}
+
+function fkEdges(db: BetterSqlite3.Database, table: string): string[] {
+  return (
+    db.prepare(`PRAGMA foreign_key_list(${table})`).all() as Array<{
+      table: string;
+      from: string;
+      to: string | null;
+      on_delete: string;
+    }>
+  )
+    .map((fk) => `${table}.${fk.from} -> ${fk.table}.${fk.to} ON DELETE ${fk.on_delete}`)
+    .sort();
+}
+
+interface Snapshot {
+  rows: Record<string, Array<Record<string, unknown>>>;
+  columns: Record<string, string[]>;
+  objects: Record<string, string[]>;
+  fks: Record<string, string[]>;
+}
+
+const TARGET_TABLES = ['sessions', 'workflow_runs'] as const;
+
+function snapshot(db: BetterSqlite3.Database): Snapshot {
+  const snap: Snapshot = { rows: {}, columns: {}, objects: {}, fks: {} };
+  for (const t of TARGET_TABLES) {
+    snap.rows[t] = allRows(db, t);
+    snap.columns[t] = columnNames(db, t);
+    snap.objects[t] = schemaObjectNames(db, t);
+    snap.fks[t] = fkEdges(db, t);
+  }
+  return snap;
+}
+
+/** Migrate to the shipped pre-119 state, seed, snapshot; then boot with 119. */
+function upgradeThrough119(): { db: BetterSqlite3.Database; before: Snapshot; svc: DatabaseService } {
+  const pre119 = migrationsDirWithout119();
+  // Two pre-119 boots, not one: initializeSchema() reads PRAGMA table_info(sessions)
+  // before schema.sql has created the table, so its imperative
+  // "ALTER TABLE sessions ADD COLUMN status_message" only lands on the SECOND
+  // launch. Settling that here keeps the snapshot diff about 119 alone — and
+  // makes `status_message` present in the pre-state, which is the whole point.
+  openAt(pre119).close();
+  const pre = openAt(pre119);
+  seedRows(pre.getDb());
+  const before = snapshot(pre.getDb());
+  pre.close();
+
+  const svc = openAt(MIGRATIONS_DIR);
+  return { db: svc.getDb(), before, svc };
+}
+
+/** Insert a session with the given runtime; return the SQLite error, if any. */
+function trySession(db: BetterSqlite3.Database, id: string, provider: string, runtime: string): string | null {
+  try {
+    db.prepare(
+      `INSERT INTO sessions (id, name, initial_prompt, worktree_name, worktree_path,
+                             agent_provider, agent_runtime)
+       VALUES (?, ?, 'go', ?, ?, ?, ?)`,
+    ).run(id, id, `wt-${id}`, `/tmp/${id}`, provider, runtime);
+    return null;
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+}
+
+function tryRun(db: BetterSqlite3.Database, id: string, provider: string, runtime: string): string | null {
+  try {
+    db.prepare(
+      `INSERT INTO workflow_runs (id, workflow_id, project_id, status, permission_mode_snapshot,
+                                  agent_provider, agent_runtime)
+       VALUES (?, 'wf-1', 1, 'running', 'default', ?, ?)`,
+    ).run(id, provider, runtime);
+    return null;
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+}
+
+describe('Migration 119: omp-fleet admitted on the session + workflow-run runtime CHECKs', () => {
+  it('(a) makes omp-fleet storable on sessions and workflow_runs', () => {
+    const { db, svc } = upgradeThrough119();
+    expect(trySession(db, 's-fleet', 'omp', 'omp-fleet')).toBeNull();
+    expect(tryRun(db, 'run-fleet', 'omp', 'omp-fleet')).toBeNull();
+    svc.close();
+  });
+
+  it("(b) preserves 103's widenings — omp-sdk and omp-pty stay storable on sessions", () => {
+    const { db, svc } = upgradeThrough119();
+    expect(trySession(db, 's-new-omp-sdk', 'omp', 'omp-sdk')).toBeNull();
+    expect(trySession(db, 's-new-omp-pty', 'omp', 'omp-pty')).toBeNull();
+    expect(tryRun(db, 'run-new-omp-sdk', 'omp', 'omp-sdk')).toBeNull();
+    svc.close();
+  });
+
+  it('(c) preserves every pre-existing row verbatim, including the omp-sdk session', () => {
+    const { db, before, svc } = upgradeThrough119();
+    for (const t of TARGET_TABLES) {
+      expect(allRows(db, t)).toEqual(before.rows[t]);
+    }
+    const ompRow = allRows(db, 'sessions').find((r) => r.id === 's-omp-sdk');
+    expect(ompRow?.agent_runtime).toBe('omp-sdk');
+    expect(ompRow?.status_message).toBe('Running');
+    svc.close();
+  });
+
+  it('(d) loses no column — status_message (added imperatively, listed in no .sql) survives', () => {
+    const { db, before, svc } = upgradeThrough119();
+    for (const t of TARGET_TABLES) {
+      expect(columnNames(db, t)).toEqual(before.columns[t]);
+    }
+    expect(columnNames(db, 'sessions')).toContain('status_message');
+    // The temp parking columns must not leak into the final shape.
+    expect(columnNames(db, 'sessions')).not.toContain('agent_runtime_widen_119');
+    expect(columnNames(db, 'workflow_runs')).not.toContain('agent_runtime_widen_119');
+    svc.close();
+  });
+
+  it('(e) leaves indexes, triggers and foreign keys untouched', () => {
+    const { db, before, svc } = upgradeThrough119();
+    for (const t of TARGET_TABLES) {
+      expect(schemaObjectNames(db, t)).toEqual(before.objects[t]);
+      expect(fkEdges(db, t)).toEqual(before.fks[t]);
+    }
+    expect(db.prepare('PRAGMA foreign_key_check').all()).toEqual([]);
+    svc.close();
+  });
+
+  it('(f) keeps omp-fleet off workflow_variants and agent_invocations, and still rejects bogus runtimes', () => {
+    const { db, svc } = upgradeThrough119();
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO workflow_variants (id, workflow_id, label, agent_provider, agent_runtime)
+           VALUES ('wfv-fleet', 'wf-1', 'fleet-arm', 'omp', 'omp-fleet')`,
+        )
+        .run(),
+    ).toThrow(/CHECK constraint failed/);
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO agent_invocations (agent_invocation_id, run_id, agent_provider, agent_runtime)
+           VALUES ('inv-fleet', 'run-claude', 'omp', 'omp-fleet')`,
+        )
+        .run(),
+    ).toThrow(/CHECK constraint failed/);
+    expect(trySession(db, 's-bogus', 'omp', 'omp-telepathy')).toMatch(/CHECK constraint failed/);
+    expect(tryRun(db, 'run-bogus', 'omp', 'omp-telepathy')).toMatch(/CHECK constraint failed/);
+    svc.close();
+  });
+
+  it('(g) lands the same constraints on a fresh install', () => {
+    const svc = openAt(MIGRATIONS_DIR);
+    const db = svc.getDb();
+    db.prepare(`INSERT INTO projects (id, name, path) VALUES (1, 'Proj', '/tmp/p119f')`).run();
+    db.prepare(
+      `INSERT INTO workflows (id, project_id, name, spec_json) VALUES ('wf-1', 1, 'sprint', '{}')`,
+    ).run();
+    expect(trySession(db, 's-fleet', 'omp', 'omp-fleet')).toBeNull();
+    expect(trySession(db, 's-sdk', 'omp', 'omp-sdk')).toBeNull();
+    expect(tryRun(db, 'run-fleet', 'omp', 'omp-fleet')).toBeNull();
+    expect(trySession(db, 's-bogus', 'omp', 'omp-telepathy')).toMatch(/CHECK constraint failed/);
+    svc.close();
+  });
+
+  it('(h) re-applying 119 after a cleared ledger marker is a harmless no-op', () => {
+    const { db, before, svc } = upgradeThrough119();
+    db.prepare('DELETE FROM user_preferences WHERE key = ?').run(
+      `file_migration_applied:${MIGRATION_119}`,
+    );
+    svc.close();
+
+    const again = openAt(MIGRATIONS_DIR);
+    const db2 = again.getDb();
+    for (const t of TARGET_TABLES) {
+      expect(allRows(db2, t)).toEqual(before.rows[t]);
+      expect(columnNames(db2, t)).toEqual(before.columns[t]);
+    }
+    expect(trySession(db2, 's-fleet-again', 'omp', 'omp-fleet')).toBeNull();
+    again.close();
+  });
+
+  it('(i) no stale pre-renumber fleet migration exists in the migrations dir', () => {
+    // The ledger is keyed by FILENAME, so a resurrected 105_/107_ copy of this
+    // widening would apply AGAIN after 119 — against an already-widened schema
+    // where its add/copy/drop sequence is still idempotent, but its existence
+    // means two files claim the same widening and the next renumber war starts
+    // here. Guard the invariant at the directory level.
+    const names = readdirSync(MIGRATIONS_DIR);
+    expect(names).toContain(MIGRATION_119);
+    expect(names).not.toContain('105_agent_runtime_omp_fleet.sql');
+    expect(names).not.toContain('107_agent_runtime_omp_fleet.sql');
+  });
+});

--- a/main/src/database/migrations/119_agent_runtime_omp_fleet.sql
+++ b/main/src/database/migrations/119_agent_runtime_omp_fleet.sql
@@ -1,0 +1,90 @@
+-- Migration 119: admit 'omp-fleet' on sessions.agent_runtime and
+-- workflow_runs.agent_runtime (OMP Phase 4, the fleet-supervisor runtime).
+--
+-- NUMBERED 119. Authored as 105, renumbered to 107 when main shipped its own
+-- 105/106 — and renumbered AGAIN to 119 on the 0.2.6 rebase because main had
+-- by then taken 107_bootstrap_proof through 118_tracker_content_archive_modes.
+-- The ledger is keyed by FILENAME: a dev install that applied the old 105 or
+-- 107 name applies this one again, which is harmless — the sequence is
+-- idempotent, and test (h) pins that.
+--
+-- WHY A NEW FILE RATHER THAN AN EDIT TO 103. The migration ledger is keyed by
+-- FILENAME and applies each .sql exactly once, so widening 103's CHECK list in
+-- place would land only on fresh installs and silently never re-apply on an
+-- already-migrated DB — the 062_approve_ideas_atype lesson 103's own header
+-- records. Every install that already shipped 0.2.3 has 103 marked applied.
+--
+-- WHY NOT A CREATE-NEW/COPY/DROP/RENAME REBUILD OF `sessions`. 103 spells out
+-- the hazard and it applies verbatim here: `sessions` is Crystal-legacy, ~40
+-- columns accreted through ALTER TABLE, several of them added imperatively by
+-- database.ts rather than by any .sql (`status_message` is the live example),
+-- so "a hardcoded CREATE TABLE would silently drop any column a given install
+-- has but this file does not list". It would also have to restate 103's own
+-- widened CHECK lists from memory, and getting that wrong would UN-widen
+-- 'omp-sdk'/'omp-pty' on the very installs that use them.
+--
+-- So this file reuses 103's shape-agnostic recipe: the constraint lives in a
+-- column-level CHECK on a column that is in no index, no trigger, no view and
+-- no other CHECK, so SQLite can DROP the column and re-ADD it with the widened
+-- CHECK. It names only the column being widened, leaves every other column,
+-- index and foreign key untouched, and needs no FK re-pointing. Values are
+-- parked in a temp column across the drop. The sequence is idempotent, so a
+-- re-run after a cleared ledger marker is harmless.
+--
+-- The widened sets deliberately differ per table, exactly as 103's do:
+--   sessions      + 'omp-fleet'  — the fleet supervisor is a session runtime.
+--   workflow_runs + 'omp-fleet'  — parity with the declared contract:
+--                                  WORKFLOW_RUN_STORABLE_RUNTIMES
+--                                  (shared/types/agentRuntime.ts) lists
+--                                  'omp-fleet' as storable, so the column's
+--                                  CHECK must admit every value that constant
+--                                  permits or the type and the schema disagree.
+--                                  NOTE: no writer emits it TODAY. The
+--                                  quick-session sentinel does not carry the
+--                                  session's resolved runtime — workflowRegistry
+--                                  derives its stamp from `ompSdkRequested` and
+--                                  writes 'omp-sdk' for a fleet session
+--                                  (workflowRegistry.ts, createRun). This
+--                                  widening is therefore forward-looking: it
+--                                  keeps a future stamp from failing the CHECK
+--                                  at write time, and costs nothing meanwhile.
+--                                  Storable, never launchable
+--                                  (WORKFLOW_LAUNCHABLE_RUNTIMES still excludes
+--                                  it — a fleet supervisor has no per-step event
+--                                  stream).
+-- workflow_variants and agent_invocations are deliberately NOT widened: a
+-- variant resolves to a workflow-launchable runtime, and an invocation row
+-- records a per-step agent turn. Neither can ever be a fleet supervisor.
+--
+-- No `PRAGMA foreign_keys=OFF` marker: unlike 103 this file drops no table, so
+-- there is nothing for a cascade or an orphan row to abort. The runner's
+-- wrapping transaction is sufficient.
+
+-- ---------------------------------------------------------------------------
+-- sessions.agent_runtime  (103 list + 'omp-fleet')
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE sessions ADD COLUMN agent_runtime_widen_119 TEXT;
+UPDATE sessions SET agent_runtime_widen_119 = agent_runtime;
+ALTER TABLE sessions DROP COLUMN agent_runtime;
+ALTER TABLE sessions
+  ADD COLUMN agent_runtime TEXT NOT NULL DEFAULT 'claude-sdk'
+    CHECK (agent_runtime IN ('claude-sdk','claude-interactive','codex-sdk','codex-pty','omp-sdk','omp-pty','omp-fleet'));
+UPDATE sessions SET agent_runtime = COALESCE(agent_runtime_widen_119, 'claude-sdk');
+ALTER TABLE sessions DROP COLUMN agent_runtime_widen_119;
+
+-- ---------------------------------------------------------------------------
+-- workflow_runs.agent_runtime  (103 list + 'omp-fleet')
+--
+-- omp-pty stays absent for the same reason codex-pty is: a workflow run needs
+-- structured events, usage, MCP progress and review-queue integration.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE workflow_runs ADD COLUMN agent_runtime_widen_119 TEXT;
+UPDATE workflow_runs SET agent_runtime_widen_119 = agent_runtime;
+ALTER TABLE workflow_runs DROP COLUMN agent_runtime;
+ALTER TABLE workflow_runs
+  ADD COLUMN agent_runtime TEXT NOT NULL DEFAULT 'claude-sdk'
+    CHECK (agent_runtime IN ('claude-sdk','claude-interactive','codex-sdk','omp-sdk','omp-fleet'));
+UPDATE workflow_runs SET agent_runtime = COALESCE(agent_runtime_widen_119, 'claude-sdk');
+ALTER TABLE workflow_runs DROP COLUMN agent_runtime_widen_119;

--- a/main/src/events.ts
+++ b/main/src/events.ts
@@ -1179,6 +1179,85 @@ export function setupEventListeners(services: AppServices, getMainWindow: () => 
     }
   });
 
+  // OMP fleet runtime (omp-phase4-coexistence-adr.md increment 4). A remote
+  // worker with no local child process: its raw text output is projected to the
+  // SAME JSON assistant-message shape the SDK transcript projects, so the
+  // unified chat renders it with no new frontend surface. The manager is
+  // optional (undefined when the bridge config did not resolve) — guard on it.
+  const ompSessionManager = services.ompSessionManager;
+  if (ompSessionManager) {
+    let ompOutputSeq = 0;
+    ompSessionManager.on(
+      'output',
+      async ({ panelId, sessionId, data }: { panelId: string; sessionId: string; data: string }) => {
+        if (isCyboflowRunId(panelId) || isCyboflowRunId(sessionId)) return;
+        // Project raw worker text to a structured assistant message so the
+        // existing projectStoredOutputs → MessageProjection path renders it.
+        ompOutputSeq += 1;
+        const messageId = `omp-${panelId}-${ompOutputSeq}`;
+        sessionManager.addPanelOutput(panelId, {
+          type: 'json',
+          data: {
+            type: 'assistant',
+            message: {
+              id: messageId,
+              model: 'omp-fleet',
+              role: 'assistant',
+              content: [{ type: 'text', text: data }],
+            },
+            session_id: sessionId,
+          },
+          timestamp: new Date(),
+        });
+        const mw = getMainWindow();
+        if (mw && !mw.isDestroyed()) {
+          mw.webContents.send('session:output', { panelId, sessionId, type: 'stdout', data });
+        }
+      },
+    );
+
+    ompSessionManager.on('spawned', async ({ panelId, sessionId }: { panelId: string; sessionId: string }) => {
+      if (isCyboflowRunId(panelId) || isCyboflowRunId(sessionId)) return;
+      await updateAIPanelStatus(panelId, 'running');
+      await sessionManager.updateSession(sessionId, { status: 'running' });
+    });
+
+    ompSessionManager.on(
+      'exit',
+      async ({ panelId, sessionId, exitCode }: { panelId: string; sessionId: string; exitCode: number | null }) => {
+        if (isCyboflowRunId(panelId) || isCyboflowRunId(sessionId)) return;
+        const isActive = isPanelActive(panelId, sessionId);
+        const panelStatusOnExit: PanelStatus = exitCode === 0 && !isActive ? 'completed_unviewed' : 'stopped';
+        await updateAIPanelStatus(panelId, panelStatusOnExit, exitCode === 0 && !isActive);
+        const dbSession = sessionManager.getDbSession(sessionId);
+        if (dbSession && dbSession.status === 'running') {
+          // Write the DB status raw, then re-fetch + emit 'session-updated' —
+          // the same shape as the SDK completion path. 'completed' has no
+          // app-level Session status: mapDbStatusToSessionStatus turns it into
+          // completed_unviewed when unviewed, so refreshSessionFromDatabase
+          // (convert + activeSessions.set + emit) surfaces the right status.
+          sessionManager.db.updateSession(sessionId, { status: exitCode === 0 ? 'completed' : 'stopped' });
+          sessionManager.refreshSessionFromDatabase(sessionId);
+        }
+      },
+    );
+
+    ompSessionManager.on(
+      'error',
+      async ({ panelId, sessionId, error, transient }: { panelId: string; sessionId: string; error: string; transient: boolean }) => {
+        if (isCyboflowRunId(panelId) || isCyboflowRunId(sessionId)) return;
+        console.error(`[Events] OMP worker error for panel ${panelId}: ${error}`);
+        // A TRANSIENT error leaves the worker live — one bridge blip must not
+        // park the panel in 'error' forever. Nothing ever clears that badge:
+        // 'spawned' fires once at spawn, so the panel would read as failed for
+        // the rest of a perfectly healthy run. Real termination arrives as
+        // 'exit' and is handled above.
+        if (transient) return;
+        await updateAIPanelStatus(panelId, 'error');
+      },
+    );
+  }
+
   // Listen for archive progress events
   if (archiveProgressManager) {
     archiveProgressManager.on('archive-progress', (progress) => {

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -92,6 +92,16 @@ import { QuestionRouter } from './orchestrator/questionRouter';
 import { TaskChangeRouter } from './orchestrator/taskChangeRouter';
 import { ReviewItemRouter, reviewItemChangeEvents, reviewItemProjectChannel } from './orchestrator/reviewItemRouter';
 import { AgentOverrideRouter } from './orchestrator/agentOverrideRouter';
+import { FleetRegistryReader } from './orchestrator/omp/fleetRegistryReader';
+import { OmpBridgeCommandAdapter } from './orchestrator/omp/ompBridgeCommandAdapter';
+import { OmpBridgeHttpClient } from './orchestrator/omp/ompBridgeClient';
+import { resolveOmpBridgeCommandConfig } from './orchestrator/omp/ompBridgeConfig';
+import { resolveOmpPrincipal } from './orchestrator/omp/ompPrincipal';
+import { OmpCommandStub } from './orchestrator/omp/ompCommandStub';
+import type { OmpCommandAdapter, OmpPrincipal } from '../../shared/types/ompCommand';
+import { OmpSessionManager } from './orchestrator/omp/ompSessionManager';
+import { OmpSupervisedAdapter, type OmpSupervisedAuditEntry } from './orchestrator/omp/ompSupervisedAdapter';
+import { hasSupervise } from '../../shared/types/ompCommand';
 import { FeedbackRouter } from './orchestrator/feedbackRouter';
 import { IdeaComponentRouter } from './orchestrator/ideaComponents/ideaComponentRouter';
 import { setRevisionLauncher } from './orchestrator/sendFeedbackHandler';
@@ -398,6 +408,69 @@ function setAppTitle() {
 }
 let taskQueue: TaskQueue | null = null;
 let orchestrator: Orchestrator | null = null;
+// Read-only OMP fleet adapter — ONE module-scope instance shared by the
+// Orchestrator (dep bag) and the tRPC context, so both layers observe the same source.
+const fleetRegistryReader = new FleetRegistryReader();
+
+/**
+ * The OMP command principal and audit sink, at module scope so the tRPC context
+ * and the fleet session manager share ONE identity and ONE trail.
+ *
+ * Resolved lazily rather than as a module-scope const: the supervise capability
+ * comes from Aria mode (`configManager.getAriaMode()`), and configManager is not
+ * constructed at module-evaluation time.
+ *
+ * Every consumer takes this FUNCTION, never a snapshot of its result — the tRPC
+ * context calls it per request, and both `OmpSupervisedAdapter` instances hold
+ * the thunk and resolve per command. So flipping Aria mode takes effect on the
+ * next call in either direction, with no relaunch: granting it makes fleet
+ * sessions launchable, revoking it forbids the very next command.
+ */
+function currentOmpPrincipal(): OmpPrincipal {
+  // Guarded: a caller before initializeServices() gets the fail-closed answer
+  // rather than a crash.
+  let ariaMode = false;
+  try {
+    ariaMode = configManager.getAriaMode();
+  } catch {
+    ariaMode = false;
+  }
+  return resolveOmpPrincipal(ariaMode);
+}
+const auditOmp = (entry: OmpSupervisedAuditEntry): void => {
+  logger.info(
+    `omp:audit ${entry.outcome} ${entry.verb} op=${entry.operationId} by=${entry.principal} ${entry.detail}`,
+  );
+};
+
+/**
+ * Build the privileged OMP command adapter: a real bridge client when the
+ * bridge is configured, else the fail-closed stub. Always wrapped in
+ * `OmpSupervisedAdapter`, so the capability gate and the audit trail hold for
+ * every caller rather than only for the ones that remember to check.
+ */
+function buildOmpCommandAdapter(): OmpCommandAdapter {
+  const config = resolveOmpBridgeCommandConfig();
+  if (config === undefined) {
+    logger.info('omp:command adapter unconfigured — commands will return unavailable');
+    return new OmpCommandStub();
+  }
+  logger.info(`omp:command adapter configured for session ${config.sessionId}`);
+  return new OmpSupervisedAdapter(
+    new OmpBridgeCommandAdapter(new OmpBridgeHttpClient(config.url, config.token, config.sessionId)),
+    // The THUNK, not a snapshot: this adapter is built once per window attach
+    // and retained, so a captured principal would freeze the capability at
+    // whatever Aria mode was when the window opened.
+    currentOmpPrincipal,
+    auditOmp,
+  );
+}
+// OMP fleet runtime manager (omp-phase4-coexistence-adr.md increment 4). Built
+// fail-closed in initializeServices(): present ONLY when the bridge command
+// config resolved at boot; `undefined` means OMP is not launchable and both the
+// dispatch seams and the picker omit it (never a fallback to a local provider).
+let ompSessionManager: OmpSessionManager | undefined;
+
 let runQueues: RunQueueRegistry;
 let workflowRegistry: WorkflowRegistry;
 let runLauncher: RunLauncher;
@@ -818,6 +891,11 @@ let verifyRunbookStatus: VerifyRunbookStatusLike | undefined;
  */
 function attachOrchestratorTrpcToWindow(win: BrowserWindow): void {
   const db = makeDatabaseLike(databaseService);
+  // Privileged OMP commands: a real bridge adapter when configured, else the
+  // fail-closed stub — supervise-gated and audited either way by the wrapper
+  // buildOmpCommandAdapter applies. The capability is OFF unless the operator
+  // set CYBOFLOW_OMP_SUPERVISE, so every command is FORBIDDEN by default.
+  const ompCommand = buildOmpCommandAdapter();
   attachOrchestratorTrpc({
     window: win,
     router: appRouter,
@@ -828,6 +906,20 @@ function attachOrchestratorTrpcToWindow(win: BrowserWindow): void {
         workflowRegistry,
         agentOverrideRouter: AgentOverrideRouter.getInstance(),
         getForcedSubstrate: () => configManager.getForcedSubstrate(),
+        omp: fleetRegistryReader,
+        ompCommand,
+        // The THUNK, not a snapshot: createContext resolves it per request, so
+        // granting or revoking Aria mode takes effect on the next call in both
+        // directions — no relaunch (the frozen-value bug this PR fixes).
+        principal: currentOmpPrincipal,
+        auditOmp,
+        // The manager exists iff the BRIDGE is configured — a boot-time,
+        // env-driven fact, so the picker asks whether it exists rather than
+        // re-deriving the config. The other half of `launchable` is the live
+        // `hasSupervise(ctx.principal)` check in the availability query, which
+        // is what makes the Aria toggle take effect without a relaunch.
+        ompFleetLaunchable: () => ompSessionManager !== undefined,
+        ompAriaMode: () => configManager.getAriaMode(),
         // The per-substrate sprint task-cap override (Settings → Sessions), read
         // LIVE per request so raising the cap takes effect without a restart —
         // runs.start layers it over the built-in defaults.
@@ -1581,12 +1673,54 @@ async function initializeServices(): Promise<boolean> {
     getMainWindow: () => mainWindow
   });
 
+
   // ---------------------------------------------------------------------------
   // Cyboflow orchestrator collaborators — constructed here so they are eager
   // singletons assembled with the rest of AppServices (not lazy on first IPC).
   // ---------------------------------------------------------------------------
   const cyboflowLogger = makeLoggerLike(logger);
   const cyboflowDb = makeDatabaseLike(databaseService);
+  // OMP fleet runtime (omp-phase4-coexistence-adr.md §5): constructed ONLY when
+  // the bridge command config resolved at boot. Unresolved ⇒ undefined ⇒ the
+  // dispatch seams + picker omit OMP entirely — a half-configured bridge never
+  // silently authorizes a session.
+  {
+    const ompBridgeConfig = resolveOmpBridgeCommandConfig();
+    // TWO gates, both required. The bridge config says the fleet is REACHABLE;
+    // the supervise capability says this operator authorized Cyboflow to drive
+    // it. Spawning and killing remote workers is the same privileged surface
+    // the ompCommand router refuses without the capability, so the manager that
+    // drives it from the panel seams must refuse on the same terms — otherwise
+    // the product's actual path sits outside the authorization model.
+    if (ompBridgeConfig !== undefined && !hasSupervise(currentOmpPrincipal())) {
+      logger.info(
+        'omp:fleet bridge is configured but the supervise capability is absent ' +
+          '(turn on Aria mode in Settings → Advanced Options, or set CYBOFLOW_OMP_SUPERVISE ' +
+          'on a headless host) — fleet sessions stay unavailable until it is granted',
+      );
+    }
+    // Constructed on the BRIDGE CONFIG alone. The supervise capability is
+    // deliberately NOT a construction condition: it comes from Aria mode, which
+    // the user flips at runtime, and gating construction on it froze the answer
+    // at launch — granting Aria appeared to do nothing until a restart. The
+    // capability is enforced per call by OmpSupervisedAdapter instead, which is
+    // strictly stronger: revoking Aria now forbids the very next command rather
+    // than leaving an already-built manager authorized for the rest of the run.
+    ompSessionManager =
+      ompBridgeConfig !== undefined
+        ? new OmpSessionManager(
+            new OmpSupervisedAdapter(
+              new OmpBridgeCommandAdapter(
+                new OmpBridgeHttpClient(ompBridgeConfig.url, ompBridgeConfig.token, ompBridgeConfig.sessionId),
+              ),
+              currentOmpPrincipal,
+              auditOmp,
+            ),
+            cyboflowLogger,
+          )
+        : undefined;
+  }
+
   // Inject the global-config provider so createRun resolves the global default
   // agent permission mode + CLI substrate via the resolvers (ConfigManager
   // satisfies WorkflowConfigProvider structurally).
@@ -3944,6 +4078,7 @@ async function initializeServices(): Promise<boolean> {
     interactiveCliManager, // PTY substrate sibling (narrowed to the concrete class above)
     codexSdkManager: createdCodexSdkManager,
     codexPtyManager,
+    ompSessionManager,
     ompSdkManager: createdOmpSdkManager,
     ompPtyManager,
     claudeModelCatalogService: new ClaudeModelCatalogService(cyboflowLogger),
@@ -4216,6 +4351,7 @@ app.whenReady().then(async () => {
       db,
       logger: loggerLike,
       runQueues,
+      omp: fleetRegistryReader,
       // The stuck-run push channel the epic always specified but never wired.
       // events.onStuckDetected subscribes to this emitter; without it the
       // renderer's runStatusMap stays empty and the whole stuck UI is dead.
@@ -6269,6 +6405,20 @@ app.on('before-quit', async (event) => {
   // exactly the crash its boot ambiguous-recovery already handles.
   if (trackerSyncService) {
     trackerSyncService.stop();
+  }
+
+  // Kill every live OMP fleet worker. Unlike the other managers' children these
+  // are REMOTE processes: nothing about this app exiting stops them, so without
+  // an explicit fleet_kill they outlive the quit, keep burning producer budget
+  // and keep mutating worktrees no one is watching. Best-effort and awaited —
+  // stopAll never rejects (a failed kill is logged and the panel terminated
+  // locally), so this cannot wedge the quit.
+  if (ompSessionManager) {
+    try {
+      await ompSessionManager.stopAll();
+    } catch (err) {
+      console.warn('[Main] OMP fleet teardown on quit failed (workers may survive):', err);
+    }
   }
 
   // Stop the vitest-orphan sweep timer. Its handle is unref'd so it could never

--- a/main/src/ipc/panels.ts
+++ b/main/src/ipc/panels.ts
@@ -69,6 +69,18 @@ export function registerPanelHandlers(ipcMain: IpcMain, services: AppServices) {
       const panel = panelManager.getPanel(panelId);
       // Unregister Claude panels from ClaudePanelManager
       if (panel?.type === 'claude') {
+        // An omp-fleet panel is a 'claude' panel whose work lives on a REMOTE
+        // worker, so claudePanelManager.isPanelRunning is false for it and the
+        // stop below never fires. Closing the tab would leave the worker alive
+        // AND leave its poll timer emitting into a deleted panel, where
+        // addPanelOutput throws 'Panel not found' on every tick. stopPanel is a
+        // no-op for a panel the fleet manager doesn't track, so this is safe to
+        // call unconditionally — no runtime lookup needed.
+        try {
+          await services.ompSessionManager?.stopPanel(panelId);
+        } catch (err) {
+          console.warn('[Panels IPC] Failed to stop OMP fleet worker during delete:', err);
+        }
         try {
           const { claudePanelManager } = require('./claudePanel');
           if (claudePanelManager) {

--- a/main/src/ipc/session.ts
+++ b/main/src/ipc/session.ts
@@ -54,6 +54,7 @@ import {
   providerForRuntime,
   providerRuntimeConflict,
 } from '../../../shared/types/agentRuntime';
+import { DEFAULT_OMP_MODEL } from '../../../shared/types/omp';
 import type { AgentProvider } from '../../../shared/types/agentRuntime';
 import type { SessionAgentRuntime } from '../../../shared/types/agentRuntime';
 import { normalizeAgentModelSelection } from '../../../shared/types/agentModels';
@@ -334,6 +335,7 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
     archiveProgressManager,
     configManager, // demo-mode probe — gates the real interactive PTY spawn/relay
     chatSentinelProvider, // chat-gate vehicle resolver (revives an app_restart-parked sentinel)
+    ompSessionManager, // OMP fleet runtime (remote worker; undefined when bridge unconfigured)
     cyboflow
   } = services;
 
@@ -388,6 +390,58 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
   const laneForPanelId = (panelId: string): PanelLane | undefined => {
     const panel = panelManager.getPanel(panelId);
     return panel ? laneForPanel(panel) : undefined;
+  };
+
+  /**
+   * Route an OMP-fleet panel turn: relay into the live worker, or spawn it on
+   * the first message (the ADR's "first message spawns"). Returns null when the
+   * panel's session is NOT omp-fleet (the caller keeps its own lane), otherwise
+   * an IPC-shaped result. Fail-closed: an unconfigured bridge (no manager) is an
+   * `unavailable`, never a fallback to a local provider.
+   */
+  const routeOmpPanelTurn = async (
+    panelId: string,
+    input: string,
+  ): Promise<{ success: boolean; error?: string } | null> => {
+    const dbSession = databaseService.getSession(panelManager.getPanel(panelId)?.sessionId ?? '');
+    if (!dbSession || dbSession.agent_runtime !== 'omp-fleet') return null;
+    // Refuse a switched-off provider BEFORE any side effect (persisted user
+    // turn, spawn, send) — the codex-pty branch does the same; the catch
+    // below already maps AgentProviderDisabledError to user-facing copy.
+    assertAgentProviderAllowed('omp', 'this chat turn');
+    if (!ompSessionManager) {
+      return { success: false, error: 'OMP fleet is not available — the bridge is not configured.' };
+    }
+    // Persist the user turn BEFORE dispatch, exactly like the claude/codex
+    // lanes: useUnifiedPanelMessages renders user bubbles solely from
+    // panels:get-conversation-messages, and the composer reconciles its
+    // optimistic 'sending' row against that same source — without this the
+    // row sticks at 'sending' forever and the transcript never shows the user.
+    if (input) {
+      sessionManager.addPanelConversationMessage(panelId, 'user', input);
+    }
+    if (ompSessionManager.isPanelRunning(panelId)) {
+      const handed = await ompSessionManager.sendInput(panelId, input);
+      if (!handed) {
+        return { success: false, error: 'Failed to deliver input to the OMP worker' };
+      }
+    } else {
+      // spawn() fails CLOSED (it emits `exit` and drops the panel) rather than
+      // throwing, so its result is the only honest signal — answering
+      // `success: true` here would leave the composer showing a delivered turn
+      // for a worker that never booted.
+      const spawned = await ompSessionManager.spawn(panelId, dbSession.id, input, {
+        model: DEFAULT_OMP_MODEL,
+        cwd: dbSession.worktree_path ?? undefined,
+      });
+      if (!spawned) {
+        return { success: false, error: 'Failed to start the OMP worker' };
+      }
+    }
+    // Mirror the other lanes: a delivered turn puts the session in 'running' so
+    // the sidebar and the session header stop showing it as idle.
+    await sessionManager.updateSession(dbSession.id, { status: 'running' });
+    return { success: true };
   };
 
   interface QueuedPanelInput {
@@ -1177,6 +1231,7 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
       // ONE resolved runtime replaces the `useCodexSdk`/`useCodexPty` boolean
       // pair: a third provider would otherwise need a third pair, and every
       // downstream site would need to learn about it.
+      const useOmpFleet = !isDesignSession && requestedAgentRuntime === 'omp-fleet';
       const quickProvider: AgentProvider | undefined =
         requestedAgentProvider ?? (fallbackToCodex ? 'codex' : undefined);
       const quickResolvedRuntime: SessionAgentRuntime | undefined = isDesignSession
@@ -1191,9 +1246,17 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
             : undefined));
       const quickResolvedProvider: AgentProvider =
         quickResolvedRuntime !== undefined ? providerForRuntime(quickResolvedRuntime) : 'claude';
-      /** A non-Claude runtime fixes the substrate outright; Claude's is a ladder. */
+      /**
+       * A non-Claude runtime fixes the substrate outright; Claude's is a ladder.
+       * omp-fleet is NOT a lane — it is the fleet-supervisor runtime backed by
+       * `OmpSessionManager` (omp-phase4-coexistence-adr.md §3) — so it is
+       * excluded here and reaches its own dispatch below via `useOmpFleet`;
+       * leaving it in would type this onto PanelLane maps that cannot serve it.
+       */
       const nonClaudeQuickRuntime =
-        quickResolvedRuntime !== undefined && quickResolvedProvider !== 'claude'
+        quickResolvedRuntime !== undefined &&
+        quickResolvedProvider !== 'claude' &&
+        quickResolvedRuntime !== 'omp-fleet'
           ? quickResolvedRuntime
           : undefined;
 
@@ -1382,6 +1445,7 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
         resolvedSubstrate,
         ...(nonClaudeQuickRuntime !== undefined ? { sessionAgentRuntime: nonClaudeQuickRuntime } : {}),
         requestedAgentMode,
+        ...(useOmpFleet ? { agentRuntimeOverride: 'omp-fleet' } : {}),
       });
       // Persist the per-session agent effort (migration 029) so the unified
       // chat composer can surface it as a read-only pill (set at session start;
@@ -1445,7 +1509,28 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
       // ultracode/fast-mode spawn options these lanes have no equivalent for.
       const eagerPtyLane =
         nonClaudeQuickRuntime !== undefined ? quickPtyLanes.get(nonClaudeQuickRuntime) : undefined;
-      if (eagerPtyLane) {
+      // OMP FLEET FIRST — this branch must outrank every substrate branch below.
+      // A fleet session's work runs on a REMOTE worker; any local eager spawn
+      // here would boot a second, unwanted agent against the same worktree.
+      // Today `ompSdkRequested` happens to force resolvedSubstrate to 'sdk', so
+      // the interactive branches miss it by luck rather than by design — one
+      // change to substrate resolution and a fleet session would silently grow a
+      // local Claude REPL. Ordering makes that structural instead of incidental.
+      if (useOmpFleet) {
+        // Create the panel server-side (so the frontend skips a duplicate) but
+        // do NOT spawn — the ADR's "first message spawns". The remote worker
+        // boots on the first panels:send-input / panels:continue.
+        try {
+          const panel = await panelManager.createPanel({
+            sessionId: session.id,
+            type: 'claude',
+            title: 'Chat',
+          });
+          claudePanelId = panel.id;
+        } catch (error) {
+          console.error(`[IPC] Failed to create OMP panel for quick session ${session.id}:`, error);
+        }
+      } else if (eagerPtyLane) {
         try {
           const panel = await panelManager.createPanel({
             sessionId: session.id,
@@ -1714,6 +1799,15 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
       const dismissPanels = panelManager.getPanelsForSession(sessionId).filter((p) => p.type === 'claude');
       for (const panel of dismissPanels) {
         try {
+          // OMP fleet panels are 'claude'-typed but owned by the remote-worker
+          // manager, and omp-fleet is NOT a PanelLane — resolvePanelLane maps
+          // them onto the omp-sdk lane, whose manager never spawned them, so
+          // its stopPanel is a no-op and the REMOTE worker survives a dismiss
+          // that is about to delete the worktree out from under it.
+          if (dbSession.agent_runtime === 'omp-fleet') {
+            await ompSessionManager?.stopPanel(panel.id);
+            continue;
+          }
           // Per-PANEL lane: a mixed session (an overridden chat next to inherited
           // ones) has panels on two different managers, so a session-level test
           // would leave the odd one out running.
@@ -2008,6 +2102,38 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
       const panelFastMode = panelLaunchSettings?.fastMode === true;
       const rawPanelEffort = panelLaunchSettings?.reasoningEffort;
       const panelReasoningEffort = isAnyEffortLevel(rawPanelEffort) ? rawPanelEffort : undefined;
+
+      if (dbSession?.agent_runtime === 'omp-fleet') {
+        // Fail-closed provider guard before any side effect (persisted user
+        // turn, remote spawn, send): a user who switched OMP off must not steer
+        // OMP panels from the composer. The catch already maps the refusal to
+        // user-facing copy.
+        assertAgentProviderAllowed('omp', 'this chat turn');
+        if (!ompSessionManager) {
+          return { success: false, error: 'OMP fleet is not available — the bridge is not configured.' };
+        }
+        if (finalInput) {
+          sessionManager.addPanelConversationMessage(claudePanel.id, 'user', finalInput);
+        }
+        if (ompSessionManager.isPanelRunning(claudePanel.id)) {
+          const handed = await ompSessionManager.sendInput(claudePanel.id, finalInput);
+          if (!handed) {
+            return { success: false, error: 'Failed to deliver input to the OMP worker' };
+          }
+        } else {
+          // See routeOmpPanelTurn: spawn fails closed, so its result is the
+          // only honest signal for this turn.
+          const spawned = await ompSessionManager.spawn(claudePanel.id, sessionId, finalInput, {
+            model: DEFAULT_OMP_MODEL,
+            cwd: session.worktreePath ?? undefined,
+          });
+          if (!spawned) {
+            return { success: false, error: 'Failed to start the OMP worker' };
+          }
+        }
+        await sessionManager.updateSession(sessionId, { status: 'running' });
+        return { success: true };
+      }
 
       // Lane, not session runtime: the two tests this replaces read the SESSION's
       // runtime as if it also fixed the panel's substrate, so a per-panel
@@ -2966,6 +3092,8 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
             // sessions:input always resolves the session's FIRST panel, which would
             // misroute an added panel's turn. relayOrSpawnPtyPanel returns false for
             // SDK / demo panels, which fall through to the structured SDK path.
+            const ompResult = await routeOmpPanelTurn(panelId, input);
+            if (ompResult !== null) return ompResult;
             const relayed = await relayOrSpawnPtyPanel(services, panel, input);
             if (relayed) return { success: true };
             // Save the user input as a conversation message for panel history
@@ -3044,6 +3172,8 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
             // warm-parked entry is NOT in `processes`, so there is no warm-idle
             // false-positive (unlike Claude's isPanelTurnInFlight).
             const continueLane = laneForPanel(panel);
+            const ompContinue = await routeOmpPanelTurn(panelId, input);
+            if (ompContinue !== null) return ompContinue;
             // A non-Claude PTY lane relays a PANEL-SCOPED turn into this panel's
             // own REPL. claudePanelManager below reaches only the two CLAUDE
             // managers, so such a terminal panel — every panel of a codex-pty /
@@ -3476,6 +3606,13 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
         // Stop all Claude panels for this session
         console.log(`[IPC] Stopping ${stopClaudePanels.length} agent panel(s) for session ${sessionId}`);
         for (const claudePanel of stopClaudePanels) {
+          if (dbSession.agent_runtime === 'omp-fleet') {
+            // OMP panels are 'claude'-typed but owned by the remote-worker
+            // manager — resolvePanelLane would map them to the claude-sdk lane
+            // and claudeCodeManager.stopPanel would stop a non-existent child.
+            await ompSessionManager?.stopPanel(claudePanel.id);
+            continue;
+          }
           // Per-PANEL lane — see the dismiss teardown above. claudeCodeManager
           // covers both Claude lanes here (its stopPanel is the session-level
           // Stop that predates the interactive split).

--- a/main/src/ipc/types.ts
+++ b/main/src/ipc/types.ts
@@ -11,6 +11,7 @@ import type { RunCommandManager } from '../services/runCommandManager';
 import type { ClaudeCodeManager } from '../services/panels/claude/claudeCodeManager';
 import type { InteractiveClaudeManager } from '../services/panels/claude/interactiveClaudeManager';
 import type { ClaudeModelCatalogService } from '../services/claudeModelCatalogService';
+import type { OmpSessionManager } from '../orchestrator/omp/ompSessionManager';
 import type {
   CliManagerFactory,
   CodexPtyManagerLike,
@@ -59,6 +60,15 @@ export interface AppServices {
   ompSdkManager: OmpSdkManagerLike;
   /** Interactive OMP PTY runtime for quick sessions only. Seam-typed — see above. */
   ompPtyManager: OmpPtyManagerLike;
+  /**
+   * OMP fleet runtime (Phase 4 coexistence, omp-phase4-coexistence-adr.md). A
+   * SIBLING to the process managers — a remote worker supervised over the Prime
+   * bridge, no local child. Fail-closed: present ONLY when the bridge command
+   * config resolved at boot; `undefined` means OMP is not launchable and the
+   * dispatch + picker omit it entirely (never a silent fallback to a local
+   * provider).
+   */
+  ompSessionManager?: OmpSessionManager;
   /** Dynamic Claude model catalog (SDK `supportedModels()`), for the picker's "Other models" section. */
   claudeModelCatalogService: ClaudeModelCatalogService;
   /**

--- a/main/src/orchestrator/dynamicWorkflows/__tests__/journalTailer.test.ts
+++ b/main/src/orchestrator/dynamicWorkflows/__tests__/journalTailer.test.ts
@@ -525,7 +525,7 @@ describe('JournalTailer', () => {
     ]);
   });
 
-  it('extracts promptExcerpt from array content (first text part), truncated to the excerpt cap', async () => {
+  it('extracts promptExcerpt from array content (first text part), truncated to the excerpt cap', { timeout: 30_000 }, async () => {
     const { onAgents } = buildTailer();
     tailer!.start();
     writeFileSync(journalPath, '{"type":"started","agentId":"a1"}\n');
@@ -593,7 +593,7 @@ describe('JournalTailer', () => {
     expect(agents?.[0]).toMatchObject({ agentId: 'a1', inputTokens: 10, outputTokens: 20 });
   });
 
-  it('stop() during an in-flight tick does not corrupt the read (buffer release is serialized)', async () => {
+  it('stop() during an in-flight tick does not corrupt the read (buffer release is serialized)', { timeout: 30_000 }, async () => {
     const { onAgents } = buildTailer();
     tailer!.start();
     writeFileSync(

--- a/main/src/orchestrator/omp/__tests__/ompSessionManager.test.ts
+++ b/main/src/orchestrator/omp/__tests__/ompSessionManager.test.ts
@@ -1,0 +1,593 @@
+/**
+ * Tests for `OmpSessionManager` (OMP Phase 4, increment 3) — the sibling
+ * manager beside the four `AbstractCliManager` managers.
+ *
+ * Verifies the ADR chat-lifecycle mapping: spawn → `fleet_spawn` (worker id
+ * stored on the panel), sendInput → `fleet_send`, output → polled
+ * `fleet_read` with sliding-window dedup, liveness → `fleet_state` with
+ * terminal detection matching the producer's `isTerminalStatus`, stop →
+ * `fleet_kill`. The adapter is a fake `OmpCommandAdapter`; no bridge is
+ * reached, and timers are driven by explicit `tick()` calls (plus fake
+ * timers where the interval itself is under test).
+ */
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  OmpApplyRequest,
+  OmpCommandAdapter,
+  OmpCommandResult,
+  OmpDiscardRequest,
+  OmpKillRequest,
+  OmpReadRequest,
+  OmpSendRequest,
+  OmpSpawnRequest,
+  OmpStateRequest,
+  OmpVerifyRequest,
+} from '../../../../../shared/types/ompCommand';
+import {
+  newOutputSince,
+  OmpSessionManager,
+  type OmpErrorEvent,
+  type OmpExitEvent,
+  type OmpOutputEvent,
+  type OmpSpawnedEvent,
+} from '../ompSessionManager';
+
+const okResult = (detail: string): OmpCommandResult => ({
+  ok: true,
+  operationId: 'op',
+  detail,
+});
+
+const failResult = (detail: string): OmpCommandResult => ({
+  ok: false,
+  operationId: 'op',
+  error: 'unavailable',
+  detail,
+});
+
+type FakeOverride = (req: unknown) => OmpCommandResult | Promise<OmpCommandResult>;
+
+function makeManager(overrides: Partial<Record<'spawn' | 'kill' | 'send' | 'read' | 'state', FakeOverride>> = {}) {
+  const spawn = vi.fn(async (_req: OmpSpawnRequest): Promise<OmpCommandResult> => okResult('worker=w1 pane=p1 model=m [pane]'));
+  const kill = vi.fn(async (_req: OmpKillRequest): Promise<OmpCommandResult> => okResult('killed'));
+  const send = vi.fn(async (_req: OmpSendRequest): Promise<OmpCommandResult> => okResult('Sent to p1.'));
+  const read = vi.fn(async (_req: OmpReadRequest): Promise<OmpCommandResult> => okResult('(empty)'));
+  const state = vi.fn(async (_req: OmpStateRequest): Promise<OmpCommandResult> => okResult('w1 backend=pane pane=p1 model=m state=working'));
+
+  const adapter: OmpCommandAdapter = {
+    authority: 'supervise',
+    spawn: (req: OmpSpawnRequest) => spawn(req),
+    kill: (req: OmpKillRequest) => kill(req),
+    send: (req: OmpSendRequest) => send(req),
+    read: (req: OmpReadRequest) => read(req),
+    state: (req: OmpStateRequest) => state(req),
+    apply: (req: OmpApplyRequest) => Promise.resolve(failResult(`apply unused: ${req.proposalId}`)),
+    discard: (req: OmpDiscardRequest) => Promise.resolve(failResult(`discard unused: ${req.proposalId}`)),
+    verifyRun: (req: OmpVerifyRequest) => Promise.resolve(failResult(`verify unused: ${req.proposalId}`)),
+  };
+
+  const manager = new OmpSessionManager(
+    { ...adapter, ...overrides } as unknown as OmpCommandAdapter,
+    undefined,
+    { pollMs: 60_000 }, // never fires in tests unless timers are advanced
+  );
+  return { manager, adapter, spawn, kill, send, read, state };
+}
+
+const collect = <T>(emitter: OmpSessionManager, event: string): T[] => {
+  const seen: T[] = [];
+  emitter.on(event, (payload: T) => {
+    seen.push(payload);
+  });
+  return seen;
+};
+
+describe('OmpSessionManager — spawn', () => {
+  it('spawns via fleet_spawn, stores the worker id, and emits spawned', async () => {
+    const { manager, spawn } = makeManager();
+    const spawned = collect<OmpSpawnedEvent>(manager, 'spawned');
+
+    const started = await manager.spawn('panel-1', 'session-1', 'do the thing', { model: 'zai/glm-5.2:high', workspace: 'ws-1', cwd: '/tmp/r' });
+
+    expect(started).toBe(true);
+    expect(spawn).toHaveBeenCalledWith({
+      model: 'zai/glm-5.2:high',
+      task: 'do the thing',
+      label: undefined,
+      workspace: 'ws-1',
+      cwd: '/tmp/r',
+      operationId: expect.any(String),
+    });
+    expect(spawned).toEqual([{ panelId: 'panel-1', sessionId: 'session-1' }]);
+    expect(manager.isPanelRunning('panel-1')).toBe(true);
+    expect(manager.panelCount).toBe(1);
+  });
+
+  it('emits exit (not spawned) when fleet_spawn fails — fail-closed, nothing tracked', async () => {
+    const { manager } = makeManager({
+      spawn: async () => failResult('bridge offline'),
+    });
+    const spawned = collect<OmpSpawnedEvent>(manager, 'spawned');
+    const exits = collect<OmpExitEvent>(manager, 'exit');
+
+    const started = await manager.spawn('panel-1', 'session-1', 'prompt', { model: 'm' });
+
+    // The IPC seam answers the composer from this boolean: spawn fails CLOSED
+    // rather than throwing, so reporting `void` let a failed launch surface as
+    // a delivered turn.
+    expect(started).toBe(false);
+    expect(spawned).toEqual([]);
+    expect(exits).toEqual([{ panelId: 'panel-1', sessionId: 'session-1', exitCode: 1, signal: null }]);
+    expect(manager.isPanelRunning('panel-1')).toBe(false);
+    expect(manager.panelCount).toBe(0);
+  });
+
+  it('emits exit when the spawn detail carries no parseable worker id', async () => {
+    const { manager } = makeManager({
+      spawn: async () => okResult('unexpected detail without a worker token'),
+    });
+    const exits = collect<OmpExitEvent>(manager, 'exit');
+
+    const started = await manager.spawn('panel-1', 'session-1', 'prompt', { model: 'm' });
+
+    expect(started).toBe(false);
+    expect(exits).toHaveLength(1);
+    expect(exits[0].exitCode).toBe(1);
+    expect(manager.isPanelRunning('panel-1')).toBe(false);
+  });
+
+  it('rejects an empty prompt and an empty model', async () => {
+    const { manager } = makeManager();
+    await expect(manager.spawn('panel-1', 'session-1', '   ', { model: 'm' })).rejects.toThrow(TypeError);
+    await expect(manager.spawn('panel-1', 'session-1', 'prompt', { model: '' })).rejects.toThrow(TypeError);
+  });
+
+  it('rejects a double spawn of the same panel', async () => {
+    const { manager } = makeManager();
+    await manager.spawn('panel-1', 'session-1', 'first', { model: 'm' });
+    await expect(manager.spawn('panel-1', 'session-1', 'second', { model: 'm' })).rejects.toThrow(/already spawned/);
+  });
+
+  it('reserves the panel while a spawn is in flight: a concurrent spawn is rejected', async () => {
+    const { manager } = makeManager();
+    const inFlight = manager.spawn('panel-1', 'session-1', 'first', { model: 'm' });
+    // The sync prefix has run: a pending record is in the map before the first
+    // await. A concurrent spawn (double-click) sees it and rejects instead of
+    // orphaning a second remote worker.
+    await expect(manager.spawn('panel-1', 'session-1', 'second', { model: 'm' })).rejects.toThrow(/already spawned/);
+    await inFlight;
+    expect(manager.isPanelRunning('panel-1')).toBe(true);
+    expect(manager.panelCount).toBe(1);
+  });
+  it('replaces a terminal record: respawn after the worker reached a terminal state', async () => {
+    const { manager, spawn, state } = makeManager({
+      state: async () => okResult('state=done'),
+    });
+    await manager.spawn('panel-1', 'session-1', 'first', { model: 'm' });
+    spawn.mockClear();
+
+    // Drive the worker to a terminal state.
+    await manager.tick('panel-1');
+    expect(manager.isPanelRunning('panel-1')).toBe(false);
+
+    // The respawn (ADR: "the first message spawns") must replace the dead
+    // record, not throw 'already spawned'.
+    await manager.spawn('panel-1', 'session-1', 'second message', { model: 'm' });
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn.mock.calls[0][0]).toMatchObject({ task: 'second message' });
+    expect(manager.isPanelRunning('panel-1')).toBe(true);
+    expect(manager.panelCount).toBe(1);
+  });
+
+  it('replaces a stopped record: respawn after stopPanel', async () => {
+    const { manager, spawn, kill } = makeManager();
+    await manager.spawn('panel-1', 'session-1', 'first', { model: 'm' });
+    spawn.mockClear();
+
+    await manager.stopPanel('panel-1');
+    expect(manager.isPanelRunning('panel-1')).toBe(false);
+
+    await manager.spawn('panel-1', 'session-1', 'after stop', { model: 'm' });
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(kill).toHaveBeenCalledTimes(1); // the respawn does not kill the new worker
+    expect(manager.isPanelRunning('panel-1')).toBe(true);
+  });
+});
+
+describe('OmpSessionManager — sendInput', () => {
+  it('forwards to fleet_send with the stored worker id', async () => {
+    const { manager, send } = makeManager();
+    await manager.spawn('panel-1', 'session-1', 'first', { model: 'm' });
+
+    const handed = await manager.sendInput('panel-1', 'follow up');
+
+    expect(handed).toBe(true);
+    expect(send).toHaveBeenCalledWith({
+      workerId: 'w1',
+      text: 'follow up',
+      operationId: expect.any(String),
+      keys: undefined,
+    });
+  });
+
+  it('returns false for an unknown panel (spawn needed instead)', async () => {
+    const { manager, send } = makeManager();
+    const handed = await manager.sendInput('ghost', 'hi');
+    expect(handed).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('emits an error event when fleet_send fails, but the panel stays live', async () => {
+    const { manager } = makeManager({
+      send: async () => failResult('pane gone'),
+    });
+    await manager.spawn('panel-1', 'session-1', 'first', { model: 'm' });
+    const errors = collect<{ error: string }>(manager, 'error');
+
+    const handed = await manager.sendInput('panel-1', 'follow up');
+
+    expect(handed).toBe(false);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].error).toContain('fleet_send failed');
+    expect(manager.isPanelRunning('panel-1')).toBe(true);
+  });
+});
+
+describe('OmpSessionManager — output polling (fleet_read)', () => {
+  it('emits only the new output since the last read', async () => {
+    const { manager, read } = makeManager();
+    let transcript = 'line 1\n';
+    read.mockImplementation(async () => okResult(transcript));
+    await manager.spawn('panel-1', 'session-1', 'first', { model: 'm' });
+    const outputs = collect<OmpOutputEvent>(manager, 'output');
+
+    await manager.tick('panel-1');
+    expect(outputs.map((e) => e.data)).toEqual(['line 1\n']);
+
+    transcript = 'line 1\nline 2\n';
+    await manager.tick('panel-1');
+    expect(outputs.map((e) => e.data)).toEqual(['line 1\n', 'line 2\n']);
+
+    // Unchanged window ⇒ no event.
+    await manager.tick('panel-1');
+    expect(outputs).toHaveLength(2);
+    expect(outputs[0]).toMatchObject({ panelId: 'panel-1', sessionId: 'session-1', type: 'stdout' });
+    expect(outputs[0].timestamp).toBeInstanceOf(Date);
+  });
+
+  it('emits only the non-overlapping tail when the recent window slid', async () => {
+    const { manager, read } = makeManager();
+    read.mockImplementationOnce(async () => okResult('AAAA\nBBBB\n'));
+    await manager.spawn('panel-1', 'session-1', 'first', { model: 'm' });
+    const outputs = collect<OmpOutputEvent>(manager, 'output');
+
+    await manager.tick('panel-1');
+    read.mockImplementationOnce(async () => okResult('BBBB\nCCCC\n'));
+    await manager.tick('panel-1');
+    read.mockImplementationOnce(async () => okResult('CCCC\nDDDD\n'));
+    await manager.tick('panel-1');
+
+    expect(outputs.map((e) => e.data)).toEqual(['AAAA\nBBBB\n', 'CCCC\n', 'DDDD\n']);
+  });
+
+  it('treats the producer "(empty)" rendering as an empty read', async () => {
+    const { manager, read } = makeManager();
+    read.mockImplementationOnce(async () => okResult('(empty)'));
+    read.mockImplementationOnce(async () => okResult('hello'));
+    await manager.spawn('panel-1', 'session-1', 'first', { model: 'm' });
+    const outputs = collect<OmpOutputEvent>(manager, 'output');
+
+    await manager.tick('panel-1');
+    expect(outputs).toEqual([]);
+    await manager.tick('panel-1');
+    expect(outputs.map((e) => e.data)).toEqual(['hello']);
+  });
+
+  it('surfaces a failed fleet_read as an error event but keeps the panel alive', async () => {
+    const { manager, read } = makeManager({
+      read: async () => failResult('herdr offline'),
+    });
+    await manager.spawn('panel-1', 'session-1', 'first', { model: 'm' });
+    const errors = collect<{ error: string }>(manager, 'error');
+
+    await manager.tick('panel-1');
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].error).toContain('fleet_read failed');
+    expect(manager.isPanelRunning('panel-1')).toBe(true);
+  });
+});
+
+describe('OmpSessionManager — liveness and exit (fleet_state)', () => {
+  it('does not exit while the worker is working or idle', async () => {
+    for (const stateText of ['state=working', 'state=idle']) {
+      const { manager, state } = makeManager();
+      state.mockImplementation(async () => okResult(`w1 backend=pane pane=p1 model=m ${stateText}`));
+      await manager.spawn('panel-1', 'session-1', 'first', { model: 'm' });
+      const exits = collect<OmpExitEvent>(manager, 'exit');
+
+      await manager.tick('panel-1');
+
+      expect(exits).toEqual([]);
+      expect(manager.isPanelRunning('panel-1')).toBe(true);
+    }
+  });
+
+  it('surfaces a failed fleet_state as an error event but keeps the panel alive', async () => {
+    const { manager, state } = makeManager();
+    state.mockImplementation(async () => failResult('herdr offline'));
+    await manager.spawn('panel-1', 'session-1', 'first', { model: 'm' });
+    const errors = collect<{ error: string }>(manager, 'error');
+    const exits = collect<OmpExitEvent>(manager, 'exit');
+
+    await manager.tick('panel-1');
+
+    expect(exits).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].error).toContain('fleet_state failed');
+    expect(manager.isPanelRunning('panel-1')).toBe(true);
+  });
+
+  it.each([
+    ['state=done', 0],
+    ['state=failed', 1],
+    ['state=dead', 1],
+    ['state=evicted', 1],
+  ])('exits with the right code when the worker is %s', async (stateText, exitCode) => {
+    const { manager, state } = makeManager();
+    state.mockImplementation(async () => okResult(`w1 backend=pane pane=p1 model=m ${stateText}`));
+    await manager.spawn('panel-1', 'session-1', 'first', { model: 'm' });
+    const exits = collect<OmpExitEvent>(manager, 'exit');
+
+    await manager.tick('panel-1');
+
+    expect(exits).toEqual([{ panelId: 'panel-1', sessionId: 'session-1', exitCode, signal: null }]);
+    expect(manager.isPanelRunning('panel-1')).toBe(false);
+  });
+
+  it('treats a vanished worker as terminal (evicted)', async () => {
+    const { manager, state } = makeManager();
+    state.mockImplementation(async () => okResult('w1 backend=pane pane=- model=m state=working [not found]'));
+    await manager.spawn('panel-1', 'session-1', 'first', { model: 'm' });
+    const exits = collect<OmpExitEvent>(manager, 'exit');
+
+    await manager.tick('panel-1');
+
+    expect(exits).toEqual([{ panelId: 'panel-1', sessionId: 'session-1', exitCode: 1, signal: null }]);
+    expect(manager.isPanelRunning('panel-1')).toBe(false);
+  });
+
+  it('stops polling once terminal, after one final drain', async () => {
+    const { manager, state, read } = makeManager();
+    state.mockImplementation(async () => okResult('w1 backend=pane pane=p1 model=m state=done'));
+    await manager.spawn('panel-1', 'session-1', 'first', { model: 'm' });
+
+    await manager.tick('panel-1');
+    expect(state).toHaveBeenCalledTimes(1);
+    // Exactly one read: the final drain. Everything the worker emitted between
+    // the previous poll and its exit lives only in the recent-lines window, and
+    // for a `done` worker that tail IS its answer — terminating without reading
+    // it would drop the one message the user is waiting for.
+    expect(read).toHaveBeenCalledTimes(1);
+
+    await manager.tick('panel-1');
+    await manager.tick('panel-1');
+    expect(state).toHaveBeenCalledTimes(1);
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits the worker's final output before the exit event", async () => {
+    const { manager, state, read } = makeManager();
+    state.mockImplementation(async () => okResult('w1 backend=pane pane=p1 model=m state=done'));
+    read.mockImplementation(async () => okResult('the final answer'));
+    await manager.spawn('panel-1', 'session-1', 'first', { model: 'm' });
+    const outputs = collect<OmpOutputEvent>(manager, 'output');
+    const exits = collect<OmpExitEvent>(manager, 'exit');
+
+    await manager.tick('panel-1');
+
+    expect(outputs.map((o) => o.data)).toEqual(['the final answer']);
+    expect(exits).toEqual([{ panelId: 'panel-1', sessionId: 'session-1', exitCode: 0, signal: null }]);
+  });
+
+  it('does not read a worker that has vanished', async () => {
+    const { manager, state, read } = makeManager();
+    state.mockImplementation(async () => okResult('w1 backend=pane pane=- model=m state=working [not found]'));
+    await manager.spawn('panel-1', 'session-1', 'first', { model: 'm' });
+
+    await manager.tick('panel-1');
+
+    // A worker that is gone has no transcript left to drain.
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it('never overlaps two poll cycles for the same panel', async () => {
+    const { manager, state, read } = makeManager();
+    let releaseState: (() => void) | undefined;
+    const stateEntered = new Promise<void>((resolve) => {
+      state.mockImplementation(async () => {
+        resolve();
+        await new Promise<void>((r) => {
+          releaseState = r;
+        });
+        return okResult('w1 backend=pane pane=p1 model=m state=working');
+      });
+    });
+    await manager.spawn('panel-1', 'session-1', 'first', { model: 'm' });
+
+    const first = manager.tick('panel-1');
+    await stateEntered;
+    // The interval fires again while the first cycle is still awaiting the
+    // bridge. Without the in-flight guard both cycles would read the same
+    // sliding window and emit it twice (or interleave and drop a chunk).
+    await manager.tick('panel-1');
+    expect(state).toHaveBeenCalledTimes(1);
+    expect(read).not.toHaveBeenCalled();
+
+    releaseState?.();
+    await first;
+    expect(state).toHaveBeenCalledTimes(1);
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('OmpSessionManager — stop', () => {
+  it('kills the worker and emits exit exactly once', async () => {
+    const { manager, kill } = makeManager();
+    await manager.spawn('panel-1', 'session-1', 'first', { model: 'm' });
+    const exits = collect<OmpExitEvent>(manager, 'exit');
+
+    await manager.stopPanel('panel-1');
+
+    expect(kill).toHaveBeenCalledWith({ workerId: 'w1', operationId: expect.any(String), timeoutMs: undefined });
+    expect(exits).toEqual([{ panelId: 'panel-1', sessionId: 'session-1', exitCode: null, signal: null }]);
+    expect(manager.isPanelRunning('panel-1')).toBe(false);
+
+    // Idempotent: a second stop is a no-op.
+    await manager.stopPanel('panel-1');
+    expect(kill).toHaveBeenCalledTimes(1);
+    expect(exits).toHaveLength(1);
+  });
+
+  it('still emits exit when fleet_kill fails (terminating locally)', async () => {
+    const { manager } = makeManager({
+      kill: async () => failResult('herdr offline'),
+    });
+    await manager.spawn('panel-1', 'session-1', 'first', { model: 'm' });
+    const exits = collect<OmpExitEvent>(manager, 'exit');
+
+    await manager.stopPanel('panel-1');
+
+    expect(exits).toHaveLength(1);
+    expect(manager.isPanelRunning('panel-1')).toBe(false);
+  });
+
+  it('sendInput after stop returns false (no live worker)', async () => {
+    const { manager, send } = makeManager();
+    await manager.spawn('panel-1', 'session-1', 'first', { model: 'm' });
+    await manager.stopPanel('panel-1');
+
+    const handed = await manager.sendInput('panel-1', 'too late');
+
+    expect(handed).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+});
+
+describe('OmpSessionManager — polling interval', () => {
+  it('ticks live panels on the configured interval and stops after terminal', async () => {
+    vi.useFakeTimers();
+    try {
+      const { manager, state } = makeManager();
+      state.mockImplementation(async () => okResult('w1 backend=pane pane=p1 model=m state=working'));
+      await manager.spawn('panel-1', 'session-1', 'first', { model: 'm' });
+
+      await vi.advanceTimersByTimeAsync(160_000); // 60_000 pollMs → 2 ticks
+      expect(state).toHaveBeenCalledTimes(2);
+
+      state.mockImplementation(async () => okResult('w1 backend=pane pane=p1 model=m state=done'));
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(state).toHaveBeenCalledTimes(3);
+
+      await vi.advanceTimersByTimeAsync(600_000);
+      expect(state).toHaveBeenCalledTimes(3); // terminal ⇒ polling stopped
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('newOutputSince', () => {
+  it('returns empty for an unchanged or empty window', () => {
+    expect(newOutputSince('abc', 'abc')).toBe('');
+    expect(newOutputSince('abc', '')).toBe('');
+    expect(newOutputSince('', 'abc')).toBe('abc');
+  });
+
+  it('returns the delta for a strict extension', () => {
+    expect(newOutputSince('line 1\n', 'line 1\nline 2\n')).toBe('line 2\n');
+  });
+
+  it('returns the non-overlapping tail for a slid window', () => {
+    expect(newOutputSince('AA\nBB\n', 'BB\nCC\n')).toBe('CC\n');
+  });
+
+  it('falls back to the whole window when nothing overlaps', () => {
+    expect(newOutputSince('xyz\n', 'abc\n')).toBe('abc\n');
+  });
+});
+
+describe('OmpSessionManager — teardown races', () => {
+  it('kills the worker when a stop lands while fleet_spawn is still in flight', async () => {
+    let releaseSpawn!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseSpawn = resolve;
+    });
+    const { manager, kill } = makeManager({
+      spawn: async () => {
+        await gate;
+        return okResult('worker=w9 pane=p1 model=m [pane]');
+      },
+    });
+
+    const inFlight = manager.spawn('panel-1', 'session-1', 'go', { model: 'm' });
+    // The stop lands while the reservation still has a null workerId, so it
+    // has nothing to kill and simply marks the record terminal.
+    await manager.stopPanel('panel-1');
+    expect(kill).not.toHaveBeenCalled();
+
+    releaseSpawn();
+    expect(await inFlight).toBe(false);
+
+    // The worker was born AFTER the kill sweep passed. If spawn does not reap
+    // it here, nothing ever will: no record tracks it and its id exists in no
+    // other frame — it would keep working the worktree forever.
+    expect(kill).toHaveBeenCalledTimes(1);
+    expect(kill.mock.calls[0][0]).toMatchObject({ workerId: 'w9' });
+    expect(manager.isPanelRunning('panel-1')).toBe(false);
+    expect(manager.panelCount).toBe(1); // the terminal record, replaceable by a respawn
+  });
+
+  it('emits no output after exit when a stop races an in-flight fleet_read', async () => {
+    let releaseRead!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    const { manager } = makeManager({
+      read: async () => {
+        await gate;
+        return okResult('a late line\n');
+      },
+    });
+    const outputs = collect<OmpOutputEvent>(manager, 'output');
+    const exits = collect<OmpExitEvent>(manager, 'exit');
+
+    await manager.spawn('panel-1', 'session-1', 'go', { model: 'm' });
+    const ticking = manager.tick('panel-1');
+    await manager.stopPanel('panel-1');
+    expect(exits).toHaveLength(1);
+
+    releaseRead();
+    await ticking;
+
+    // The read resolved after exit. Emitting it would reopen a panel the
+    // consumer has already closed out.
+    expect(outputs).toHaveLength(0);
+  });
+
+  it('marks a poll blip transient and keeps the panel live', async () => {
+    const { manager } = makeManager({ state: async () => failResult('bridge unreachable') });
+    const errors = collect<OmpErrorEvent>(manager, 'error');
+
+    await manager.spawn('panel-1', 'session-1', 'go', { model: 'm' });
+    await manager.tick('panel-1');
+
+    // Transient: the worker is untouched and the next poll may succeed, so the
+    // consumer must not park the panel in a terminal-looking 'error' state.
+    expect(errors).toHaveLength(1);
+    expect(errors[0].transient).toBe(true);
+    expect(manager.isPanelRunning('panel-1')).toBe(true);
+  });
+});

--- a/main/src/orchestrator/omp/fleetRegistryReader.test.ts
+++ b/main/src/orchestrator/omp/fleetRegistryReader.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Unit tests for the OMP read adapter: the versioned parser and the file reader.
+ *
+ * Inline sanitized fixtures only — no test reads the live mutable
+ * `~/.omp/agent/fleet-registry.json`. The parser is tested against in-memory
+ * objects; the reader is tested against temp-dir files.
+ */
+
+import { describe, test, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { RegistryParseResult } from "./registryContract";
+import {
+  parseRegistrySnapshot,
+  SUPPORTED_REGISTRY_VERSION,
+} from "./registryContract";
+import {
+  FleetRegistryReader,
+  resolveDefaultFleetRegistryPath,
+} from "./fleetRegistryReader";
+
+/** Narrow a parser result to the `malformed` variant and return its errors. */
+function malformedErrors(result: RegistryParseResult): string[] {
+  if (result.ok) throw new Error("expected malformed result, got ok");
+  if (result.reason !== "malformed") {
+    throw new Error(`expected malformed result, got ${result.reason}`);
+  }
+  return result.errors;
+}
+
+/** Narrow a parser result to the `unsupported-version` variant and return its version. */
+function unsupportedVersion(result: RegistryParseResult): number {
+  if (result.ok) throw new Error("expected unsupported-version result, got ok");
+  if (result.reason !== "unsupported-version") {
+    throw new Error(`expected unsupported-version result, got ${result.reason}`);
+  }
+  return result.version;
+}
+
+function minimalWorker(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "wkr-test-1",
+    paneId: "w1:p1",
+    workspaceId: "ws-1",
+    backend: "subprocess",
+    model: "zai/glm-5.2:high",
+    task: "edit files",
+    label: "test",
+    status: "working",
+    spawnedAt: "2026-08-13T00:00:00.000Z",
+    lastSeenAt: "2026-08-13T00:01:00.000Z",
+    leaseExpiresAt: "2026-08-13T00:10:00.000Z",
+    lastOutput: "working",
+    ...overrides,
+  };
+}
+
+function snapshot(workers: unknown[]): unknown {
+  return {
+    version: SUPPORTED_REGISTRY_VERSION,
+    savedAt: "2026-08-13T00:02:00.000Z",
+    workers,
+  };
+}
+
+/** Create a temp dir, register it for cleanup, and return its path. */
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "omp-reader-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir !== undefined) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("parseRegistrySnapshot", () => {
+  test("accepts a valid snapshot", () => {
+    const result = parseRegistrySnapshot(snapshot([minimalWorker()]));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.snapshot.version).toBe(SUPPORTED_REGISTRY_VERSION);
+      expect(result.snapshot.workers).toHaveLength(1);
+      expect(result.snapshot.workers[0].id).toBe("wkr-test-1");
+    }
+  });
+
+  test("accepts unknown extra keys (forward-compatible)", () => {
+    const worker = minimalWorker({ futureField: { nested: true } });
+    expect(parseRegistrySnapshot(snapshot([worker])).ok).toBe(true);
+  });
+
+  test("refuses unsupported version before shape validation", () => {
+    const result = parseRegistrySnapshot({
+      version: 999,
+      savedAt: "x",
+      workers: [{ totally: "different" }],
+    });
+    expect(result.ok).toBe(false);
+    expect(unsupportedVersion(result)).toBe(999);
+  });
+
+  test("refuses malformed top level", () => {
+    expect(parseRegistrySnapshot(null)).toMatchObject({ ok: false, reason: "malformed" });
+    expect(parseRegistrySnapshot({ version: "1", savedAt: "x", workers: [] }))
+      .toMatchObject({ ok: false, reason: "malformed" });
+    expect(parseRegistrySnapshot({ version: 1, workers: [] }))
+      .toMatchObject({ ok: false, reason: "malformed" });
+  });
+
+  test("refuses a worker missing a required field, with path-qualified error", () => {
+    const worker = minimalWorker();
+    delete worker.id;
+    const result = parseRegistrySnapshot(snapshot([worker]));
+    expect(result.ok).toBe(false);
+    expect(malformedErrors(result).some((e) => e.includes("workers[0].id"))).toBe(true);
+  });
+
+  test("refuses legacy backend missing-or-null (documented drift)", () => {
+    const missing = minimalWorker();
+    delete missing.backend;
+    const missingResult = parseRegistrySnapshot(snapshot([missing]));
+    expect(missingResult.ok).toBe(false);
+
+    const nullBackend = minimalWorker({ backend: null });
+    const nullResult = parseRegistrySnapshot(snapshot([nullBackend]));
+    expect(nullResult.ok).toBe(false);
+    expect(malformedErrors(nullResult).some((e) => e.includes("workers[0].backend"))).toBe(true);
+  });
+
+  test("one bad worker fails the whole snapshot (all-or-nothing)", () => {
+    const result = parseRegistrySnapshot(snapshot([minimalWorker(), { bad: true }]));
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("resolveDefaultFleetRegistryPath", () => {
+  const original = process.env.OMP_FLEET_REGISTRY_PATH;
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.OMP_FLEET_REGISTRY_PATH;
+    else process.env.OMP_FLEET_REGISTRY_PATH = original;
+  });
+
+  test("defaults to ~/.omp/agent/fleet-registry.json", () => {
+    delete process.env.OMP_FLEET_REGISTRY_PATH;
+    const path = resolveDefaultFleetRegistryPath();
+    expect(path.endsWith(join(".omp", "agent", "fleet-registry.json"))).toBe(true);
+  });
+
+  test("honors an absolute override", () => {
+    process.env.OMP_FLEET_REGISTRY_PATH = "/tmp/custom-fleet-registry.json";
+    expect(resolveDefaultFleetRegistryPath()).toBe("/tmp/custom-fleet-registry.json");
+  });
+
+  test("rejects a relative override (fail closed)", () => {
+    process.env.OMP_FLEET_REGISTRY_PATH = "relative/path.json";
+    expect(() => resolveDefaultFleetRegistryPath()).toThrow(/absolute/);
+  });
+
+  test("rejects an empty override (fail closed)", () => {
+    process.env.OMP_FLEET_REGISTRY_PATH = "";
+    expect(() => resolveDefaultFleetRegistryPath()).toThrow(/absolute/);
+  });
+});
+
+describe("FleetRegistryReader", () => {
+  test("reads and validates a good registry file", async () => {
+    const dir = tempDir();
+    const path = join(dir, "fleet-registry.json");
+    writeFileSync(path, JSON.stringify(snapshot([minimalWorker()])));
+
+    const reader = new FleetRegistryReader(path);
+    expect(reader.authority).toBe("read");
+    const result = await reader.getFleetSnapshot();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.snapshot.workers).toHaveLength(1);
+    }
+  });
+
+  test("returns missing (ENOENT) for a missing file", async () => {
+    const reader = new FleetRegistryReader(join(tempDir(), "missing.json"));
+    const result = await reader.getFleetSnapshot();
+    expect(result).toMatchObject({ ok: false, error: "missing" });
+  });
+
+  test("returns malformed for invalid JSON", async () => {
+    const dir = tempDir();
+    const path = join(dir, "fleet-registry.json");
+    writeFileSync(path, "not json");
+
+    const reader = new FleetRegistryReader(path);
+    const result = await reader.getFleetSnapshot();
+    expect(result).toMatchObject({ ok: false, error: "malformed" });
+  });
+
+  test("returns unsupported-version for a v999 file", async () => {
+    const dir = tempDir();
+    const path = join(dir, "fleet-registry.json");
+    writeFileSync(path, JSON.stringify({ version: 999, savedAt: "x", workers: [] }));
+
+    const reader = new FleetRegistryReader(path);
+    const result = await reader.getFleetSnapshot();
+    expect(result).toMatchObject({ ok: false, error: "unsupported-version" });
+  });
+
+  test("rejects a relative constructor path", () => {
+    expect(() => new FleetRegistryReader("relative/path.json")).toThrow(/absolute/);
+  });
+});

--- a/main/src/orchestrator/omp/fleetRegistryReader.ts
+++ b/main/src/orchestrator/omp/fleetRegistryReader.ts
@@ -1,0 +1,117 @@
+/**
+ * File-backed implementation of `OmpControlPlaneAdapter`.
+ *
+ * Reads the durable fleet registry (default `~/.omp/agent/fleet-registry.json`,
+ * overridable via `OMP_FLEET_REGISTRY_PATH` or an explicit constructor path),
+ * parses it through the versioned contract (`registryContract.ts`), and maps
+ * the result onto the adapter surface (`shared/types/omp.ts`).
+ *
+ * Read-only by construction: this module only ever reads the registry file. It
+ * exposes no mutators and cannot grow any without also widening the adapter
+ * contract — which is deliberately separate and privileged.
+ */
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
+import type {
+  OmpControlPlaneAdapter,
+  OmpSnapshotResult,
+} from "../../../../shared/types/omp";
+import { parseRegistrySnapshot, SUPPORTED_REGISTRY_VERSION } from "./registryContract";
+
+const DEFAULT_REGISTRY_PATH = join(homedir(), ".omp", "agent", "fleet-registry.json");
+
+/**
+ * Resolve the default registry path, honoring the `OMP_FLEET_REGISTRY_PATH`
+ * environment override. An empty or relative override is rejected (fail
+ * closed: an ambiguous path must never silently read the wrong file). Matches
+ * the producer's `resolveDefaultFleetRegistryPath`: `override !== undefined`
+ * means even `""` is treated as an override and rejected for not being absolute.
+ */
+export function resolveDefaultFleetRegistryPath(): string {
+  const override = process.env.OMP_FLEET_REGISTRY_PATH;
+  if (override !== undefined) {
+    if (!isAbsolute(override)) {
+      throw new Error(
+        "OMP_FLEET_REGISTRY_PATH must be an absolute path (rejecting relative override)",
+      );
+    }
+    return override;
+  }
+  return DEFAULT_REGISTRY_PATH;
+}
+
+/**
+ * Read-only fleet-registry adapter. The constructor path (when supplied) must
+ * be absolute; the default honors `OMP_FLEET_REGISTRY_PATH`.
+ */
+export class FleetRegistryReader implements OmpControlPlaneAdapter {
+  readonly version = SUPPORTED_REGISTRY_VERSION;
+  readonly authority = "read" as const;
+
+  private readonly registryPath: string;
+
+  constructor(registryPath?: string) {
+    if (registryPath !== undefined) {
+      if (!isAbsolute(registryPath)) {
+        throw new Error(
+          "FleetRegistryReader registryPath must be an absolute path (rejecting relative override)",
+        );
+      }
+      this.registryPath = registryPath;
+    } else {
+      this.registryPath = resolveDefaultFleetRegistryPath();
+    }
+  }
+
+  async getFleetSnapshot(): Promise<OmpSnapshotResult> {
+    let text: string;
+    try {
+      text = readFileSync(this.registryPath, "utf8");
+    } catch (error) {
+      // Distinguish "never ran here" (ENOENT) from "can't read" (permission
+      // denied, I/O error) — the two mean very different things to the UI.
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return {
+          ok: false,
+          error: "missing",
+          detail: `fleet registry not found: ${this.registryPath}`,
+        };
+      }
+      return {
+        ok: false,
+        error: "unavailable",
+        detail: `fleet registry not readable: ${this.registryPath}`,
+      };
+    }
+
+    let data: unknown;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      return {
+        ok: false,
+        error: "malformed",
+        detail: `fleet registry is not valid JSON: ${this.registryPath}`,
+      };
+    }
+
+    const parsed = parseRegistrySnapshot(data);
+    if (parsed.ok) {
+      return { ok: true, snapshot: parsed.snapshot };
+    }
+    if (parsed.reason === "unsupported-version") {
+      return {
+        ok: false,
+        error: "unsupported-version",
+        detail: `fleet registry version ${parsed.version} is not supported`,
+      };
+    }
+    return {
+      ok: false,
+      error: "malformed",
+      detail: `fleet registry is malformed: ${parsed.errors.join("; ")}`,
+    };
+  }
+}

--- a/main/src/orchestrator/omp/ompBridge.live.test.ts
+++ b/main/src/orchestrator/omp/ompBridge.live.test.ts
@@ -1,0 +1,53 @@
+/**
+ * LIVE smoke — runs Cyboflow's real config resolver, adapter, and HTTP client
+ * against the real bridge. Requires OMP_BRIDGE_* env AND an explicit
+ * OMP_BRIDGE_LIVE=1 opt-in (the skip gate is on by default, so a normal
+ * `pnpm test:unit` run never reaches a live bridge by accident); run explicitly:
+ *   OMP_BRIDGE_LIVE=1 OMP_BRIDGE_TOKEN_FILE=... OMP_BRIDGE_SESSION_ID=... \
+ *     npx vitest run <this>
+ * Uses a nonexistent worker id so fleet_kill traverses the full path (auth →
+ * session scope → tool gate → tool host → fleet controller) without side effects.
+ */
+import { describe, expect, it } from 'vitest';
+import { resolveOmpBridgeCommandConfig } from './ompBridgeConfig';
+import { OmpBridgeCommandAdapter } from './ompBridgeCommandAdapter';
+import { OmpBridgeHttpClient } from './ompBridgeClient';
+
+const config = resolveOmpBridgeCommandConfig();
+// Opt-in ONLY: a live smoke must never run in CI / a plain test:unit pass.
+const live = process.env.OMP_BRIDGE_LIVE === '1';
+
+describe.skipIf(!live || config === undefined)('live bridge smoke', () => {
+  it('resolves real config', () => {
+    expect(config).toBeDefined();
+  });
+
+  it('fleet_kill on a nonexistent worker traverses the full path', async () => {
+    const adapter = new OmpBridgeCommandAdapter(
+      new OmpBridgeHttpClient(config!.url, config!.token, config!.sessionId),
+    );
+    const result = await adapter.kill({ operationId: 'op-live-smoke-1', workerId: 'cyboflow-smoke-nonexistent' });
+    // The command must correlate and return a structured result — not throw.
+    expect(result.operationId).toBe('op-live-smoke-1');
+    expect(typeof result.ok).toBe('boolean');
+    if (!result.ok) expect(typeof result.detail).toBe('string');
+  });
+
+  it.each([
+    ['read', 'op-live-smoke-2'],
+    ['state', 'op-live-smoke-3'],
+    ['send', 'op-live-smoke-4'],
+  ] as const)('%s on a nonexistent worker traverses the full path', async (verb, operationId) => {
+    const adapter = new OmpBridgeCommandAdapter(
+      new OmpBridgeHttpClient(config!.url, config!.token, config!.sessionId),
+    );
+    let result;
+    if (verb === 'read') result = await adapter.read({ operationId, workerId: 'cyboflow-smoke-nonexistent' });
+    else if (verb === 'state') result = await adapter.state({ operationId, workerId: 'cyboflow-smoke-nonexistent' });
+    else result = await adapter.send({ operationId, workerId: 'cyboflow-smoke-nonexistent', text: 'noop' });
+    // The command must correlate and return a structured result — not throw.
+    expect(result.operationId).toBe(operationId);
+    expect(typeof result.ok).toBe('boolean');
+    if (!result.ok) expect(typeof result.detail).toBe('string');
+  });
+});

--- a/main/src/orchestrator/omp/ompBridgeClient.ts
+++ b/main/src/orchestrator/omp/ompBridgeClient.ts
@@ -1,0 +1,124 @@
+/**
+ * Minimal MCP-over-HTTP client for the OMP Prime bridge.
+ *
+ * Speaks JSON-RPC 2.0 to the bridge's streamable-HTTP MCP endpoint
+ * (`POST /mcp/v1/sessions/<sessionId>`) with a bearer token. Only what the
+ * command adapter needs — `tools/call` — is implemented; `tools/list` and the
+ * initialize handshake are out of scope (the bridge accepts `tools/call`
+ * without a prior initialize, and the command surface calls tools by exact
+ * name, never by discovery).
+ *
+ * Standalone-typecheck invariant: no imports from electron, better-sqlite3, or
+ * services/*. `fetch` is Node 22 global; this module is pure.
+ */
+
+/** A tool invocation, as the bridge's MCP endpoint expects it. */
+export interface OmpBridgeToolCall {
+  readonly name: string;
+  readonly arguments: Record<string, unknown>;
+}
+
+/** The useful slice of an MCP `tools/call` result. */
+export type OmpBridgeCallResult =
+  | { readonly ok: true; readonly text: string; readonly structuredContent?: unknown }
+  | { readonly ok: false; readonly isError: boolean; readonly text: string; readonly structuredContent?: unknown };
+
+/** Narrow client seam so the command adapter is testable without a live bridge. */
+export interface OmpBridgeClientLike {
+  callTool(call: OmpBridgeToolCall): Promise<OmpBridgeCallResult>;
+}
+
+/** Wire shape of the bridge MCP `tools/call` response. */
+interface McpCallResponse {
+  jsonrpc: "2.0";
+  id?: unknown;
+  result?: {
+    content?: Array<{ type: "text"; text: string } | { type: "image" }>;
+    structuredContent?: unknown;
+    isError?: boolean;
+  };
+  error?: { code: number; message: string };
+}
+
+/**
+ * Ceiling on a single bridge round trip. `fetch` has NO default timeout: a
+ * herder that accepts the connection and then never answers would leave the
+ * promise pending forever, and with it the caller's `polling` flag — the one
+ * way that guard can wedge a panel permanently instead of merely skipping a
+ * beat. Generous enough for a slow `fleet_read`, finite enough to recover.
+ */
+const BRIDGE_TIMEOUT_MS = 30_000;
+
+export class OmpBridgeHttpClient implements OmpBridgeClientLike {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly token: string,
+    private readonly sessionId: string,
+    private readonly timeoutMs: number = BRIDGE_TIMEOUT_MS,
+  ) {}
+
+  async callTool(call: OmpBridgeToolCall): Promise<OmpBridgeCallResult> {
+    const url = `${this.baseUrl.replace(/\/$/, "")}/mcp/v1/sessions/${encodeURIComponent(this.sessionId)}`;
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name: call.name, arguments: call.arguments },
+        }),
+        signal: AbortSignal.timeout(this.timeoutMs),
+      });
+    } catch (error) {
+      // An AbortSignal.timeout abort surfaces as a TimeoutError DOMException;
+      // name it so a wedged herder is distinguishable from a refused socket.
+      const timedOut = error instanceof Error && error.name === 'TimeoutError';
+      return {
+        ok: false,
+        isError: true,
+        text: timedOut
+          ? `bridge timed out after ${this.timeoutMs}ms`
+          : `bridge unreachable: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+
+    let body: McpCallResponse;
+    try {
+      body = (await response.json()) as McpCallResponse;
+    } catch {
+      return { ok: false, isError: true, text: `bridge returned non-JSON (HTTP ${response.status})` };
+    }
+
+    if (response.status === 401 || response.status === 403) {
+      return {
+        ok: false,
+        isError: true,
+        text: `bridge rejected the credential (HTTP ${response.status})`,
+      };
+    }
+
+    if (body.error !== undefined) {
+      return { ok: false, isError: true, text: body.error.message };
+    }
+
+    const result = body.result;
+    const text = (result?.content ?? [])
+      .filter((item): item is { type: "text"; text: string } => item.type === "text")
+      .map((item) => item.text)
+      .join("\n");
+    const isError = result?.isError === true;
+    return {
+      ok: !isError,
+      isError,
+      text,
+      structuredContent: result?.structuredContent,
+    };
+  }
+}

--- a/main/src/orchestrator/omp/ompBridgeCommandAdapter.test.ts
+++ b/main/src/orchestrator/omp/ompBridgeCommandAdapter.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for `OmpBridgeCommandAdapter` — the Cyboflow→producer tool mapping.
+ *
+ * Verifies the translation contract: Cyboflow's camelCase request types become
+ * the producer's exact `fleet_*` tool names and snake_case argument schemas,
+ * and the producer's `isError`/structured detail maps onto `OmpCommandResult`
+ * with `operationId` echoed verbatim (correlation).
+ *
+ * The client is a fake `OmpBridgeClientLike`, so no bridge is reached.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import type { OmpBridgeCallResult, OmpBridgeClientLike, OmpBridgeToolCall } from './ompBridgeClient';
+import { OmpBridgeCommandAdapter } from './ompBridgeCommandAdapter';
+
+function fakeClient(record: Array<{ call: OmpBridgeToolCall; result: OmpBridgeCallResult }>) {
+  const client: OmpBridgeClientLike = {
+    callTool: vi.fn(async (call: OmpBridgeToolCall): Promise<OmpBridgeCallResult> => {
+      const entry = record.find((e) => e.call.name === call.name);
+      if (entry === undefined) throw new Error(`unexpected tool: ${call.name}`);
+      return entry.result;
+    }),
+  };
+  return { client, calls: record };
+}
+
+describe('OmpBridgeCommandAdapter', () => {
+  it('maps spawn to fleet_spawn with snake_case args and timeout in seconds', async () => {
+    const { client } = fakeClient([
+      { call: { name: 'fleet_spawn', arguments: {} }, result: { ok: true, text: 'spawned w1' } },
+    ]);
+    const adapter = new OmpBridgeCommandAdapter(client);
+    const result = await adapter.spawn({
+      operationId: 'op-1',
+      model: 'm',
+      task: 't',
+      label: 'L',
+      target: 'pane',
+      workspace: 'ws',
+      cwd: '/tmp',
+      timeoutMs: 1500,
+      executionMode: 'shepherd',
+      intent: 'mutating',
+      scope: { repo: { path: '/r', access: 'overlay_write', include: ['src'], exclude: ['dist'] } },
+    });
+
+    expect(result).toEqual({ ok: true, operationId: 'op-1', detail: 'spawned w1' });
+    const call = (client.callTool as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as OmpBridgeToolCall;
+    expect(call).toEqual({
+      name: 'fleet_spawn',
+      arguments: {
+        model: 'm',
+        task: 't',
+        label: 'L',
+        target: 'pane',
+        workspace: 'ws',
+        cwd: '/tmp',
+        timeout: 2,
+        execution_mode: 'shepherd',
+        intent: 'mutating',
+        scope: { repo: { path: '/r', access: 'overlay_write', include: ['src'], exclude: ['dist'] } },
+      },
+    });
+  });
+
+  it('maps kill to fleet_kill with { id }', async () => {
+    const { client } = fakeClient([
+      { call: { name: 'fleet_kill', arguments: {} }, result: { ok: true, text: 'killed' } },
+    ]);
+    const adapter = new OmpBridgeCommandAdapter(client);
+    await adapter.kill({ operationId: 'op-2', workerId: 'w9' });
+    const call = (client.callTool as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as OmpBridgeToolCall;
+    expect(call).toEqual({ name: 'fleet_kill', arguments: { id: 'w9' } });
+  });
+
+  it('maps apply/discard to proposal_id + reason', async () => {
+    const { client } = fakeClient([
+      { call: { name: 'fleet_proposal_apply', arguments: {} }, result: { ok: true, text: 'applied' } },
+      { call: { name: 'fleet_proposal_discard', arguments: {} }, result: { ok: true, text: 'discarded' } },
+    ]);
+    const adapter = new OmpBridgeCommandAdapter(client);
+    await adapter.apply({ operationId: 'op-3', proposalId: 'p1', reason: 'because' });
+    await adapter.discard({ operationId: 'op-4', proposalId: 'p1', reason: 'nope' });
+    const calls = (client.callTool as ReturnType<typeof vi.fn>).mock.calls.map((c) => c?.[0]) as OmpBridgeToolCall[];
+    expect(calls[0]).toEqual({ name: 'fleet_proposal_apply', arguments: { proposal_id: 'p1', reason: 'because' } });
+    expect(calls[1]).toEqual({ name: 'fleet_proposal_discard', arguments: { proposal_id: 'p1', reason: 'nope' } });
+  });
+
+  it('maps verifyRun to fleet_verification_run with { proposal_id }', async () => {
+    const { client } = fakeClient([
+      { call: { name: 'fleet_verification_run', arguments: {} }, result: { ok: true, text: 'PASS' } },
+    ]);
+    const adapter = new OmpBridgeCommandAdapter(client);
+    await adapter.verifyRun({ operationId: 'op-5', proposalId: 'p1' });
+    const call = (client.callTool as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as OmpBridgeToolCall;
+    expect(call).toEqual({ name: 'fleet_verification_run', arguments: { proposal_id: 'p1' } });
+  });
+
+  it('surfaces a producer isError as unavailable with operationId echoed', async () => {
+    const { client } = fakeClient([
+      {
+        call: { name: 'fleet_spawn', arguments: {} },
+        result: { ok: false, isError: true, text: 'fleet_spawn blocked by escalation' },
+      },
+    ]);
+    const adapter = new OmpBridgeCommandAdapter(client);
+    const result = await adapter.spawn({ operationId: 'op-6', model: 'm', task: 't' });
+    expect(result).toEqual({
+      ok: false,
+      operationId: 'op-6',
+      error: 'unavailable',
+      detail: 'fleet_spawn blocked by escalation',
+    });
+  });
+
+  it('maps an apply denial (verification denied) to blocked, shadow_warning to shadow', async () => {
+    const { client } = fakeClient([
+      {
+        call: { name: 'fleet_proposal_apply', arguments: {} },
+        result: {
+          ok: false,
+          isError: true,
+          text: 'Apply failed',
+          structuredContent: { verification: { status: 'denied', reason: 'no PASS' } },
+        },
+      },
+    ]);
+    const adapter = new OmpBridgeCommandAdapter(client);
+    const denied = await adapter.apply({ operationId: 'op-7', proposalId: 'p1', reason: 'r' });
+    expect(denied).toEqual({ ok: false, operationId: 'op-7', error: 'blocked', detail: 'Apply failed' });
+
+    const shadowClient: OmpBridgeClientLike = {
+      callTool: vi.fn(async () => ({
+        ok: false,
+        isError: true,
+        text: 'Apply failed',
+        structuredContent: { verification: { status: 'shadow_warning', reason: 'no proof' } },
+      })),
+    };
+    const shadowAdapter = new OmpBridgeCommandAdapter(shadowClient);
+    const shadow = await shadowAdapter.apply({ operationId: 'op-8', proposalId: 'p1', reason: 'r' });
+    expect(shadow).toEqual({ ok: false, operationId: 'op-8', error: 'shadow', detail: 'Apply failed' });
+  });
+
+  it('omits undefined spawn options from the producer args', async () => {
+    const { client } = fakeClient([
+      { call: { name: 'fleet_spawn', arguments: {} }, result: { ok: true, text: 'ok' } },
+    ]);
+    const adapter = new OmpBridgeCommandAdapter(client);
+    await adapter.spawn({ operationId: 'op-9', model: 'm', task: 't' });
+    const call = (client.callTool as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as OmpBridgeToolCall;
+    expect(call.arguments).toEqual({ model: 'm', task: 't' });
+  });
+
+  it('maps send to fleet_send with { id, text } and includes keys only when set', async () => {
+    const { client } = fakeClient([
+      { call: { name: 'fleet_send', arguments: {} }, result: { ok: true, text: 'Sent to w1.' } },
+    ]);
+    const adapter = new OmpBridgeCommandAdapter(client);
+    const result = await adapter.send({ operationId: 'op-10', workerId: 'w1', text: 'continue' });
+    expect(result).toEqual({ ok: true, operationId: 'op-10', detail: 'Sent to w1.' });
+
+    await adapter.send({ operationId: 'op-10b', workerId: 'w1', text: 'ctrl+c', keys: true });
+    const calls = (client.callTool as ReturnType<typeof vi.fn>).mock.calls.map((c) => c?.[0]) as OmpBridgeToolCall[];
+    expect(calls[0]).toEqual({ name: 'fleet_send', arguments: { id: 'w1', text: 'continue' } });
+    expect(calls[1]).toEqual({ name: 'fleet_send', arguments: { id: 'w1', text: 'ctrl+c', keys: true } });
+  });
+
+  it('maps read to fleet_read with { id } and includes lines/source only when set', async () => {
+    const { client } = fakeClient([
+      { call: { name: 'fleet_read', arguments: {} }, result: { ok: true, text: 'pane output' } },
+    ]);
+    const adapter = new OmpBridgeCommandAdapter(client);
+    await adapter.read({ operationId: 'op-11', workerId: 'w1' });
+    await adapter.read({ operationId: 'op-11b', workerId: 'w1', lines: 40, source: 'recent' });
+    const calls = (client.callTool as ReturnType<typeof vi.fn>).mock.calls.map((c) => c?.[0]) as OmpBridgeToolCall[];
+    expect(calls[0]).toEqual({ name: 'fleet_read', arguments: { id: 'w1' } });
+    expect(calls[1]).toEqual({ name: 'fleet_read', arguments: { id: 'w1', lines: 40, source: 'recent' } });
+  });
+
+  it('maps state to fleet_state with { id }', async () => {
+    const { client } = fakeClient([
+      {
+        call: { name: 'fleet_state', arguments: {} },
+        result: { ok: true, text: 'w1 backend=herdr pane=p1 model=m state=working' },
+      },
+    ]);
+    const adapter = new OmpBridgeCommandAdapter(client);
+    const result = await adapter.state({ operationId: 'op-12', workerId: 'w1' });
+    expect(result).toEqual({ ok: true, operationId: 'op-12', detail: 'w1 backend=herdr pane=p1 model=m state=working' });
+    const call = (client.callTool as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as OmpBridgeToolCall;
+    expect(call).toEqual({ name: 'fleet_state', arguments: { id: 'w1' } });
+  });
+});

--- a/main/src/orchestrator/omp/ompBridgeCommandAdapter.ts
+++ b/main/src/orchestrator/omp/ompBridgeCommandAdapter.ts
@@ -1,0 +1,151 @@
+/**
+ * Real `OmpCommandAdapter` — shells Cyboflow's privileged command surface to
+ * the OMP Prime bridge's `fleet_*` MCP tools.
+ *
+ * Mapping (Cyboflow request → producer tool):
+ * - spawn       → fleet_spawn
+ * - kill        → fleet_kill
+ * - apply       → fleet_proposal_apply
+ * - discard     → fleet_proposal_discard
+ * - verifyRun   → fleet_verification_run
+ *
+ * The producer's argument schema is snake_case (`proposal_id`, `execution_mode`,
+ * `timeout` in seconds); Cyboflow's contract is camelCase (`proposalId`,
+ * `executionMode`, `timeoutMs`). This adapter is the translation layer and owns
+ * that fidelity — callers never do.
+ *
+ * Standalone-typecheck invariant: no imports from electron, better-sqlite3, or
+ * services/*. The client is injected (`OmpBridgeClientLike`) so this module is
+ * testable without a live bridge.
+ */
+import type {
+  OmpApplyRequest,
+  OmpCommandAdapter,
+  OmpCommandResult,
+  OmpDiscardRequest,
+  OmpKillRequest,
+  OmpReadRequest,
+  OmpSendRequest,
+  OmpSpawnRequest,
+  OmpStateRequest,
+  OmpVerifyRequest,
+} from "../../../../shared/types/ompCommand";
+import type { OmpBridgeClientLike } from "./ompBridgeClient";
+
+/** Verification status the producer reports on apply/discard, verbatim. */
+type ProducerVerificationStatus = "off" | "pass" | "shadow_warning" | "denied";
+
+interface ProducerApplyDetails {
+  success?: boolean;
+  reason?: string;
+  verification?: { status?: ProducerVerificationStatus; reason?: string };
+}
+
+/** A `tools/call` result that is an MCP error (isError) or a transport failure. */
+function toFailureResult(operationId: string, detail: string): OmpCommandResult {
+  return { ok: false, operationId, error: "unavailable", detail };
+}
+
+/** Map the producer's apply/discard structured detail onto Cyboflow's error taxonomy. */
+function failureFromApplyDetails(operationId: string, fallbackDetail: string, details: unknown): OmpCommandResult {
+  const status = (details as ProducerApplyDetails | undefined)?.verification?.status;
+  if (status === "denied") {
+    return {
+      ok: false,
+      operationId,
+      error: "blocked",
+      detail: fallbackDetail || "apply denied by verification policy",
+    };
+  }
+  if (status === "shadow_warning") {
+    return { ok: false, operationId, error: "shadow", detail: fallbackDetail || "apply allowed only in shadow mode" };
+  }
+  return toFailureResult(operationId, fallbackDetail);
+}
+
+/** Project Cyboflow's WorkerScope onto the producer's spawn `scope` (repo only). */
+function toProducerScope(scope: OmpSpawnRequest["scope"]): Record<string, unknown> | undefined {
+  if (scope?.repo === undefined) return undefined;
+  const repo: Record<string, unknown> = {
+    path: scope.repo.path,
+    access: scope.repo.access,
+  };
+  if (scope.repo.include !== undefined) repo.include = scope.repo.include;
+  if (scope.repo.exclude !== undefined) repo.exclude = scope.repo.exclude;
+  return { repo };
+}
+
+export class OmpBridgeCommandAdapter implements OmpCommandAdapter {
+  readonly authority = "supervise" as const;
+
+  constructor(private readonly client: OmpBridgeClientLike) {}
+
+  async spawn(req: OmpSpawnRequest): Promise<OmpCommandResult> {
+    const args: Record<string, unknown> = { model: req.model, task: req.task };
+    if (req.label !== undefined) args.label = req.label;
+    if (req.target !== undefined) args.target = req.target;
+    if (req.workspace !== undefined) args.workspace = req.workspace;
+    if (req.cwd !== undefined) args.cwd = req.cwd;
+    // Producer `timeout` is integer seconds; Cyboflow carries milliseconds.
+    if (req.timeoutMs !== undefined) args.timeout = Math.max(1, Math.ceil(req.timeoutMs / 1000));
+    if (req.executionMode !== undefined) args.execution_mode = req.executionMode;
+    if (req.intent !== undefined) args.intent = req.intent;
+    const scope = toProducerScope(req.scope);
+    if (scope !== undefined) args.scope = scope;
+
+    return this.invoke("fleet_spawn", args, req.operationId);
+  }
+
+  async kill(req: OmpKillRequest): Promise<OmpCommandResult> {
+    return this.invoke("fleet_kill", { id: req.workerId }, req.operationId);
+  }
+
+  async apply(req: OmpApplyRequest): Promise<OmpCommandResult> {
+    const result = await this.client.callTool({
+      name: "fleet_proposal_apply",
+      arguments: { proposal_id: req.proposalId, reason: req.reason },
+    });
+    if (result.ok) return { ok: true, operationId: req.operationId, detail: result.text };
+    return failureFromApplyDetails(req.operationId, result.text, result.structuredContent);
+  }
+
+  async discard(req: OmpDiscardRequest): Promise<OmpCommandResult> {
+    const result = await this.client.callTool({
+      name: "fleet_proposal_discard",
+      arguments: { proposal_id: req.proposalId, reason: req.reason },
+    });
+    if (result.ok) return { ok: true, operationId: req.operationId, detail: result.text };
+    return failureFromApplyDetails(req.operationId, result.text, result.structuredContent);
+  }
+
+  async verifyRun(req: OmpVerifyRequest): Promise<OmpCommandResult> {
+    return this.invoke("fleet_verification_run", { proposal_id: req.proposalId }, req.operationId);
+  }
+
+  async send(req: OmpSendRequest): Promise<OmpCommandResult> {
+    const args: Record<string, unknown> = { id: req.workerId, text: req.text };
+    if (req.keys !== undefined) args.keys = req.keys;
+    return this.invoke("fleet_send", args, req.operationId);
+  }
+
+  async read(req: OmpReadRequest): Promise<OmpCommandResult> {
+    const args: Record<string, unknown> = { id: req.workerId };
+    if (req.lines !== undefined) args.lines = req.lines;
+    if (req.source !== undefined) args.source = req.source;
+    return this.invoke("fleet_read", args, req.operationId);
+  }
+
+  async state(req: OmpStateRequest): Promise<OmpCommandResult> {
+    return this.invoke("fleet_state", { id: req.workerId }, req.operationId);
+  }
+
+  private async invoke(
+    toolName: string,
+    args: Record<string, unknown>,
+    operationId: string,
+  ): Promise<OmpCommandResult> {
+    const result = await this.client.callTool({ name: toolName, arguments: args });
+    if (result.ok) return { ok: true, operationId, detail: result.text };
+    return toFailureResult(operationId, result.text || `fleet tool failed: ${toolName}`);
+  }
+}

--- a/main/src/orchestrator/omp/ompBridgeConfig.test.ts
+++ b/main/src/orchestrator/omp/ompBridgeConfig.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for `resolveOmpBridgeCommandConfig` — the fail-closed bridge config.
+ *
+ * The command path must never silently authorize: any missing or unusable
+ * field resolves to `undefined` (no adapter → stub → `unavailable`).
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveOmpBridgeCommandConfig } from './ompBridgeConfig';
+
+const URL = 'http://127.0.0.1:53138';
+
+/**
+ * A real 0600 token file. The source file itself will not do: the resolver
+ * enforces owner-only permissions, and a checked-out .ts is world-readable.
+ */
+let tokenFile: string;
+let tokenDir: string;
+/** Same content, but group/world-readable — a credential we must refuse. */
+let looseTokenFile: string;
+
+beforeAll(() => {
+  tokenDir = mkdtempSync(join(tmpdir(), 'omp-bridge-token-'));
+  tokenFile = join(tokenDir, 'token');
+  writeFileSync(tokenFile, 'bearer-value\n');
+  chmodSync(tokenFile, 0o600);
+  looseTokenFile = join(tokenDir, 'token-loose');
+  writeFileSync(looseTokenFile, 'bearer-value\n');
+  chmodSync(looseTokenFile, 0o644);
+});
+
+afterAll(() => {
+  rmSync(tokenDir, { recursive: true, force: true });
+});
+const ENV_KEYS = ['OMP_BRIDGE_URL', 'OMP_BRIDGE_TOKEN_FILE', 'OMP_BRIDGE_SESSION_ID'] as const;
+
+function withEnv(overrides: Record<string, string | undefined>): () => void {
+  const saved = new Map<string, string | undefined>();
+  for (const key of ENV_KEYS) {
+    saved.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  return () => {
+    for (const key of ENV_KEYS) {
+      const original = saved.get(key);
+      if (original === undefined) delete process.env[key];
+      else process.env[key] = original;
+    }
+  };
+}
+
+describe('resolveOmpBridgeCommandConfig', () => {
+  it('resolves a full config from env', () => {
+    const restore = withEnv({
+      OMP_BRIDGE_URL: URL,
+      OMP_BRIDGE_TOKEN_FILE: tokenFile,
+      OMP_BRIDGE_SESSION_ID: 'sess-a',
+    });
+    try {
+      const config = resolveOmpBridgeCommandConfig();
+      expect(config).toBeDefined();
+      expect(config?.url).toBe(URL);
+      expect(config?.sessionId).toBe('sess-a');
+    } finally {
+      restore();
+    }
+  });
+
+  it('returns undefined when the token file is missing', () => {
+    const restore = withEnv({
+      OMP_BRIDGE_URL: URL,
+      OMP_BRIDGE_TOKEN_FILE: '/nonexistent/bridge-token',
+      OMP_BRIDGE_SESSION_ID: 'sess-a',
+    });
+    try {
+      expect(resolveOmpBridgeCommandConfig()).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it('returns undefined when any env field is absent', () => {
+    const restore = withEnv({ OMP_BRIDGE_URL: URL });
+    try {
+      expect(resolveOmpBridgeCommandConfig()).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it('rejects a non-loopback URL', () => {
+    const restore = withEnv({
+      OMP_BRIDGE_URL: 'http://evil.example.com',
+      OMP_BRIDGE_TOKEN_FILE: tokenFile,
+      OMP_BRIDGE_SESSION_ID: 'sess-a',
+    });
+    try {
+      expect(resolveOmpBridgeCommandConfig()).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it('rejects a session id containing a slash', () => {
+    const restore = withEnv({
+      OMP_BRIDGE_URL: URL,
+      OMP_BRIDGE_TOKEN_FILE: tokenFile,
+      OMP_BRIDGE_SESSION_ID: 'a/b',
+    });
+    try {
+      expect(resolveOmpBridgeCommandConfig()).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('resolveOmpBridgeCommandConfig — loopback enforcement', () => {
+  /**
+   * The config carries a bearer token that the client sends to whatever host
+   * resolves here, so "loopback only" has to mean the parsed hostname. A
+   * `startsWith('http://127.0.0.1')` test reads the same but accepts any
+   * registrable domain that merely BEGINS with those characters.
+   */
+  const SPOOFED = [
+    'http://127.0.0.1.evil.example/mcp',
+    'http://localhost.attacker.tld/mcp',
+    'http://127.0.0.1x:9000',
+    'http://notlocalhost:9000',
+  ];
+
+  for (const url of SPOOFED) {
+    it(`refuses a non-loopback host that only looks like one: ${url}`, () => {
+      const restore = withEnv({
+        OMP_BRIDGE_URL: url,
+        OMP_BRIDGE_TOKEN_FILE: tokenFile,
+        OMP_BRIDGE_SESSION_ID: 'sess-a',
+      });
+      try {
+        expect(resolveOmpBridgeCommandConfig()).toBeUndefined();
+      } finally {
+        restore();
+      }
+    });
+  }
+
+  for (const url of ['http://127.0.0.1:53138', 'http://localhost:53138', 'http://[::1]:53138']) {
+    it(`accepts the genuine loopback host ${url}`, () => {
+      const restore = withEnv({
+        OMP_BRIDGE_URL: url,
+        OMP_BRIDGE_TOKEN_FILE: tokenFile,
+        OMP_BRIDGE_SESSION_ID: 'sess-a',
+      });
+      try {
+        expect(resolveOmpBridgeCommandConfig()?.url).toBe(url);
+      } finally {
+        restore();
+      }
+    });
+  }
+
+  it('refuses https even to loopback — a bridge with a certificate is a proxy', () => {
+    const restore = withEnv({
+      OMP_BRIDGE_URL: 'https://127.0.0.1:53138',
+      OMP_BRIDGE_TOKEN_FILE: tokenFile,
+      OMP_BRIDGE_SESSION_ID: 'sess-a',
+    });
+    try {
+      expect(resolveOmpBridgeCommandConfig()).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it('refuses a malformed URL rather than throwing', () => {
+    const restore = withEnv({
+      OMP_BRIDGE_URL: 'not-a-url',
+      OMP_BRIDGE_TOKEN_FILE: tokenFile,
+      OMP_BRIDGE_SESSION_ID: 'sess-a',
+    });
+    try {
+      expect(resolveOmpBridgeCommandConfig()).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('resolveOmpBridgeCommandConfig — token file permissions', () => {
+  it.skipIf(process.platform === 'win32')(
+    'refuses a group/world-readable token file',
+    () => {
+      const restore = withEnv({
+        OMP_BRIDGE_URL: URL,
+        OMP_BRIDGE_TOKEN_FILE: looseTokenFile,
+        OMP_BRIDGE_SESSION_ID: 'sess-a',
+      });
+      try {
+        // Reading it anyway would hand the bridge's authority to every local
+        // account; fail closed instead.
+        expect(resolveOmpBridgeCommandConfig()).toBeUndefined();
+      } finally {
+        restore();
+      }
+    },
+  );
+
+  it('accepts an owner-only token file and carries its trimmed contents', () => {
+    const restore = withEnv({
+      OMP_BRIDGE_URL: URL,
+      OMP_BRIDGE_TOKEN_FILE: tokenFile,
+      OMP_BRIDGE_SESSION_ID: 'sess-a',
+    });
+    try {
+      expect(resolveOmpBridgeCommandConfig()?.token).toBe('bearer-value');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/main/src/orchestrator/omp/ompBridgeConfig.ts
+++ b/main/src/orchestrator/omp/ompBridgeConfig.ts
@@ -1,0 +1,129 @@
+/**
+ * Resolve the OMP bridge configuration for the privileged command adapter.
+ *
+ * The command path is deliberately fail-closed: unless every field resolves,
+ * no adapter is built and the router returns `unavailable` (the Phase-2 stub
+ * behaviour). A half-configured bridge must never silently authorize commands.
+ *
+ * Sources, in precedence order:
+ * - `OMP_BRIDGE_URL` env, else the Prime bridge pointer file
+ *   (`~/.prime/agent/omp-bridge.json`, field `url`) — loopback only, checked
+ *   by parsed hostname rather than string prefix.
+ * - `OMP_BRIDGE_TOKEN_FILE` env (a 0600 file holding the raw bearer token —
+ *   the mode is ENFORCED, not assumed); a raw bearer is required because the
+ *   token is a minted credential, not a recoverable value.
+ * - `OMP_BRIDGE_SESSION_ID` env (the OMP session whose tool host exposes the
+ *   `fleet_*` tools).
+ *
+ * Standalone-typecheck invariant: node:fs only, no electron/services imports.
+ */
+import { readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
+
+export interface OmpBridgeCommandConfig {
+  readonly url: string;
+  readonly token: string;
+  readonly sessionId: string;
+}
+
+const DEFAULT_POINTER_PATH = join(homedir(), ".prime", "agent", "omp-bridge.json");
+
+function readPointerUrl(pointerPath: string): string | undefined {
+  let raw: string;
+  try {
+    raw = readFileSync(pointerPath, "utf8");
+  } catch {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(raw) as { url?: unknown };
+    return typeof parsed.url === "string" && parsed.url.length > 0 ? parsed.url : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveUrl(): string | undefined {
+  const fromEnv = process.env.OMP_BRIDGE_URL;
+  if (fromEnv !== undefined && fromEnv.length > 0) return fromEnv;
+  return readPointerUrl(DEFAULT_POINTER_PATH);
+}
+
+/** Hostnames that are genuinely this machine. */
+const LOOPBACK_HOSTS: ReadonlySet<string> = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
+
+/**
+ * True only when `url` is plain HTTP to a loopback host.
+ *
+ * Parsed, never prefix-matched. `url.startsWith('http://127.0.0.1')` reads as a
+ * loopback check but accepts `http://127.0.0.1.evil.example/` and
+ * `http://localhost.attacker.tld/` — both registrable domains an attacker can
+ * point anywhere — and this config carries a bearer token that the client sends
+ * to whatever host comes back. Comparing the parsed hostname closes that: a
+ * label appended to `127.0.0.1` makes a different hostname, not a prefix.
+ *
+ * The scheme stays http-only, matching the Prime bridge: a loopback listener
+ * has no certificate to present, so an `https://127.0.0.1` pointer means
+ * something is proxying and the token would leave this machine.
+ */
+function isLoopbackHttpUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "http:") return false;
+  return LOOPBACK_HOSTS.has(parsed.hostname.toLowerCase());
+}
+
+/**
+ * Read the bearer token, refusing a file any other account can read.
+ *
+ * The header has always described this as "a 0600 file holding the raw bearer
+ * token" — this enforces it rather than trusting it. A group- or world-readable
+ * credential is a misconfiguration we can detect for free, and reading it
+ * anyway would hand the bridge's authority to every local account. Fail closed:
+ * an unreadable, empty, or over-permissive file yields no adapter at all.
+ */
+function readTokenFile(tokenFile: string): string | undefined {
+  if (!isAbsolute(tokenFile)) return undefined;
+  let token: string;
+  try {
+    // Windows does not model POSIX permission bits, so the mode check is
+    // meaningful only where they exist; the absolute-path and content checks
+    // still apply everywhere.
+    if (process.platform !== "win32") {
+      const mode = statSync(tokenFile).mode & 0o077;
+      if (mode !== 0) return undefined;
+    }
+    token = readFileSync(tokenFile, "utf8").trim();
+  } catch {
+    return undefined;
+  }
+  return token.length > 0 ? token : undefined;
+}
+
+/**
+ * Resolve the bridge command config, or `undefined` when any required piece is
+ * missing (or an env value is present but unusable). Callers treat `undefined`
+ * as "no command adapter".
+ */
+export function resolveOmpBridgeCommandConfig(): OmpBridgeCommandConfig | undefined {
+  const url = resolveUrl();
+  if (url === undefined) return undefined;
+  if (!isLoopbackHttpUrl(url)) return undefined;
+
+  const tokenFile = process.env.OMP_BRIDGE_TOKEN_FILE;
+  if (tokenFile === undefined || tokenFile.length === 0) return undefined;
+  const token = readTokenFile(tokenFile);
+  if (token === undefined) return undefined;
+
+  const sessionId = process.env.OMP_BRIDGE_SESSION_ID;
+  if (sessionId === undefined || sessionId.length === 0 || sessionId.length > 256 || sessionId.includes("/")) {
+    return undefined;
+  }
+
+  return { url, token, sessionId };
+}

--- a/main/src/orchestrator/omp/ompCommandStub.ts
+++ b/main/src/orchestrator/omp/ompCommandStub.ts
@@ -1,0 +1,69 @@
+/**
+ * Stub implementation of `OmpCommandAdapter` — Phase 2 of the OMP plan.
+ *
+ * Every method fails closed with `unavailable`, echoing the request's
+ * `operationId` verbatim so the audit trail and the returned result correlate
+ * on one token. There is no transport yet (Phase 3 ADR:
+ * `docs/proposals/omp-phase3-command-adr.md` records that decision as NO-GO),
+ * so no method can distinguish a real producer denial from a not-implemented
+ * gap — `unavailable` is the only honest failure class at this layer.
+ * `blocked`/`shadow` are producer verification outcomes, not transport states,
+ * and are only returned by a real adapter after an actual gate result.
+ */
+import type {
+  OmpApplyRequest,
+  OmpCommandAdapter,
+  OmpCommandResult,
+  OmpDiscardRequest,
+  OmpKillRequest,
+  OmpReadRequest,
+  OmpSendRequest,
+  OmpSpawnRequest,
+  OmpStateRequest,
+  OmpVerifyRequest,
+} from '../../../../shared/types/ompCommand';
+
+export class OmpCommandStub implements OmpCommandAdapter {
+  readonly authority = 'supervise' as const;
+
+  private unavailable(verb: string, operationId: string): OmpCommandResult {
+    return {
+      ok: false,
+      operationId,
+      error: 'unavailable',
+      detail: `omp:${verb} not implemented (Phase 3 ADR: transport NO-GO)`,
+    };
+  }
+
+  spawn(req: OmpSpawnRequest): Promise<OmpCommandResult> {
+    return Promise.resolve(this.unavailable('spawn', req.operationId));
+  }
+
+  kill(req: OmpKillRequest): Promise<OmpCommandResult> {
+    return Promise.resolve(this.unavailable('kill', req.operationId));
+  }
+
+  apply(req: OmpApplyRequest): Promise<OmpCommandResult> {
+    return Promise.resolve(this.unavailable('apply', req.operationId));
+  }
+
+  discard(req: OmpDiscardRequest): Promise<OmpCommandResult> {
+    return Promise.resolve(this.unavailable('discard', req.operationId));
+  }
+
+  verifyRun(req: OmpVerifyRequest): Promise<OmpCommandResult> {
+    return Promise.resolve(this.unavailable('verifyRun', req.operationId));
+  }
+
+  send(req: OmpSendRequest): Promise<OmpCommandResult> {
+    return Promise.resolve(this.unavailable('send', req.operationId));
+  }
+
+  read(req: OmpReadRequest): Promise<OmpCommandResult> {
+    return Promise.resolve(this.unavailable('read', req.operationId));
+  }
+
+  state(req: OmpStateRequest): Promise<OmpCommandResult> {
+    return Promise.resolve(this.unavailable('state', req.operationId));
+  }
+}

--- a/main/src/orchestrator/omp/ompPrincipal.test.ts
+++ b/main/src/orchestrator/omp/ompPrincipal.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for `resolveOmpPrincipal` — the fail-closed supervise opt-in.
+ */
+import { describe, expect, it } from 'vitest';
+import { resolveOmpPrincipal } from './ompPrincipal';
+import { OMP_SUPERVISE_CAPABILITY } from '../../../../shared/types/ompCommand';
+
+const KEY = 'CYBOFLOW_OMP_SUPERVISE';
+
+function withEnv(value: string | undefined): () => void {
+  const saved = process.env[KEY];
+  if (value === undefined) delete process.env[KEY];
+  else process.env[KEY] = value;
+  return () => {
+    if (saved === undefined) delete process.env[KEY];
+    else process.env[KEY] = saved;
+  };
+}
+
+describe('resolveOmpPrincipal', () => {
+  it('grants no capability by default (fail closed)', () => {
+    const restore = withEnv(undefined);
+    try {
+      const principal = resolveOmpPrincipal();
+      expect(principal.userId).toBe('local');
+      expect(principal.capabilities.size).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it('grants omp:supervise when the env is truthy', () => {
+    for (const value of ['1', 'true', 'yes', 'on', ' TRUE ']) {
+      const restore = withEnv(value);
+      try {
+        expect(resolveOmpPrincipal().capabilities.has(OMP_SUPERVISE_CAPABILITY)).toBe(true);
+      } finally {
+        restore();
+      }
+    }
+  });
+
+  it('does not grant supervise for falsy values', () => {
+    for (const value of ['0', 'false', 'off', 'no', '', '   ']) {
+      const restore = withEnv(value);
+      try {
+        expect(resolveOmpPrincipal().capabilities.has(OMP_SUPERVISE_CAPABILITY)).toBe(false);
+      } finally {
+        restore();
+      }
+    }
+  });
+
+  it('grants omp:supervise from Aria mode with no env var set', () => {
+    const restore = withEnv(undefined);
+    try {
+      // The Settings toggle IS the grant: an operator turning on remote-fleet
+      // supervision is exactly the person authorizing it, so a desktop feature
+      // does not need a shell incantation to switch on.
+      expect(resolveOmpPrincipal(true).capabilities.has(OMP_SUPERVISE_CAPABILITY)).toBe(true);
+      expect(resolveOmpPrincipal(false).capabilities.has(OMP_SUPERVISE_CAPABILITY)).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it('keeps the env var as an override for hosts with no Settings UI', () => {
+    const restore = withEnv('1');
+    try {
+      // Aria mode off but the env explicitly on — a headless/CI host. Either
+      // source alone grants; they are OR-ed, not AND-ed.
+      expect(resolveOmpPrincipal(false).capabilities.has(OMP_SUPERVISE_CAPABILITY)).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  it('defaults ariaMode to false so an unaware caller still fails closed', () => {
+    const restore = withEnv(undefined);
+    try {
+      expect(resolveOmpPrincipal().capabilities.size).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/main/src/orchestrator/omp/ompPrincipal.ts
+++ b/main/src/orchestrator/omp/ompPrincipal.ts
@@ -1,0 +1,38 @@
+/**
+ * Resolve the OMP command principal for the local desktop session.
+ *
+ * v1: userId is hard-coded `'local'` (the auth-principal placeholder — see
+ * `trpc/context.ts`). The `omp:supervise` capability is granted by EITHER:
+ *
+ * - **Aria mode** (Settings → Advanced Options), passed in as `ariaMode`. This
+ *   is the ordinary path: an operator turning on remote-fleet supervision is
+ *   exactly the person authorizing it, so the toggle IS the grant. A desktop
+ *   feature should not need a shell incantation to switch on.
+ * - **`CYBOFLOW_OMP_SUPERVISE`** truthy — an override for headless and CI hosts
+ *   that have no Settings UI to click.
+ *
+ * Neither present ⇒ the principal carries no capabilities, every `ompCommand`
+ * mutation is FORBIDDEN at the router, and no fleet session manager is built —
+ * fail closed, never fail open. Reachability of the bridge is deliberately NOT
+ * part of this: "the fleet can be reached" and "this operator authorized
+ * driving it" are different questions.
+ *
+ * Standalone-typecheck invariant: no imports from electron, better-sqlite3, or
+ * services/*. This module is pure — the caller reads config and passes the flag.
+ */
+import type { OmpPrincipal } from '../../../../shared/types/ompCommand';
+import { OMP_SUPERVISE_CAPABILITY } from '../../../../shared/types/ompCommand';
+
+function isTruthy(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const trimmed = value.trim().toLowerCase();
+  return trimmed !== '' && trimmed !== '0' && trimmed !== 'false' && trimmed !== 'off' && trimmed !== 'no';
+}
+
+export function resolveOmpPrincipal(ariaMode = false): OmpPrincipal {
+  const supervise = ariaMode || isTruthy(process.env.CYBOFLOW_OMP_SUPERVISE);
+  return {
+    userId: 'local',
+    capabilities: supervise ? new Set([OMP_SUPERVISE_CAPABILITY]) : new Set<string>(),
+  };
+}

--- a/main/src/orchestrator/omp/ompSessionManager.ts
+++ b/main/src/orchestrator/omp/ompSessionManager.ts
@@ -1,0 +1,571 @@
+/**
+ * OMP Phase-4 increment 3 — `OmpSessionManager`: a sibling of the four
+ * `AbstractCliManager` managers (ADR `omp-phase4-coexistence-adr.md` §3),
+ * NOT a subclass of `AbstractCliManager`. It has no child process, no PTY,
+ * no stdout stream: one panel ≙ one remote OMP worker, supervised over the
+ * Phase-3 bridge through the supervise-authorized `OmpCommandAdapter`.
+ *
+ * Chat-lifecycle mapping (ADR table, §3):
+ *
+ * | Chat lifecycle            | Fleet tool      | Implementation here |
+ * |---------------------------|-----------------|---------------------|
+ * | `spawn(panelId, …, prompt)` | `fleet_spawn` | worker id parsed from the detail, stored on the panel |
+ * | `sendInput(panelId, text)`  | `fleet_send`    | follow-up turns steer the same worker |
+ * | `output` (poll)             | `fleet_read`    | new output since last read, emitted as `output` events |
+ * | liveness / exit detection   | `fleet_state`   | leaves a live state ⇒ emit `exit` (terminal) |
+ * | `stop(panelId)`             | `fleet_kill`    | deliberate termination |
+ *
+ * The event payload shapes mirror the (module-private) shapes of
+ * `AbstractCliManager` — `output` `{ panelId, sessionId, type, data,
+ * timestamp }` and `exit` `{ panelId, sessionId, exitCode, signal }` — so the
+ * `AbstractAIPanelManager` forwarding layer can consume this manager unmodified
+ * once increment 4 wires it in. Increment 3 itself is standalone: it is not
+ * constructed by anything yet, and dispatch wiring is increment 4.
+ *
+ * `fleet_read` returns a *sliding* recent-lines window with no byte offset, so
+ * "new output since last read" is derived by comparing against the last-read
+ * transcript (`newOutputSince`): a strict extension emits the delta; a slid
+ * window emits only the non-overlapping tail.
+ *
+ * Fail-closed: the manager is only ever constructed with a RESOLVED adapter
+ * (ADR §5 — the wiring checks `resolveOmpBridgeCommandConfig()` first). A
+ * failed `spawn` result or an unparseable worker id terminates the panel with
+ * an `exit` event instead of leaving a half-spawned record.
+ *
+ * Standalone-typecheck invariant: node imports only (`node:crypto`,
+ * `node:events`); no electron / better-sqlite3 / services imports.
+ */
+import { randomUUID } from "node:crypto";
+import { EventEmitter } from "node:events";
+import type {
+  OmpCommandAdapter,
+  OmpCommandResult,
+} from "../../../../shared/types/ompCommand";
+import type { LoggerLike } from "../types";
+
+/** Default poll cadence for `fleet_read`/`fleet_state` per live panel. */
+export const OMP_DEFAULT_POLL_MS = 1500;
+
+/**
+ * Cap for the sliding-window overlap search in `newOutputSince`. The recent
+ * window is bounded upstream; this cap keeps the O(k·n) comparison cheap even
+ * for an unbounded transcript. Mirrors the `LAST_OUTPUT_TAIL_BYTES` diagnostic
+ * cap on the CLI manager.
+ */
+const OUTPUT_OVERLAP_CAP = 8192;
+
+/**
+ * Terminal OMP worker states — matches the producer's own
+ * `isTerminalStatus` (OMP-fleet-management `extensions/fleet/controller.ts`):
+ * a worker in one of these will not produce more output on its own and is not
+ * accepting input. `idle` (turn done, awaiting input) is deliberately NOT
+ * terminal: it is the REPL equivalent.
+ */
+const OMP_TERMINAL_STATES: ReadonlySet<string> = new Set([
+  "done",
+  "failed",
+  "dead",
+  "evicted",
+]);
+
+/** Event shapes mirror `AbstractCliManager`'s module-private interfaces. */
+export interface OmpOutputEvent {
+  panelId: string;
+  sessionId: string;
+  type: "stdout" | "stderr";
+  data: string;
+  timestamp: Date;
+}
+
+export interface OmpExitEvent {
+  panelId: string;
+  sessionId: string;
+  exitCode: number | null;
+  signal: number | null;
+}
+
+export interface OmpSpawnedEvent {
+  panelId: string;
+  sessionId: string;
+}
+
+export interface OmpErrorEvent {
+  panelId: string;
+  sessionId: string;
+  error: string;
+  /**
+   * `true` when the panel SURVIVES this error — a bridge blip, a herder
+   * hiccup, a rejected send. The worker is still live and the next poll may
+   * succeed, so consumers must not park the panel in a terminal-looking
+   * state. Real termination arrives as `exit`, never as `error`.
+   */
+  transient: boolean;
+}
+
+export interface OmpSpawnConfig {
+  /** Model id forwarded to `fleet_spawn` (required by the producer). */
+  model: string;
+  /** Workspace id for spawn serialization. */
+  workspace?: string;
+  /** Working directory for the spawned agent. */
+  cwd?: string;
+  /** Optional pane label. */
+  label?: string;
+}
+
+export interface OmpSessionManagerOptions {
+  /** Poll cadence in ms (default {@link OMP_DEFAULT_POLL_MS}). */
+  pollMs?: number;
+}
+
+interface OmpPanelRecord {
+  panelId: string;
+  sessionId: string;
+  workerId: string | null;
+  model: string;
+  /** Last `fleet_read` transcript (for sliding-window dedup, not storage). */
+  emitted: string;
+  terminal: boolean;
+  timer: NodeJS.Timeout | null;
+  /** True while a tick is mid-flight; the poll loop skips rather than overlaps. */
+  polling: boolean;
+}
+
+/** `worker=<id>` as rendered by the producer's `fleet_spawn` success detail. */
+const WORKER_ID_PATTERN = /worker=([^\s\]]+)/;
+
+/** `state=<status>` as rendered by the producer's `fleet_state` detail lines. */
+const STATE_PATTERN = /state=([A-Za-z_]+)/;
+
+function exitCodeForTerminal(state: string): number {
+  return state === "done" ? 0 : 1;
+}
+
+/**
+ * Derive "new output since last read" from a sliding recent-lines window.
+ *
+ * - `fresh` empty (the producer renders an empty read as `"(empty)"`, which
+ *   callers normalize to `""` before arriving here) ⇒ nothing new.
+ * - identical ⇒ nothing new.
+ * - strict extension (window still contains everything read before) ⇒ the delta.
+ * - the window slid off the old head ⇒ only the non-overlapping tail, where the
+ *   overlap is the longest suffix of `last` that is also a prefix of `fresh`
+ *   (search capped at {@link OUTPUT_OVERLAP_CAP} characters).
+ * - no overlap at all (pathological) ⇒ the whole fresh window (one duplicate
+ *   edge accepted over silently dropping output).
+ */
+export function newOutputSince(last: string, fresh: string): string {
+  if (fresh.length === 0 || fresh === last) return "";
+  if (last.length === 0 || fresh.startsWith(last)) return fresh.slice(last.length);
+  const cap = Math.min(OUTPUT_OVERLAP_CAP, last.length, fresh.length);
+  for (let k = cap; k > 0; k--) {
+    if (fresh.startsWith(last.slice(last.length - k))) {
+      return fresh.slice(k);
+    }
+  }
+  return fresh;
+}
+
+export class OmpSessionManager extends EventEmitter {
+  private readonly records = new Map<string, OmpPanelRecord>();
+  private readonly adapter: OmpCommandAdapter;
+  private readonly logger?: LoggerLike;
+  private readonly pollMs: number;
+
+  constructor(adapter: OmpCommandAdapter, logger?: LoggerLike, options?: OmpSessionManagerOptions) {
+    super();
+    if (adapter === null || typeof adapter.spawn !== "function") {
+      throw new Error("OmpSessionManager requires a resolved OmpCommandAdapter");
+    }
+    this.adapter = adapter;
+    this.logger = logger;
+    this.pollMs = options?.pollMs ?? OMP_DEFAULT_POLL_MS;
+  }
+
+  /** Number of panels this manager is tracking (any state). */
+  get panelCount(): number {
+    return this.records.size;
+  }
+
+  /** True while the panel has a worker and has not reached a terminal state. */
+  isPanelRunning(panelId: string): boolean {
+    const record = this.records.get(panelId);
+    return record !== undefined && !record.terminal && record.workerId !== null;
+  }
+
+  /**
+   * Spawn the panel's OMP worker (`fleet_spawn`). Emits `spawned` on success;
+   * a failed result or an unparseable worker id emits `exit` (fail-closed) and
+   * the panel is dropped.
+   *
+   * Returns whether a live worker is now tracked for the panel, so the IPC
+   * caller can report the turn honestly rather than answering `success: true`
+   * to a spawn that failed closed.
+   *
+   * One panel ≙ one LIVE worker: when the panel's previous worker has reached
+   * a terminal state (or the record was never live), a new spawn REPLACES the
+   * dead record — this is the ADR's "the first message spawns" respawn path.
+   * Spawning a panel whose worker is still live is rejected: steering a live
+   * worker is `sendInput`'s job.
+   */
+  async spawn(panelId: string, sessionId: string, prompt: string, config: OmpSpawnConfig): Promise<boolean> {
+    if (prompt.trim() === "") {
+      throw new TypeError("OmpSessionManager.spawn requires a non-empty prompt");
+    }
+    if (config.model.trim() === "") {
+      throw new TypeError("OmpSessionManager.spawn requires a model");
+    }
+    // Reserve the panel BEFORE the (awaited) adapter call: a double-click
+    // spawns two concurrent calls, and both would pass a pure "existing"
+    // guard before either sets `this.records` — orphaning a second remote
+    // worker. A pending record (workerId still null) makes the in-flight
+    // spawn visible to a concurrent spawn, which rejects.
+    const existing = this.records.get(panelId);
+    if (existing !== undefined && !existing.terminal) {
+      throw new Error(`OmpSessionManager: panel ${panelId} already spawned`);
+    }
+    if (existing !== undefined) {
+      // The previous worker is dead; replace its record. Clear any lingering
+      // poll timer (defensive — finishTerminal/stopPanel already did).
+      this.clearPolling(existing);
+    }
+    const pending: OmpPanelRecord = {
+      panelId,
+      sessionId,
+      workerId: null,
+      model: config.model,
+      emitted: "",
+      terminal: false,
+      timer: null,
+      polling: false,
+    };
+    this.records.set(panelId, pending);
+
+    let result: OmpCommandResult;
+    try {
+      result = await this.adapter.spawn({
+        operationId: randomUUID(),
+        model: config.model,
+        task: prompt,
+        label: config.label,
+        workspace: config.workspace,
+        cwd: config.cwd,
+      });
+    } catch (err) {
+      this.logger?.error(`[OmpSessionManager] fleet_spawn threw for panel ${panelId}`, {
+        sessionId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      if (this.records.get(panelId) === pending) this.records.delete(panelId);
+      this.emitExit(panelId, sessionId, 1);
+      return false;
+    }
+
+    if (!result.ok) {
+      this.logger?.error(`[OmpSessionManager] fleet_spawn failed for panel ${panelId}`, {
+        sessionId,
+        error: result.error,
+        detail: result.detail,
+      });
+      if (this.records.get(panelId) === pending) this.records.delete(panelId);
+      this.emitExit(panelId, sessionId, 1);
+      return false;
+    }
+
+    const workerMatch = WORKER_ID_PATTERN.exec(result.detail);
+    const workerId = workerMatch ? workerMatch[1] : null;
+    if (workerId === null) {
+      this.logger?.error(`[OmpSessionManager] fleet_spawn returned no worker id for panel ${panelId}`, {
+        sessionId,
+        detail: result.detail,
+      });
+      if (this.records.get(panelId) === pending) this.records.delete(panelId);
+      this.emitExit(panelId, sessionId, 1);
+      return false;
+    }
+
+    // The pending reservation becomes the live record in place. stopPanel
+    // marks it terminal while spawn is still in flight; honor that instead of
+    // reviving the panel.
+    if (pending.terminal) {
+      // stopPanel/stopAll ran while `fleet_spawn` was in flight, so it saw a
+      // null workerId and had nothing to kill — the worker was born AFTER the
+      // kill sweep passed. Untracked and unkilled, it would keep working the
+      // worktree forever. Reap it here: this is the only frame that has ever
+      // held its id.
+      this.logger?.info(`[OmpSessionManager] panel ${panelId} stopped while spawn was in flight; killing the orphaned worker`, {
+        sessionId,
+        workerId,
+      });
+      const killed = await this.adapter.kill({ operationId: randomUUID(), workerId });
+      if (!killed.ok) {
+        this.logger?.warn(`[OmpSessionManager] fleet_kill failed for orphaned worker ${workerId} (panel ${panelId})`, {
+          sessionId,
+          detail: killed.detail,
+        });
+      }
+      return false;
+    }
+    pending.workerId = workerId;
+    this.records.set(panelId, pending);
+    this.emit("spawned", { panelId, sessionId } satisfies OmpSpawnedEvent);
+    this.startPolling(pending);
+    this.logger?.info(`[OmpSessionManager] spawned ${workerId} for panel ${panelId}`, {
+      sessionId,
+      model: config.model,
+    });
+    return true;
+  }
+
+  /**
+   * Send a follow-up turn to the panel's worker (`fleet_send`). Returns `true`
+   * when the input was handed to a live worker (or the send reached the
+   * adapter), `false` when the panel has no live worker and a spawn is needed
+   * instead — mirroring the relay-or-spawn convention of the other runtimes.
+   */
+  async sendInput(panelId: string, text: string): Promise<boolean> {
+    const record = this.requireLiveRecord(panelId);
+    if (record === null) return false;
+    const result = await this.adapter.send({
+      operationId: randomUUID(),
+      workerId: record.workerId as string,
+      text,
+    });
+    if (!result.ok) {
+      this.logger?.error(`[OmpSessionManager] fleet_send failed for panel ${panelId}`, {
+        sessionId: record.sessionId,
+        workerId: record.workerId,
+        error: result.error,
+        detail: result.detail,
+      });
+      this.emitError(record, `fleet_send failed: ${result.detail}`);
+      // The turn did NOT reach the worker: report failure to the caller so
+      // the IPC layer can surface it instead of claiming success. The panel
+      // stays live (requireLiveRecord still passes) so the user can retry.
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Deliberate termination (`fleet_kill`). Emits `exit` exactly once and stops
+   * polling. A failed kill still terminates locally: the panel is unusable
+   * from Cyboflow's side either way.
+   */
+  async stopPanel(panelId: string): Promise<void> {
+    const record = this.records.get(panelId);
+    if (record === undefined || record.terminal) return;
+    this.clearPolling(record);
+    record.terminal = true;
+    if (record.workerId !== null) {
+      const result = await this.adapter.kill({
+        operationId: randomUUID(),
+        workerId: record.workerId,
+      });
+      if (!result.ok) {
+        this.logger?.warn(`[OmpSessionManager] fleet_kill failed for panel ${panelId} (terminating locally)`, {
+          sessionId: record.sessionId,
+          workerId: record.workerId,
+          detail: result.detail,
+        });
+      }
+    }
+    this.emitExit(panelId, record.sessionId, null);
+    this.logger?.info(`[OmpSessionManager] stopped panel ${panelId}`, {
+      sessionId: record.sessionId,
+      workerId: record.workerId,
+    });
+  }
+
+  /** Stop every tracked panel (best-effort `fleet_kill` on each live worker). */
+  async stopAll(): Promise<void> {
+    const records = [...this.records.values()];
+    this.records.clear();
+    await Promise.all(records.map((record) => this.stopRecord(record)));
+  }
+
+  /**
+   * One poll cycle for a panel: `fleet_read` (emit new output) then
+   * `fleet_state` (detect terminal). Exposed for tests and for incremental
+   * drivers; the internal timer is the production caller.
+   */
+  async tick(panelId: string): Promise<void> {
+    const record = this.records.get(panelId);
+    if (record === undefined || record.terminal || record.workerId === null) return;
+    // One tick per panel at a time. Each cycle makes two awaited bridge round
+    // trips; when those outlast the poll interval the timer would start a
+    // second tick that races the first on `record.emitted` — the two would
+    // read the same window and both emit it, or interleave their writes and
+    // drop a chunk. Skipping a beat is the correct answer: the next tick sees
+    // the same sliding window and picks up whatever is new.
+    if (record.polling) return;
+    record.polling = true;
+    try {
+      await this.pollOnce(record);
+    } finally {
+      record.polling = false;
+    }
+  }
+
+  /** One poll cycle for a record already claimed by {@link tick}. */
+  private async pollOnce(record: OmpPanelRecord): Promise<void> {
+    const workerId = record.workerId;
+    if (workerId === null) return;
+    let stateResult: OmpCommandResult;
+    try {
+      stateResult = await this.adapter.state({ operationId: randomUUID(), workerId });
+    } catch (err) {
+      this.emitError(record, `fleet_state failed: ${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+    // A transport-level state failure (`ok:false`) is TRANSIENT — a bridge
+    // blip, a herder offline. Surface it and keep the panel alive; only a
+    // genuinely unparseable live-state line or a vanished worker is terminal.
+    if (!stateResult.ok) {
+      this.emitError(record, `fleet_state failed: ${stateResult.detail}`);
+      return;
+    }
+    const state = this.parseState(stateResult);
+    const workerGone = state !== null && !OMP_TERMINAL_STATES.has(state) && /not found/i.test(stateResult.detail);
+    if (state === null || workerGone) {
+      // Unparseable or vanished worker: terminal from this side. No final drain
+      // — a worker that is gone has no transcript left to read.
+      this.finishTerminal(record, workerGone ? "evicted" : "failed");
+      return;
+    }
+    if (OMP_TERMINAL_STATES.has(state)) {
+      // Drain BEFORE terminating. Everything the worker emitted between the
+      // previous poll and its exit is still only in the recent-lines window,
+      // and terminating first would drop it — which for a `done` worker is
+      // precisely its final answer, the one message the user is waiting for.
+      await this.drainOutput(record, workerId);
+      this.finishTerminal(record, state);
+      return;
+    }
+
+    // Live worker: surface any new output since the last read.
+    await this.drainOutput(record, workerId);
+  }
+
+  /**
+   * `fleet_read` once and emit whatever is new. A failed read is transient and
+   * non-fatal: `fleet_state` is the authority for terminal detection, so a read
+   * blip must not end the panel.
+   */
+  private async drainOutput(record: OmpPanelRecord, workerId: string): Promise<void> {
+    let readResult: OmpCommandResult;
+    try {
+      readResult = await this.adapter.read({ operationId: randomUUID(), workerId });
+    } catch (err) {
+      this.emitError(record, `fleet_read failed: ${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+    if (!readResult.ok) {
+      this.emitError(record, `fleet_read failed: ${readResult.detail}`);
+      return;
+    }
+    const fresh = readResult.detail === "(empty)" ? "" : readResult.detail;
+    const chunk = newOutputSince(record.emitted, fresh);
+    record.emitted = fresh;
+    if (chunk !== "") {
+      this.emitOutput(record, chunk);
+    }
+  }
+
+  // ── internals ──────────────────────────────────────────────────────────
+
+  private requireLiveRecord(panelId: string): OmpPanelRecord | null {
+    const record = this.records.get(panelId);
+    if (record === undefined || record.terminal) return null;
+    if (record.workerId === null) return null;
+    return record;
+  }
+
+  private async stopRecord(record: OmpPanelRecord): Promise<void> {
+    if (record.terminal) return;
+    this.clearPolling(record);
+    record.terminal = true;
+    if (record.workerId !== null) {
+      const result = await this.adapter.kill({
+        operationId: randomUUID(),
+        workerId: record.workerId,
+      });
+      if (!result.ok) {
+        this.logger?.warn(`[OmpSessionManager] fleet_kill failed during stopAll for panel ${record.panelId}`, {
+          sessionId: record.sessionId,
+          workerId: record.workerId,
+          detail: result.detail,
+        });
+      }
+    }
+    this.emitExit(record.panelId, record.sessionId, null);
+  }
+
+  private finishTerminal(record: OmpPanelRecord, state: string): void {
+    if (record.terminal) return;
+    this.clearPolling(record);
+    record.terminal = true;
+    this.emitExit(record.panelId, record.sessionId, exitCodeForTerminal(state));
+    this.logger?.info(`[OmpSessionManager] worker ${record.workerId} terminal (${state}) for panel ${record.panelId}`, {
+      sessionId: record.sessionId,
+    });
+  }
+
+  private emitExit(panelId: string, sessionId: string, exitCode: number | null): void {
+    this.emit("exit", { panelId, sessionId, exitCode, signal: null } satisfies OmpExitEvent);
+  }
+
+  private emitOutput(record: OmpPanelRecord, data: string): void {
+    // A concurrent stopPanel can terminate the record while an awaited
+    // fleet_read is in flight; `exit` has already been emitted by then, and
+    // output arriving after it reopens a panel the consumer has closed out.
+    if (record.terminal) return;
+    this.emit(
+      "output",
+      {
+        panelId: record.panelId,
+        sessionId: record.sessionId,
+        type: "stdout",
+        data,
+        timestamp: new Date(),
+      } satisfies OmpOutputEvent,
+    );
+  }
+
+  /**
+   * Every current call site is a LIVE-panel failure (poll blip, failed send):
+   * the record stays non-terminal and the panel remains usable, so the event
+   * is marked transient. Terminal outcomes go through {@link finishTerminal}.
+   */
+  private emitError(record: OmpPanelRecord, error: string): void {
+    if (record.terminal) return;
+    this.emit("error", {
+      panelId: record.panelId,
+      sessionId: record.sessionId,
+      error,
+      transient: true,
+    } satisfies OmpErrorEvent);
+  }
+
+  private parseState(result: OmpCommandResult): string | null {
+    if (!result.ok) return null;
+    const match = STATE_PATTERN.exec(result.detail);
+    return match ? match[1] : null;
+  }
+
+  private startPolling(record: OmpPanelRecord): void {
+    if (record.timer !== null) return;
+    record.timer = setInterval(() => {
+      void this.tick(record.panelId);
+    }, this.pollMs);
+    // A per-panel poll must not pin the main process open.
+    record.timer.unref?.();
+  }
+
+  private clearPolling(record: OmpPanelRecord): void {
+    if (record.timer !== null) {
+      clearInterval(record.timer);
+      record.timer = null;
+    }
+  }
+}

--- a/main/src/orchestrator/omp/ompSupervisedAdapter.test.ts
+++ b/main/src/orchestrator/omp/ompSupervisedAdapter.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Tests for `OmpSupervisedAdapter` — the capability + audit chokepoint.
+ *
+ * The regression this guards: `OmpSessionManager` drives the same privileged
+ * fleet_* surface as the `ompCommand` tRPC router, but from the panel dispatch
+ * seams. Handed a bare bridge adapter it spawned and killed real remote workers
+ * with no capability check and no audit trail, while the router answered
+ * FORBIDDEN for the same verbs. Wrapping makes the gate structural, so these
+ * tests assert it holds for BOTH the mutating and the read-only surface.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import type { OmpCommandAdapter, OmpCommandResult, OmpPrincipal } from '../../../../shared/types/ompCommand';
+import { OMP_SUPERVISE_CAPABILITY } from '../../../../shared/types/ompCommand';
+import { OmpSupervisedAdapter, type OmpSupervisedAuditEntry } from './ompSupervisedAdapter';
+
+const authorized: OmpPrincipal = { userId: 'local', capabilities: new Set([OMP_SUPERVISE_CAPABILITY]) };
+const unauthorized: OmpPrincipal = { userId: 'local', capabilities: new Set<string>() };
+
+function ok(operationId: string): OmpCommandResult {
+  return { ok: true, operationId, detail: 'worker=w1' };
+}
+
+function makeInner(): { inner: OmpCommandAdapter; calls: string[] } {
+  const calls: string[] = [];
+  const record =
+    (verb: string) =>
+    async (req: { operationId: string }): Promise<OmpCommandResult> => {
+      calls.push(verb);
+      return ok(req.operationId);
+    };
+  const inner: OmpCommandAdapter = {
+    authority: 'supervise',
+    spawn: record('spawn'),
+    kill: record('kill'),
+    send: record('send'),
+    apply: record('apply'),
+    discard: record('discard'),
+    verifyRun: record('verifyRun'),
+    read: record('read'),
+    state: record('state'),
+  };
+  return { inner, calls };
+}
+
+function make(principal: OmpPrincipal): {
+  adapter: OmpSupervisedAdapter;
+  calls: string[];
+  audit: OmpSupervisedAuditEntry[];
+} {
+  const { inner, calls } = makeInner();
+  const audit: OmpSupervisedAuditEntry[] = [];
+  return { adapter: new OmpSupervisedAdapter(inner, principal, (e) => audit.push(e)), calls, audit };
+}
+
+const MUTATIONS = ['spawn', 'kill', 'send', 'apply', 'discard', 'verifyRun'] as const;
+
+/** Minimal well-typed request per verb; only operationId matters to the wrapper. */
+function invoke(adapter: OmpSupervisedAdapter, verb: string, operationId: string): Promise<OmpCommandResult> {
+  switch (verb) {
+    case 'spawn':
+      return adapter.spawn({ operationId, model: 'm', task: 't' });
+    case 'kill':
+      return adapter.kill({ operationId, workerId: 'w1' });
+    case 'send':
+      return adapter.send({ operationId, workerId: 'w1', text: 'hi' });
+    case 'apply':
+      return adapter.apply({ operationId, proposalId: 'p1', reason: 'r' });
+    case 'discard':
+      return adapter.discard({ operationId, proposalId: 'p1', reason: 'r' });
+    case 'verifyRun':
+      return adapter.verifyRun({ operationId, proposalId: 'p1' });
+    case 'read':
+      return adapter.read({ operationId, workerId: 'w1' });
+    default:
+      return adapter.state({ operationId, workerId: 'w1' });
+  }
+}
+
+describe('OmpSupervisedAdapter — without the supervise capability', () => {
+  for (const verb of MUTATIONS) {
+    it(`refuses ${verb} and never reaches the bridge`, async () => {
+      const { adapter, calls, audit } = make(unauthorized);
+      const result = await invoke(adapter, verb, 'op-1');
+
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.error).toBe('forbidden');
+      expect(calls).toEqual([]);
+      // Refusals are audited too — a denied privileged attempt is exactly the
+      // event an operator wants in the trail.
+      expect(audit).toEqual([
+        { verb, principal: 'local', outcome: 'attempted', operationId: 'op-1', detail: '' },
+        { verb, principal: 'local', outcome: 'completed', operationId: 'op-1', detail: 'forbidden' },
+      ]);
+    });
+  }
+
+  for (const verb of ['read', 'state'] as const) {
+    it(`refuses the read-only verb ${verb} without auditing the poll`, async () => {
+      const { adapter, calls, audit } = make(unauthorized);
+      const result = await invoke(adapter, verb, 'op-1');
+
+      expect(result.ok === false && result.error).toBe('forbidden');
+      expect(calls).toEqual([]);
+      expect(audit).toEqual([]);
+    });
+  }
+});
+
+describe('OmpSupervisedAdapter — with the supervise capability', () => {
+  for (const verb of MUTATIONS) {
+    it(`delegates ${verb} and records attempted + completed on one operationId`, async () => {
+      const { adapter, calls, audit } = make(authorized);
+      const result = await invoke(adapter, verb, 'op-7');
+
+      expect(result.ok).toBe(true);
+      expect(result.operationId).toBe('op-7');
+      expect(calls).toEqual([verb]);
+      expect(audit.map((e) => e.outcome)).toEqual(['attempted', 'completed']);
+      expect(audit.every((e) => e.operationId === 'op-7')).toBe(true);
+      expect(audit[1].detail).toBe('ok');
+    });
+  }
+
+  it('delegates the poll verbs without writing audit rows', async () => {
+    const { adapter, calls, audit } = make(authorized);
+    await invoke(adapter, 'read', 'op-r');
+    await invoke(adapter, 'state', 'op-s');
+
+    // Two log lines per poll per panel would bury the mutation trail this sink
+    // exists to preserve; these verbs observe, they never act.
+    expect(calls).toEqual(['read', 'state']);
+    expect(audit).toEqual([]);
+  });
+
+  it('records a terminal outcome when the bridge throws, and never propagates', async () => {
+    const { inner } = makeInner();
+    const audit: OmpSupervisedAuditEntry[] = [];
+    inner.spawn = vi.fn(async () => {
+      throw new Error('bridge unreachable');
+    });
+    const adapter = new OmpSupervisedAdapter(inner, authorized, (e) => audit.push(e));
+
+    const result = await adapter.spawn({ operationId: 'op-9', model: 'm', task: 't' });
+
+    expect(result.ok === false && result.error).toBe('unavailable');
+    expect(result.ok === false && result.detail).toBe('bridge unreachable');
+    expect(audit.map((e) => e.outcome)).toEqual(['attempted', 'completed']);
+    expect(audit[1].detail).toBe('unavailable');
+  });
+
+  it('carries a non-ok bridge result through as the audited outcome', async () => {
+    const { inner } = makeInner();
+    const audit: OmpSupervisedAuditEntry[] = [];
+    inner.kill = vi.fn(
+      async (req): Promise<OmpCommandResult> => ({
+        ok: false,
+        operationId: req.operationId,
+        error: 'conflict',
+        detail: 'worker already gone',
+      }),
+    );
+    const adapter = new OmpSupervisedAdapter(inner, authorized, (e) => audit.push(e));
+
+    const result = await adapter.kill({ operationId: 'op-c', workerId: 'w1' });
+
+    expect(result.ok === false && result.error).toBe('conflict');
+    expect(audit[1].detail).toBe('conflict');
+  });
+
+  it('audits no raw payload — the attempted row carries no task text', async () => {
+    const { adapter, audit } = make(authorized);
+    await adapter.spawn({ operationId: 'op-x', model: 'm', task: 'SECRET customer data' });
+
+    for (const entry of audit) {
+      expect(JSON.stringify(entry)).not.toContain('SECRET');
+    }
+  });
+});
+
+describe('OmpSupervisedAdapter — a live principal (Aria mode flipped at runtime)', () => {
+  /** Same harness, but the identity comes from a mutable cell via a thunk. */
+  function makeLive(): {
+    adapter: OmpSupervisedAdapter;
+    calls: string[];
+    setSupervise: (on: boolean) => void;
+  } {
+    const { inner, calls } = makeInner();
+    let supervise = false;
+    const adapter = new OmpSupervisedAdapter(
+      inner,
+      () => ({
+        userId: 'local',
+        capabilities: supervise ? new Set([OMP_SUPERVISE_CAPABILITY]) : new Set<string>(),
+      }),
+      () => {},
+    );
+    return { adapter, calls, setSupervise: (on: boolean) => { supervise = on; } };
+  }
+
+  // The restart bug: the manager captured its principal at boot, so granting
+  // Aria mode did nothing until relaunch. Resolving per call fixes it.
+  it('authorizes commands as soon as the capability is granted, with no rebuild', async () => {
+    const { adapter, calls, setSupervise } = makeLive();
+
+    expect((await invoke(adapter, 'spawn', 'op-1')).ok).toBe(false);
+    expect(calls).toEqual([]);
+
+    setSupervise(true);
+
+    expect((await invoke(adapter, 'spawn', 'op-2')).ok).toBe(true);
+    expect(calls).toEqual(['spawn']);
+  });
+
+  // The same freeze in the dangerous direction: a captured principal kept an
+  // already-built adapter authorized for the rest of the run.
+  it('forbids the very next command once the capability is revoked', async () => {
+    const { adapter, calls, setSupervise } = makeLive();
+    setSupervise(true);
+    expect((await invoke(adapter, 'kill', 'op-1')).ok).toBe(true);
+
+    setSupervise(false);
+
+    const result = await invoke(adapter, 'kill', 'op-2');
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toBe('forbidden');
+    // The revoked call never reached the bridge.
+    expect(calls).toEqual(['kill']);
+  });
+
+  it('gates the read-only verbs on the live capability too', async () => {
+    const { adapter, calls, setSupervise } = makeLive();
+    expect((await adapter.read({ operationId: 'op-1', workerId: 'w1' })).ok).toBe(false);
+    setSupervise(true);
+    expect((await adapter.read({ operationId: 'op-2', workerId: 'w1' })).ok).toBe(true);
+    expect(calls).toEqual(['read']);
+  });
+
+  // A provider that throws (config not yet constructed at an early call) must
+  // fail CLOSED rather than crash the caller.
+  it('forbids rather than throwing when the principal provider throws', async () => {
+    const { inner, calls } = makeInner();
+    const adapter = new OmpSupervisedAdapter(
+      inner,
+      () => {
+        throw new Error('configManager not ready');
+      },
+      () => {},
+    );
+    const result = await invoke(adapter, 'spawn', 'op-1');
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toBe('forbidden');
+    expect(calls).toEqual([]);
+  });
+});

--- a/main/src/orchestrator/omp/ompSupervisedAdapter.ts
+++ b/main/src/orchestrator/omp/ompSupervisedAdapter.ts
@@ -1,0 +1,194 @@
+/**
+ * `OmpSupervisedAdapter` — the capability + audit chokepoint for the OMP
+ * command surface, expressed as a decorator over any `OmpCommandAdapter`.
+ *
+ * WHY THIS EXISTS. The `cyboflow.ompCommand` tRPC router gates every mutation on
+ * `hasSupervise(ctx.principal)` and refuses to run at all without an audit sink.
+ * But the router is not the only caller: `OmpSessionManager` drives the SAME
+ * privileged surface (`fleet_spawn` / `fleet_send` / `fleet_kill`) directly from
+ * the panel dispatch seams. Handing that manager a bare
+ * `OmpBridgeCommandAdapter` put the product's actual path OUTSIDE the
+ * authorization model — a user with the bridge configured but the supervise
+ * capability withheld could spawn and kill real remote workers with no check
+ * and no audit trail, while the tRPC surface for the same verbs answered
+ * FORBIDDEN.
+ *
+ * Wrapping instead of re-checking at each call site makes the guarantee
+ * structural: a manager holding this adapter CANNOT reach the bridge
+ * unauthorized, and a future seam that discovers the adapter inherits the gate
+ * rather than having to remember it.
+ *
+ * WHAT IS AUDITED. The six MUTATING verbs (spawn, kill, send, apply, discard,
+ * verifyRun) are capability-checked and audited ATTEMPTED + COMPLETED, matching
+ * the router's contract. The two read-only verbs (read, state) are
+ * capability-checked but NOT audited: they are the poll loop, firing per live
+ * panel every `OMP_DEFAULT_POLL_MS`, and writing two log lines per poll would
+ * bury the mutation trail it exists to preserve. They observe, they never act.
+ *
+ * Standalone-typecheck invariant: no imports from electron, better-sqlite3, or
+ * services/*. This module is pure.
+ */
+import { randomUUID } from 'node:crypto';
+import type {
+  OmpApplyRequest,
+  OmpCommandAdapter,
+  OmpCommandResult,
+  OmpDiscardRequest,
+  OmpKillRequest,
+  OmpPrincipal,
+  OmpReadRequest,
+  OmpSendRequest,
+  OmpSpawnRequest,
+  OmpStateRequest,
+  OmpVerifyRequest,
+} from '../../../../shared/types/ompCommand';
+import { hasSupervise, OMP_SUPERVISE_CAPABILITY } from '../../../../shared/types/ompCommand';
+
+/** Mirrors the router's `OmpAuditEntry` — narrow, string-only, trivially redactable. */
+export interface OmpSupervisedAuditEntry {
+  verb: string;
+  principal: string;
+  outcome: 'attempted' | 'completed';
+  operationId: string;
+  detail: string;
+}
+
+export type OmpSupervisedAuditSink = (entry: OmpSupervisedAuditEntry) => void;
+
+/**
+ * Where the adapter reads its identity from.
+ *
+ * A THUNK is the form production uses, and the distinction is load-bearing: the
+ * supervise capability comes from Aria mode, a setting the user can flip while
+ * the app is running. Capturing an `OmpPrincipal` value at construction freezes
+ * the answer at whatever it was when the owning object was built — which for a
+ * boot-time singleton means "whatever it was at launch", so granting the
+ * capability appeared to do nothing until a restart and revoking it kept
+ * authorizing commands. Resolving per call makes both directions immediate.
+ *
+ * A plain value stays accepted for tests, which want a fixed identity.
+ */
+export type OmpPrincipalSource = OmpPrincipal | (() => OmpPrincipal);
+
+export class OmpSupervisedAdapter implements OmpCommandAdapter {
+  readonly authority = 'supervise' as const;
+
+  constructor(
+    private readonly inner: OmpCommandAdapter,
+    private readonly principalSource: OmpPrincipalSource,
+    private readonly audit: OmpSupervisedAuditSink,
+  ) {}
+
+  spawn(req: OmpSpawnRequest): Promise<OmpCommandResult> {
+    return this.guardMutation('spawn', req.operationId, () => this.inner.spawn(req));
+  }
+  kill(req: OmpKillRequest): Promise<OmpCommandResult> {
+    return this.guardMutation('kill', req.operationId, () => this.inner.kill(req));
+  }
+  send(req: OmpSendRequest): Promise<OmpCommandResult> {
+    return this.guardMutation('send', req.operationId, () => this.inner.send(req));
+  }
+  apply(req: OmpApplyRequest): Promise<OmpCommandResult> {
+    return this.guardMutation('apply', req.operationId, () => this.inner.apply(req));
+  }
+  discard(req: OmpDiscardRequest): Promise<OmpCommandResult> {
+    return this.guardMutation('discard', req.operationId, () => this.inner.discard(req));
+  }
+  verifyRun(req: OmpVerifyRequest): Promise<OmpCommandResult> {
+    return this.guardMutation('verifyRun', req.operationId, () => this.inner.verifyRun(req));
+  }
+
+  read(req: OmpReadRequest): Promise<OmpCommandResult> {
+    return this.guardRead('read', req.operationId, () => this.inner.read(req));
+  }
+  state(req: OmpStateRequest): Promise<OmpCommandResult> {
+    return this.guardRead('state', req.operationId, () => this.inner.state(req));
+  }
+
+  // ── internals ──────────────────────────────────────────────────────────
+
+  /**
+   * The identity for THIS call. Never cached: see {@link OmpPrincipalSource}.
+   * A throwing provider (config not yet constructed) is the fail-closed answer,
+   * not a crash — an empty capability set forbids everything.
+   */
+  private principal(): OmpPrincipal {
+    if (typeof this.principalSource !== 'function') return this.principalSource;
+    try {
+      return this.principalSource();
+    } catch {
+      return { userId: 'unknown', capabilities: new Set<string>() };
+    }
+  }
+
+  private forbidden(operationId: string): OmpCommandResult {
+    return {
+      ok: false,
+      operationId,
+      error: 'forbidden',
+      detail: `missing capability ${OMP_SUPERVISE_CAPABILITY}`,
+    };
+  }
+
+  /**
+   * A privileged verb: audited ATTEMPTED before delegation and COMPLETED after,
+   * including the forbidden and thrown paths. `operationId` correlates all
+   * three, exactly as the router's `runGuarded` does. An adapter that throws is
+   * converted to `unavailable` rather than propagating, so a caller can never
+   * observe a mutation whose completion went unrecorded.
+   */
+  private async guardMutation(
+    verb: string,
+    operationId: string,
+    invoke: () => Promise<OmpCommandResult>,
+  ): Promise<OmpCommandResult> {
+    const id = operationId || randomUUID();
+    const identity = this.principal();
+    const principal = identity.userId;
+    this.audit({ verb, principal, outcome: 'attempted', operationId: id, detail: '' });
+
+    if (!hasSupervise(identity)) {
+      this.audit({ verb, principal, outcome: 'completed', operationId: id, detail: 'forbidden' });
+      return this.forbidden(id);
+    }
+
+    let result: OmpCommandResult;
+    try {
+      result = await invoke();
+    } catch (error) {
+      result = {
+        ok: false,
+        operationId: id,
+        error: 'unavailable',
+        detail: error instanceof Error ? error.message : 'OMP command failed',
+      };
+    }
+    this.audit({
+      verb,
+      principal,
+      outcome: 'completed',
+      operationId: id,
+      detail: result.ok ? 'ok' : result.error,
+    });
+    return result;
+  }
+
+  /** A read-only verb: same capability gate, no audit rows (see the header). */
+  private async guardRead(
+    verb: string,
+    operationId: string,
+    invoke: () => Promise<OmpCommandResult>,
+  ): Promise<OmpCommandResult> {
+    if (!hasSupervise(this.principal())) return this.forbidden(operationId || randomUUID());
+    try {
+      return await invoke();
+    } catch (error) {
+      return {
+        ok: false,
+        operationId,
+        error: 'unavailable',
+        detail: error instanceof Error ? error.message : `OMP ${verb} failed`,
+      };
+    }
+  }
+}

--- a/main/src/orchestrator/omp/registryContract.ts
+++ b/main/src/orchestrator/omp/registryContract.ts
@@ -1,0 +1,276 @@
+/**
+ * Versioned fleet-registry parser — the Cyboflow-side copy of the producer's
+ * `parseRegistrySnapshot` (OMP-fleet-management `extensions/fleet/registry-contract.ts`).
+ *
+ * This module is PURE: it imports only types (erased at compile time) and
+ * performs no I/O. It exists so Cyboflow validates the durable registry with
+ * IDENTICAL semantics to the producer, rather than re-implementing a laxer
+ * check that would silently accept a skewed file.
+ *
+ * The producer explicitly sanctions this copy: "a separate consumer repo can
+ * `import type` the shapes — and copy or alias `parseRegistrySnapshot` verbatim."
+ *
+ * ## Version semantics
+ *
+ * - `SUPPORTED_REGISTRY_VERSION` pins the exact shape this module understands.
+ * - A version bump is REQUIRED on any breaking change: field removal, a field
+ *   type change, or a new required field.
+ * - Additive OPTIONAL fields do NOT bump the version; unknown keys are accepted.
+ * - On an unsupported version, a consumer MUST refuse the file — never
+ *   best-effort a version-skewed registry.
+ */
+
+import type {
+  RegistrySnapshot,
+  WorkerEntry,
+} from "../../../../shared/types/omp";
+
+export const SUPPORTED_REGISTRY_VERSION = 1 as const;
+
+export type RegistryParseResult =
+  | { ok: true; snapshot: RegistrySnapshot }
+  | { ok: false; reason: "unsupported-version"; version: number }
+  | { ok: false; reason: "malformed"; errors: string[] };
+
+// ─── Literal sets (single source for the validator) ────────────────────────
+
+const WORKER_STATUSES: ReadonlySet<string> = new Set([
+  "spawning", "working", "idle", "blocked", "dead", "evicted",
+  "proposal_ready", "killing", "done", "failed",
+]);
+
+const BACKENDS: ReadonlySet<string> = new Set(["subprocess", "shepherd"]);
+
+const INTENTS: ReadonlySet<string> = new Set([
+  "read_only", "mutating", "high_stakes_mutating", "external_side_effect",
+]);
+
+const FAILURE_REPORT_STATES: ReadonlySet<string> = new Set([
+  "pending", "claimed", "acknowledged",
+]);
+
+const FAILURE_TRANSITION_STATUSES: ReadonlySet<string> = new Set(["failed", "dead"]);
+
+const REPO_ACCESS_LEVELS: ReadonlySet<string> = new Set([
+  "none", "read", "overlay_write", "host_write",
+]);
+
+// ─── Validators ────────────────────────────────────────────────────────────
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function fail(errors: string[], path: string, message: string): void {
+  errors.push(`${path}: ${message}`);
+}
+
+function checkString(errors: string[], path: string, value: unknown): void {
+  if (typeof value !== "string") fail(errors, path, "expected string");
+}
+
+function checkNullableString(errors: string[], path: string, value: unknown): void {
+  if (value !== null && typeof value !== "string") fail(errors, path, "expected string or null");
+}
+
+function checkStringArray(errors: string[], path: string, value: unknown): void {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    fail(errors, path, "expected string[]");
+  }
+}
+
+function validateWorkerScope(errors: string[], path: string, value: unknown): void {
+  if (value === undefined) return;
+  if (!isRecord(value)) {
+    fail(errors, path, "expected object");
+    return;
+  }
+  if (value.repo !== undefined) {
+    if (!isRecord(value.repo)) {
+      fail(errors, `${path}.repo`, "expected object");
+    } else {
+      checkString(errors, `${path}.repo.path`, value.repo.path);
+      if (
+        typeof value.repo.access !== "string" ||
+        !REPO_ACCESS_LEVELS.has(value.repo.access)
+      ) {
+        fail(errors, `${path}.repo.access`, "expected a valid repo access level");
+      }
+      if (value.repo.include !== undefined) {
+        checkStringArray(errors, `${path}.repo.include`, value.repo.include);
+      }
+      if (value.repo.exclude !== undefined) {
+        checkStringArray(errors, `${path}.repo.exclude`, value.repo.exclude);
+      }
+    }
+  }
+  const sectionArrayFields = {
+    shell: "commands",
+    network: "domains",
+    secrets: "names",
+  } as const;
+  for (const section of ["shell", "network", "secrets"] as const) {
+    if (value[section] === undefined) continue;
+    if (!isRecord(value[section])) {
+      fail(errors, `${path}.${section}`, "expected object");
+      continue;
+    }
+    if (typeof value[section].allowed !== "boolean") {
+      fail(errors, `${path}.${section}.allowed`, "expected boolean");
+    }
+    const arrayField = sectionArrayFields[section];
+    if (value[section][arrayField] !== undefined) {
+      checkStringArray(errors, `${path}.${section}.${arrayField}`, value[section][arrayField]);
+    }
+  }
+}
+
+function validateFailureReport(errors: string[], path: string, value: unknown): void {
+  if (!isRecord(value)) {
+    fail(errors, path, "expected object");
+    return;
+  }
+  if (
+    typeof value.state !== "string" ||
+    !FAILURE_REPORT_STATES.has(value.state)
+  ) {
+    fail(errors, `${path}.state`, "expected a valid failure report state");
+  }
+  checkString(errors, `${path}.idempotencyKey`, value.idempotencyKey);
+  if (
+    typeof value.transitionStatus !== "string" ||
+    !FAILURE_TRANSITION_STATUSES.has(value.transitionStatus)
+  ) {
+    fail(errors, `${path}.transitionStatus`, 'expected "failed" | "dead"');
+  }
+  checkString(errors, `${path}.output`, value.output);
+  if (value.traceId !== undefined) checkString(errors, `${path}.traceId`, value.traceId);
+  if (value.claimedBy !== undefined) checkString(errors, `${path}.claimedBy`, value.claimedBy);
+  if (value.claimExpiresAt !== undefined && typeof value.claimExpiresAt !== "number") {
+    fail(errors, `${path}.claimExpiresAt`, "expected number");
+  }
+  if (value.acknowledgedAt !== undefined) {
+    checkString(errors, `${path}.acknowledgedAt`, value.acknowledgedAt);
+  }
+}
+
+function validateWorker(errors: string[], path: string, value: unknown): void {
+  if (!isRecord(value)) {
+    fail(errors, path, "expected object");
+    return;
+  }
+
+  // Required fields.
+  checkString(errors, `${path}.id`, value.id);
+  checkNullableString(errors, `${path}.paneId`, value.paneId);
+  checkNullableString(errors, `${path}.workspaceId`, value.workspaceId);
+  if (typeof value.backend !== "string" || !BACKENDS.has(value.backend)) {
+    fail(errors, `${path}.backend`, 'expected "subprocess" | "shepherd"');
+  }
+  checkString(errors, `${path}.model`, value.model);
+  checkString(errors, `${path}.task`, value.task);
+  checkNullableString(errors, `${path}.label`, value.label);
+  if (typeof value.status !== "string" || !WORKER_STATUSES.has(value.status)) {
+    fail(errors, `${path}.status`, "expected a valid worker status");
+  }
+  checkString(errors, `${path}.spawnedAt`, value.spawnedAt);
+  checkString(errors, `${path}.lastSeenAt`, value.lastSeenAt);
+  checkNullableString(errors, `${path}.leaseExpiresAt`, value.leaseExpiresAt);
+  checkNullableString(errors, `${path}.lastOutput`, value.lastOutput);
+
+  // Optional fields (checked only when present — absent is always valid).
+  if (value.sandboxId !== undefined) checkString(errors, `${path}.sandboxId`, value.sandboxId);
+  if (value.runId !== undefined) checkString(errors, `${path}.runId`, value.runId);
+  if (value.traceId !== undefined) checkString(errors, `${path}.traceId`, value.traceId);
+  if (value.proposalId !== undefined) checkString(errors, `${path}.proposalId`, value.proposalId);
+  if (value.baseRevision !== undefined) checkString(errors, `${path}.baseRevision`, value.baseRevision);
+  if (value.repoPath !== undefined) checkString(errors, `${path}.repoPath`, value.repoPath);
+  if (value.allowedPaths !== undefined) checkStringArray(errors, `${path}.allowedPaths`, value.allowedPaths);
+  if (value.proposalAuthorityFrozen !== undefined && typeof value.proposalAuthorityFrozen !== "boolean") {
+    fail(errors, `${path}.proposalAuthorityFrozen`, "expected boolean");
+  }
+  if (value.intent !== undefined) {
+    if (typeof value.intent !== "string" || !INTENTS.has(value.intent)) {
+      fail(errors, `${path}.intent`, "expected a valid execution intent");
+    }
+  }
+  if (value.scope !== undefined) validateWorkerScope(errors, `${path}.scope`, value.scope);
+  if (value.cwd !== undefined) checkString(errors, `${path}.cwd`, value.cwd);
+  if (value.ownerProcessId !== undefined) checkString(errors, `${path}.ownerProcessId`, value.ownerProcessId);
+  if (value.ownerPid !== undefined && typeof value.ownerPid !== "number") {
+    fail(errors, `${path}.ownerPid`, "expected number");
+  }
+  if (value.ownerHeartbeatAt !== undefined && typeof value.ownerHeartbeatAt !== "number") {
+    fail(errors, `${path}.ownerHeartbeatAt`, "expected number");
+  }
+  if (value.timeout !== undefined && typeof value.timeout !== "number") {
+    fail(errors, `${path}.timeout`, "expected number");
+  }
+  if (value.queued !== undefined && typeof value.queued !== "boolean") {
+    fail(errors, `${path}.queued`, "expected boolean");
+  }
+  if (value.failureReportSequence !== undefined && typeof value.failureReportSequence !== "number") {
+    fail(errors, `${path}.failureReportSequence`, "expected number");
+  }
+  if (value.failureReport !== undefined) {
+    validateFailureReport(errors, `${path}.failureReport`, value.failureReport);
+  }
+  if (value.failureReports !== undefined) {
+    if (!Array.isArray(value.failureReports)) {
+      fail(errors, `${path}.failureReports`, "expected array");
+    } else {
+      value.failureReports.forEach((report, index) => {
+        validateFailureReport(errors, `${path}.failureReports[${index}]`, report);
+      });
+    }
+  }
+}
+
+/**
+ * Parse and strictly validate an already-JSON-parsed registry payload.
+ *
+ * Pure: takes `unknown`, performs no I/O, and never throws.
+ *
+ * - `version !== SUPPORTED_REGISTRY_VERSION` → `unsupported-version` (checked
+ *   before shape validation: a future version may legitimately not match the
+ *   v1 shape).
+ * - Any structural violation (top-level or per-worker) → `malformed`, with
+ *   `path.field`-style error strings.
+ * - Unknown keys are accepted (forward-compatible additive fields).
+ */
+export function parseRegistrySnapshot(data: unknown): RegistryParseResult {
+  if (!isRecord(data)) {
+    return { ok: false, reason: "malformed", errors: ["root: expected object"] };
+  }
+
+  if (typeof data.version !== "number") {
+    return { ok: false, reason: "malformed", errors: ["version: expected number"] };
+  }
+  if (data.version !== SUPPORTED_REGISTRY_VERSION) {
+    return { ok: false, reason: "unsupported-version", version: data.version };
+  }
+  if (typeof data.savedAt !== "string") {
+    return { ok: false, reason: "malformed", errors: ["savedAt: expected string"] };
+  }
+  if (!Array.isArray(data.workers)) {
+    return { ok: false, reason: "malformed", errors: ["workers: expected array"] };
+  }
+
+  const errors: string[] = [];
+  data.workers.forEach((worker, index) => {
+    validateWorker(errors, `workers[${index}]`, worker);
+  });
+
+  if (errors.length > 0) {
+    return { ok: false, reason: "malformed", errors };
+  }
+
+  return {
+    ok: true,
+    snapshot: {
+      workers: data.workers as WorkerEntry[],
+      version: SUPPORTED_REGISTRY_VERSION,
+      savedAt: data.savedAt,
+    },
+  };
+}

--- a/main/src/orchestrator/trpc/__tests__/contextPrincipal.test.ts
+++ b/main/src/orchestrator/trpc/__tests__/contextPrincipal.test.ts
@@ -1,0 +1,55 @@
+/**
+ * createContext principal resolution — the regression behind the "Aria mode
+ * takes effect without a relaunch" claim.
+ *
+ * The wiring passes a RESOLVER (currentOmpPrincipal), because the supervise
+ * capability comes from Aria mode, a runtime setting. createContext must call
+ * that resolver ONCE PER REQUEST: a value frozen at window-attach left
+ * availability.launchable and the ompCommand gate stale until relaunch — the
+ * exact defect class this suite pins shut.
+ */
+import { describe, expect, it } from 'vitest';
+import type { OmpPrincipal } from '../../../../../shared/types/ompCommand';
+import { OMP_SUPERVISE_CAPABILITY } from '../../../../../shared/types/ompCommand';
+import { createContext } from '../context';
+
+const privileged: OmpPrincipal = {
+  userId: 'local',
+  capabilities: new Set([OMP_SUPERVISE_CAPABILITY]),
+};
+const unprivileged: OmpPrincipal = { userId: 'local', capabilities: new Set<string>() };
+
+describe('createContext principal', () => {
+  it('passes a plain value through untouched (test convenience shape)', () => {
+    const ctx = createContext({ principal: unprivileged });
+    expect(ctx.principal).toBe(unprivileged);
+  });
+
+  it('resolves a thunk at creation time and reflects later mutations on the NEXT call', () => {
+    let supervise = false;
+    const resolve = (): OmpPrincipal =>
+      supervise ? privileged : unprivileged;
+
+    // Request 1: capability withheld.
+    expect(
+      createContext({ principal: resolve }).principal?.capabilities.has(OMP_SUPERVISE_CAPABILITY),
+    ).toBe(false);
+
+    // The setting flips between requests — no rebuild, no relaunch.
+    supervise = true;
+
+    // Request 2: same resolver, live answer.
+    expect(
+      createContext({ principal: resolve }).principal?.capabilities.has(OMP_SUPERVISE_CAPABILITY),
+    ).toBe(true);
+
+    // And back: revoking forbids the very next request.
+    supervise = false;
+    expect(createContext({ principal: resolve }).principal).toEqual(unprivileged);
+  });
+
+  it('omits principal entirely when the deps omit it (fail-closed default)', () => {
+    const ctx = createContext({});
+    expect(ctx.principal).toBeUndefined();
+  });
+});

--- a/main/src/orchestrator/trpc/context.ts
+++ b/main/src/orchestrator/trpc/context.ts
@@ -14,6 +14,8 @@ import type { NativeGrantProbe, VerificationModality } from '../../../../shared/
 import type { VerifyRunbookStatusDetail } from '../verify/runbookStore';
 import type { PermissionMode, WorkflowRow, WorkflowDefinition } from '../../../../shared/types/workflows';
 import type { CliSubstrate } from '../../../../shared/types/substrate';
+import type { OmpControlPlaneAdapter } from '../../../../shared/types/omp';
+import type { OmpCommandAdapter, OmpPrincipal } from '../../../../shared/types/ompCommand';
 import type { SprintMaxTasksOverrides } from '../../../../shared/types/sprintBatch';
 import type { RunGitDiff } from '../../../../shared/types/runFiles';
 import type { WorkflowDescriptor } from '../workflowRegistry';
@@ -376,6 +378,28 @@ export interface ContextDeps {
    * reporting a host with nothing installed, which would be a lie).
    */
   verifyHostProbes?: VerifyHostProbesLike;
+  /** Read-only OMP fleet adapter (getFleetSnapshot). Absent => fleetSnapshot returns 'unavailable'. */
+  omp?: OmpControlPlaneAdapter;
+  /**
+   * The OMP command principal — a VALUE or a RESOLVER. Production passes the
+   * resolver (`currentOmpPrincipal`): the supervise capability comes from Aria
+   * mode, a setting flipped at runtime, and createContext resolves this per
+   * request so granting/revoking takes effect on the next call with no relaunch.
+   * A plain value stays accepted for tests that want a fixed identity.
+   */
+  principal?: OmpPrincipal | (() => OmpPrincipal);
+  /** Privileged command adapter. Absent => every ompCommand mutation returns 'unavailable'. */
+  ompCommand?: OmpCommandAdapter;
+  /** Redacted audit sink for OMP commands (attempted + completed). Injected as a closure like setDockBadge. */
+  auditOmp?: (entry: { verb: string; principal: string; outcome: 'attempted' | 'completed'; operationId: string; detail: string }) => void;
+  /**
+   * Whether the boot-built fleet session manager EXISTS. A closure rather than a
+   * boolean so the router reads the live wiring (like `getForcedSubstrate`), and
+   * so the standalone router keeps no services/* import. Absent ⇒ not launchable.
+   */
+  ompFleetLaunchable?: () => boolean;
+  /** Aria mode — remote fleet vs local OMP runtimes (see AppConfig.ariaMode). Absent ⇒ false. */
+  ompAriaMode?: () => boolean;
 
   /**
    * Resolve a (project, modality) runbook's status the way the ENGINE resolves
@@ -449,6 +473,13 @@ export function createContext(deps: ContextDeps = {}): {
   agentThreadStore?: AgentThreadStoreLike;
   agentProposalExecutor?: AgentProposalExecutorLike;
   verifyHostProbes?: VerifyHostProbesLike;
+  omp?: OmpControlPlaneAdapter;
+  /** Resolved per request from the deps value-or-resolver — never a boot-time snapshot. */
+  principal?: OmpPrincipal;
+  ompCommand?: OmpCommandAdapter;
+  auditOmp?: (entry: { verb: string; principal: string; outcome: 'attempted' | 'completed'; operationId: string; detail: string }) => void;
+  ompFleetLaunchable?: () => boolean;
+  ompAriaMode?: () => boolean;
   verifyRunbookStatus?: VerifyRunbookStatusLike;
 } {
   const {
@@ -463,8 +494,20 @@ export function createContext(deps: ContextDeps = {}): {
     agentThreadStore,
     agentProposalExecutor,
     verifyHostProbes,
+    omp,
+    principal,
+    ompCommand,
+    auditOmp,
+    ompFleetLaunchable,
+    ompAriaMode,
     verifyRunbookStatus,
   } = deps;
+  // Resolve the principal NOW, once per request. Accepting a resolver here is
+  // what makes an Aria-mode flip take effect on the next call in either
+  // direction: a frozen value captured at window-attach would leave
+  // `availability.launchable` and the ompCommand gate stale until relaunch.
+  const resolvedPrincipal =
+    typeof principal === 'function' ? principal() : principal;
   return {
     userId: 'local' as const,
     setDockBadge,
@@ -478,6 +521,12 @@ export function createContext(deps: ContextDeps = {}): {
     agentThreadStore,
     agentProposalExecutor,
     verifyHostProbes,
+    omp,
+    principal: resolvedPrincipal,
+    ompCommand,
+    auditOmp,
+    ompFleetLaunchable,
+    ompAriaMode,
     verifyRunbookStatus,
   };
 }

--- a/main/src/orchestrator/trpc/router.ts
+++ b/main/src/orchestrator/trpc/router.ts
@@ -32,6 +32,8 @@ import { pluginsRouter } from './routers/plugins';
 import { variantsRouter } from './routers/variants';
 import { experimentsRouter } from './routers/experiments';
 import { verificationRequestsRouter } from './routers/verificationRequests';
+import { ompRouter } from './routers/omp';
+import { ompCommandRouter } from './routers/ompCommand';
 
 export const appRouter = router({
   cyboflow: router({
@@ -61,6 +63,8 @@ export const appRouter = router({
     variants: variantsRouter,
     verificationRequests: verificationRequestsRouter,
     workflows: workflowsRouter,
+    omp: ompRouter,
+    ompCommand: ompCommandRouter,
   }),
 });
 

--- a/main/src/orchestrator/trpc/routers/__tests__/omp.test.ts
+++ b/main/src/orchestrator/trpc/routers/__tests__/omp.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for cyboflow.omp.fleetSnapshot — the redacted read surface.
+ *
+ * Verifies the DTO boundary: a full snapshot carrying sentinel secrets in
+ * task/lastOutput/repoPath/allowedPaths/failure output is projected down to
+ * summary fields only before crossing the tRPC reply. Typecheck alone cannot
+ * prove redaction; this test asserts the sentinels are absent and the summary
+ * fields are present.
+ */
+import { describe, it, expect } from 'vitest';
+import { appRouter } from '../../router';
+import { createContext } from '../../context';
+import type { OmpControlPlaneAdapter, RegistrySnapshot, WorkerEntry } from '../../../../../../shared/types/omp';
+import { OMP_SUPERVISE_CAPABILITY } from '../../../../../../shared/types/ompCommand';
+
+const SENTINEL = 'SENTINEL_SECRET_DO_NOT_CROSS_IPC';
+
+function fullWorker(): WorkerEntry {
+  return {
+    id: 'wkr-1',
+    paneId: 'p1',
+    workspaceId: 'ws-1',
+    backend: 'subprocess',
+    model: 'zai/glm-5.2:high',
+    task: `deploy ${SENTINEL}`,
+    label: 'a-label',
+    status: 'working',
+    spawnedAt: '2026-08-13T00:00:00.000Z',
+    lastSeenAt: '2026-08-13T00:01:00.000Z',
+    leaseExpiresAt: '2026-08-13T00:10:00.000Z',
+    lastOutput: `stdout: ${SENTINEL}`,
+    repoPath: `/repos/${SENTINEL}`,
+    allowedPaths: [`/src/${SENTINEL}.ts`],
+    failureReport: {
+      state: 'pending',
+      idempotencyKey: 'k',
+      transitionStatus: 'failed',
+      output: `failure ${SENTINEL}`,
+    },
+  };
+}
+
+const adapter: OmpControlPlaneAdapter = {
+  version: 1,
+  authority: 'read',
+  async getFleetSnapshot() {
+    const snapshot: RegistrySnapshot = {
+      version: 1,
+      savedAt: '2026-08-13T00:02:00.000Z',
+      workers: [fullWorker()],
+    };
+    return { ok: true, snapshot };
+  },
+};
+
+describe('cyboflow.omp.fleetSnapshot redaction', () => {
+  it('projects a full snapshot down to summary fields only (no secrets cross the boundary)', async () => {
+    const caller = appRouter.createCaller(createContext({ omp: adapter }));
+    const res = await caller.cyboflow.omp.fleetSnapshot();
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('expected ok');
+
+    const wire = JSON.stringify(res);
+
+    // Summary fields present.
+    expect(res.snapshot.totalWorkers).toBe(1);
+    expect(res.snapshot.workers[0]).toEqual({
+      id: 'wkr-1',
+      label: 'a-label',
+      model: 'zai/glm-5.2:high',
+      status: 'working',
+      backend: 'subprocess',
+      spawnedAt: '2026-08-13T00:00:00.000Z',
+      lastSeenAt: '2026-08-13T00:01:00.000Z',
+    });
+
+    // Secret-bearing fields absent from the wire.
+    expect(wire).not.toContain(SENTINEL);
+    expect(wire).not.toContain('task');
+    expect(wire).not.toContain('lastOutput');
+    expect(wire).not.toContain('repoPath');
+    expect(wire).not.toContain('allowedPaths');
+    expect(wire).not.toContain('failureReport');
+    expect(wire).not.toContain('paneId');
+  });
+
+  it('surfaces unavailable when no adapter is configured', async () => {
+    const caller = appRouter.createCaller(createContext({}));
+    const res = await caller.cyboflow.omp.fleetSnapshot();
+    expect(res).toMatchObject({ ok: false, error: 'unavailable' });
+  });
+});
+
+/**
+ * cyboflow.omp.availability — what the picker may offer.
+ *
+ * Two independent axes, and the router must not collapse them: `launchable`
+ * asks whether a remote worker can be spawned RIGHT NOW (boot-built manager +
+ * supervise capability), `ariaMode` says which OMP flavor this install runs.
+ * A toggle flipped without a relaunch is exactly the state where they disagree.
+ */
+describe('cyboflow.omp.availability', () => {
+  const supervising = {
+    userId: 'local',
+    capabilities: new Set([OMP_SUPERVISE_CAPABILITY]),
+  };
+  const unprivileged = { userId: 'local', capabilities: new Set<string>() };
+
+  async function query(deps: Parameters<typeof createContext>[0]) {
+    return appRouter.createCaller(createContext(deps)).cyboflow.omp.availability();
+  }
+
+  it('reports launchable only when the manager exists AND the principal supervises', async () => {
+    expect(
+      await query({ principal: supervising, ompFleetLaunchable: () => true, ompAriaMode: () => true }),
+    ).toEqual({ launchable: true, ariaMode: true });
+
+    // Manager absent (Aria mode on, but the app has not relaunched yet).
+    expect(
+      await query({ principal: supervising, ompFleetLaunchable: () => false, ompAriaMode: () => true }),
+    ).toEqual({ launchable: false, ariaMode: true });
+
+    // Capability revoked while a manager from an earlier boot still exists.
+    expect(
+      await query({ principal: unprivileged, ompFleetLaunchable: () => true, ompAriaMode: () => true }),
+    ).toEqual({ launchable: false, ariaMode: true });
+  });
+
+  it('reports ariaMode independently of launchability', async () => {
+    // A local-OMP install: not a fleet, and that is not a failure.
+    expect(
+      await query({ principal: unprivileged, ompFleetLaunchable: () => false, ompAriaMode: () => false }),
+    ).toEqual({ launchable: false, ariaMode: false });
+  });
+
+  it('floors both to false when nothing is wired (fail closed)', async () => {
+    expect(await query({})).toEqual({ launchable: false, ariaMode: false });
+  });
+});

--- a/main/src/orchestrator/trpc/routers/__tests__/ompCommand.e2e.test.ts
+++ b/main/src/orchestrator/trpc/routers/__tests__/ompCommand.e2e.test.ts
@@ -1,0 +1,69 @@
+/**
+ * End-to-end integration test for the privileged OMP command path.
+ *
+ * Drives the REAL tRPC router (`cyboflow.ompCommand.spawn`) with a supervise
+ * principal, the REAL `OmpBridgeCommandAdapter`, and a FAKE bridge client, to
+ * prove the whole chain — authorize → audit → map → invoke → correlate — works
+ * as one path, not as isolated units.
+ *
+ * The fake client asserts the exact producer wire call, so this also pins the
+ * mapping contract at the integration boundary.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { appRouter } from '../../router';
+import { createContext } from '../../context';
+import type { OmpAuditEntry } from '../ompCommand';
+import { OmpBridgeCommandAdapter } from '../../../omp/ompBridgeCommandAdapter';
+import type { OmpBridgeCallResult, OmpBridgeClientLike, OmpBridgeToolCall } from '../../../omp/ompBridgeClient';
+import { OMP_SUPERVISE_CAPABILITY, type OmpPrincipal } from '../../../../../../shared/types/ompCommand';
+
+const SUPERVISE: OmpPrincipal = {
+  userId: 'local',
+  capabilities: new Set([OMP_SUPERVISE_CAPABILITY]),
+};
+
+describe('cyboflow.ompCommand end-to-end (real router + real adapter + fake bridge)', () => {
+  it('spawn reaches the bridge with the mapped producer call and returns the result', async () => {
+    const calls: OmpBridgeToolCall[] = [];
+    const client: OmpBridgeClientLike = {
+      callTool: vi.fn(async (call: OmpBridgeToolCall): Promise<OmpBridgeCallResult> => {
+        calls.push(call);
+        return { ok: true, text: 'spawned wkr-1' };
+      }),
+    };
+    const adapter = new OmpBridgeCommandAdapter(client);
+    const audit: OmpAuditEntry[] = [];
+    const caller = appRouter.createCaller(
+      createContext({ principal: SUPERVISE, ompCommand: adapter, auditOmp: (e) => audit.push(e) }),
+    );
+
+    const result = await caller.cyboflow.ompCommand.spawn({
+      model: 'zai/glm-5.2:high',
+      task: 'edit files',
+      executionMode: 'shepherd',
+      intent: 'mutating',
+      scope: { repo: { path: '/repos/x', access: 'overlay_write' } },
+      idempotencyKey: 'op-e2e-1',
+    });
+
+    expect(result).toMatchObject({ ok: true, operationId: 'op-e2e-1', detail: 'spawned wkr-1' });
+
+    // The exact producer wire call, with snake_case + seconds timeout omitted when absent.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      name: 'fleet_spawn',
+      arguments: {
+        model: 'zai/glm-5.2:high',
+        task: 'edit files',
+        execution_mode: 'shepherd',
+        intent: 'mutating',
+        scope: { repo: { path: '/repos/x', access: 'overlay_write' } },
+      },
+    });
+
+    // Both audit rows correlate on the client-supplied token.
+    expect(audit).toHaveLength(2);
+    expect(audit[0]).toMatchObject({ verb: 'spawn', outcome: 'attempted', operationId: 'op-e2e-1' });
+    expect(audit[1]).toMatchObject({ verb: 'spawn', outcome: 'completed', operationId: 'op-e2e-1', detail: 'ok' });
+  });
+});

--- a/main/src/orchestrator/trpc/routers/__tests__/ompCommand.test.ts
+++ b/main/src/orchestrator/trpc/routers/__tests__/ompCommand.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for cyboflow.ompCommand — the privileged OMP command router.
+ *
+ * Verifies the authority boundary, the fail-closed audit trail, the
+ * operationId correlation, and the actual stub behavior:
+ *   1. A principal without `omp:supervise` is rejected FORBIDDEN AND the
+ *      attempt is still audited (attempted + forbidden completed).
+ *   2. A supervised principal with the REAL stub returns `unavailable` with an
+ *      operationId that matches the audit rows (correlation).
+ *   3. A missing audit sink is refused with `unavailable` before anything runs.
+ *   4. Input is genuinely redacted: field keys survive, field VALUES do not.
+ */
+import { describe, it, expect } from 'vitest';
+import { appRouter } from '../../router';
+import { createContext } from '../../context';
+import { OmpCommandStub } from '../../../omp/ompCommandStub';
+import type { OmpAuditEntry } from '../ompCommand';
+import type { OmpPrincipal } from '../../../../../../shared/types/ompCommand';
+
+const SUPERVISE: OmpPrincipal = {
+  userId: 'local',
+  capabilities: new Set(['omp:supervise']),
+};
+
+const NO_SUPERVISE: OmpPrincipal = {
+  userId: 'local',
+  capabilities: new Set([]),
+};
+
+function callerWith(deps: Parameters<typeof createContext>[0]): ReturnType<typeof appRouter.createCaller> {
+  return appRouter.createCaller(createContext(deps));
+}
+
+describe('cyboflow.ompCommand authorization', () => {
+  it('rejects a non-supervise principal FORBIDDEN and still audits the attempt', async () => {
+    const audit: OmpAuditEntry[] = [];
+    const caller = callerWith({ principal: NO_SUPERVISE, auditOmp: (e) => audit.push(e) });
+
+    await expect(
+      caller.cyboflow.ompCommand.spawn({ model: 'm', task: 'secret task text' }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+    expect(audit).toHaveLength(2);
+    expect(audit[0]).toMatchObject({ verb: 'spawn', outcome: 'attempted' });
+    expect(audit[1]).toMatchObject({ verb: 'spawn', outcome: 'completed', detail: 'forbidden' });
+    // Both rows share one operationId.
+    expect(audit[0].operationId).toBe(audit[1].operationId);
+  });
+
+  it('redacts input values: keys survive, secret values do not', async () => {
+    const audit: OmpAuditEntry[] = [];
+    const caller = callerWith({ principal: SUPERVISE, ompCommand: new OmpCommandStub(), auditOmp: (e) => audit.push(e) });
+
+    await caller.cyboflow.ompCommand.spawn({ model: 'm', task: 'SECRET_DO_NOT_LEAK', scope: { repo: { path: '/SECRET/PATH', access: 'read' } } });
+
+    const attempted = audit.find((e) => e.outcome === 'attempted');
+    expect(attempted).toBeDefined();
+    expect(attempted!.detail).toContain('model');
+    expect(attempted!.detail).toContain('task');
+    expect(attempted!.detail).toContain('scope');
+    // Values are redacted: no raw task text, no raw repo path.
+    expect(JSON.stringify(audit)).not.toContain('SECRET_DO_NOT_LEAK');
+    expect(JSON.stringify(audit)).not.toContain('/SECRET/PATH');
+  });
+
+  it('the real stub returns unavailable with a correlated operationId', async () => {
+    const audit: OmpAuditEntry[] = [];
+    const caller = callerWith({ principal: SUPERVISE, ompCommand: new OmpCommandStub(), auditOmp: (e) => audit.push(e) });
+
+    const res = await caller.cyboflow.ompCommand.spawn({ model: 'm', task: 't', idempotencyKey: 'op-123' });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error).toBe('unavailable');
+      // The client-supplied idempotency key became the correlation token.
+      expect(res.operationId).toBe('op-123');
+    }
+    // Both audit rows carry the same token as the result.
+    expect(audit).toHaveLength(2);
+    expect(audit[0].operationId).toBe('op-123');
+    expect(audit[1].operationId).toBe('op-123');
+  });
+
+  it('refuses outright when no audit sink is configured', async () => {
+    const caller = callerWith({ principal: SUPERVISE, ompCommand: new OmpCommandStub() });
+    const res = await caller.cyboflow.ompCommand.spawn({ model: 'm', task: 't' });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe('unavailable');
+  });
+
+  it('rejects an idempotencyKey with newline/control characters (log-injection guard)', async () => {
+    const caller = callerWith({ principal: SUPERVISE, ompCommand: new OmpCommandStub(), auditOmp: () => {} });
+    await expect(
+      caller.cyboflow.ompCommand.spawn({ model: 'm', task: 't', idempotencyKey: 'forged\nop=evil' }),
+    ).rejects.toBeDefined();
+  });
+});

--- a/main/src/orchestrator/trpc/routers/omp.ts
+++ b/main/src/orchestrator/trpc/routers/omp.ts
@@ -1,0 +1,89 @@
+/**
+ * cyboflow.omp sub-router — read-only OMP fleet awareness.
+ *
+ * Exposes a REDACTED fleet summary from the injected OmpControlPlaneAdapter.
+ * The adapter's full snapshot carries task text, lastOutput, repoPath,
+ * allowedPaths, and failure-report output — none of which may cross into the
+ * renderer. This router maps it to the renderer-safe view DTO BEFORE the tRPC
+ * reply, so sensitive fields never leave main.
+ *
+ * Read-only by construction: no mutation surface lives here (commands are a
+ * separate, privileged router).
+ *
+ * Standalone-typecheck invariant: no imports from 'electron', 'better-sqlite3',
+ * or main/src/services/*.
+ */
+import { router, protectedProcedure } from '../trpc';
+import type {
+  OmpFleetViewResult,
+  OmpFleetViewSnapshot,
+  OmpSnapshotResult,
+} from '../../../../../shared/types/omp';
+import { hasSupervise } from '../../../../../shared/types/ompCommand';
+
+/** Map a full snapshot to the renderer-safe view projection. */
+function toViewSnapshot(result: OmpSnapshotResult): OmpFleetViewResult {
+  if (!result.ok) {
+    return result;
+  }
+  const s = result.snapshot;
+  const view: OmpFleetViewSnapshot = {
+    version: s.version,
+    savedAt: s.savedAt,
+    totalWorkers: s.workers.length,
+    workers: s.workers.map((w) => ({
+      id: w.id,
+      label: w.label,
+      model: w.model,
+      status: w.status,
+      backend: w.backend,
+      spawnedAt: w.spawnedAt,
+      lastSeenAt: w.lastSeenAt,
+    })),
+  };
+  return { ok: true, snapshot: view };
+}
+
+export const ompRouter = router({
+  /**
+   * What the OMP picker may offer.
+   *
+   * `launchable` asks the boot-built fleet manager whether it EXISTS, rather
+   * than re-deriving "bridge config resolved" here. The manager owns long-lived
+   * remote workers, so it is constructed once at boot; re-deriving would let the
+   * picker offer OMP fleet the instant Aria mode is toggled, while dispatch
+   * still answered "the bridge is not configured" until the next launch. Asking
+   * the manager keeps the picker and the dispatch seam telling the same story.
+   *
+   * `ariaMode` says WHICH OMP flavor this install runs — the renderer shows the
+   * local runtimes (`omp-sdk`/`omp-pty`) or the fleet supervisor, never both.
+   * Reported live from config, so the picker reflects a toggle immediately even
+   * though `launchable` waits for the relaunch.
+   *
+   * Both are read-only probes. The renderer ANDs them with the `omp` provider
+   * toggle; none of it is enforcement — the main side fails closed regardless.
+   */
+  availability: protectedProcedure.query(({ ctx }) => ({
+    launchable: ctx.ompFleetLaunchable?.() === true && hasSupervise(ctx.principal),
+    ariaMode: ctx.ompAriaMode?.() === true,
+  })),
+  /**
+   * The latest fleet summary (redacted), or a discriminated failure.
+   * An absent registry surfaces as `{ ok: false, error: 'missing' }`; an
+   * unreadable (permission-denied/IO) registry as `'unavailable'`; a parse or
+   * version failure as `'malformed'` / `'unsupported-version'`. Never a thrown
+   * error or an empty-success.
+   */
+  fleetSnapshot: protectedProcedure.query(async ({ ctx }): Promise<OmpFleetViewResult> => {
+    const omp = ctx.omp;
+    if (!omp) {
+      return {
+        ok: false,
+        error: 'unavailable',
+        detail: 'OMP adapter not configured',
+      };
+    }
+    const result = await omp.getFleetSnapshot();
+    return toViewSnapshot(result);
+  }),
+});

--- a/main/src/orchestrator/trpc/routers/ompCommand.ts
+++ b/main/src/orchestrator/trpc/routers/ompCommand.ts
@@ -1,0 +1,206 @@
+/**
+ * cyboflow.ompCommand sub-router — the privileged OMP command surface.
+ *
+ * Every mutation is gated on `hasSupervise(ctx.principal)` (an immutable
+ * capability, NOT merely `ctx.userId === 'local'`) and is audited twice —
+ * ATTEMPTED before delegation, COMPLETED after — with input/result redacted.
+ *
+ * Audit is FAIL-CLOSED: every attempt with an audit sink present records a
+ * terminal outcome, including `forbidden` and thrown adapter failures. A
+ * missing audit sink is refused (a privileged mutation without an audit trail
+ * is never allowed). A single operationId is minted per request, threaded into
+ * the adapter request, echoed in the result, and recorded in both audit rows —
+ * so audit trail, adapter result, and idempotency key all correlate.
+ *
+ * In Phase 2 the injected `OmpCommandAdapter` is a stub that fails closed with
+ * `unavailable`, so no real command can run even though the router, its
+ * authorization, and its audit trail are all live and tested.
+ *
+ * Standalone-typecheck invariant: no imports from 'electron', 'better-sqlite3',
+ * or main/src/services/*.
+ */
+import { randomUUID } from 'node:crypto';
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+import { router, protectedProcedure } from '../trpc';
+import { hasSupervise, OMP_SUPERVISE_CAPABILITY } from '../../../../../shared/types/ompCommand';
+import type {
+  OmpApplyRequest,
+  OmpCommandAdapter,
+  OmpCommandResult,
+  OmpDiscardRequest,
+  OmpKillRequest,
+  OmpPrincipal,
+  OmpSpawnRequest,
+  OmpVerifyRequest,
+} from '../../../../../shared/types/ompCommand';
+
+/** Audit entry shape — narrow and string-only, trivially redactable and serializable. */
+export interface OmpAuditEntry {
+  verb: string;
+  principal: string;
+  outcome: 'attempted' | 'completed';
+  operationId: string;
+  /** Redacted detail: never raw task text, scope paths, or proof blobs. */
+  detail: string;
+}
+
+type OmpAuditSink = (entry: OmpAuditEntry) => void;
+
+/** Redact command input to a stable, non-sensitive summary (field keys only). */
+function redactInput(input: unknown): string {
+  if (input === null || input === undefined) return '';
+  if (typeof input === 'object') {
+    return Object.keys(input as Record<string, unknown>).join(',');
+  }
+  return String(input);
+}
+
+interface OmpCommandCtx {
+  principal?: OmpPrincipal;
+  ompCommand?: OmpCommandAdapter;
+  auditOmp?: OmpAuditSink;
+}
+
+const scopeSchema = z
+  .object({
+    repo: z
+      .object({
+        path: z.string(),
+        access: z.enum(['none', 'read', 'overlay_write', 'host_write']),
+        include: z.array(z.string()).optional(),
+        exclude: z.array(z.string()).optional(),
+      })
+      .optional(),
+    shell: z.object({ allowed: z.boolean(), commands: z.array(z.string()).optional() }).optional(),
+    network: z.object({ allowed: z.boolean(), domains: z.array(z.string()).optional() }).optional(),
+    secrets: z.object({ allowed: z.boolean(), names: z.array(z.string()).optional() }).optional(),
+  })
+  .optional();
+
+/**
+ * Authorize, audit, and dispatch one command. Mints a single operationId,
+ * threads it into the request, records both audit rows with it, and returns the
+ * adapter result (which must echo it). An unauthorized attempt with an audit
+ * sink still records attempted + forbidden completed before failing closed.
+ */
+async function runGuarded<TInput extends { idempotencyKey?: string }, TReq>(
+  ctx: OmpCommandCtx,
+  verb: string,
+  input: TInput,
+  buildReq: (input: TInput, operationId: string) => TReq,
+  invoke: (adapter: OmpCommandAdapter, req: TReq) => Promise<OmpCommandResult>,
+): Promise<OmpCommandResult> {
+  // A privileged mutation without an audit trail is refused, not allowed.
+  if (!ctx.auditOmp) {
+    return {
+      ok: false,
+      operationId: 'n/a',
+      error: 'unavailable',
+      detail: 'OMP audit sink not configured',
+    };
+  }
+
+  // One correlation token: the client-supplied idempotency key, else minted.
+  const operationId = input.idempotencyKey ?? randomUUID();
+  const principal = ctx.principal?.userId ?? 'unknown';
+  ctx.auditOmp({ verb, principal, outcome: 'attempted', operationId, detail: redactInput(input) });
+
+  if (!hasSupervise(ctx.principal)) {
+    ctx.auditOmp({ verb, principal, outcome: 'completed', operationId, detail: 'forbidden' });
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: `missing capability ${OMP_SUPERVISE_CAPABILITY}`,
+    });
+  }
+
+  let result: OmpCommandResult;
+  if (!ctx.ompCommand) {
+    result = {
+      ok: false,
+      operationId,
+      error: 'unavailable',
+      detail: 'OMP command adapter not configured',
+    };
+  } else {
+    try {
+      result = await invoke(ctx.ompCommand, buildReq(input, operationId));
+    } catch (error) {
+      result = {
+        ok: false,
+        operationId,
+        error: 'unavailable',
+        detail: error instanceof Error ? error.message : 'OMP command failed',
+      };
+    }
+  }
+
+  ctx.auditOmp({
+    verb,
+    principal,
+    outcome: 'completed',
+    operationId,
+    detail: result.ok ? 'ok' : result.error,
+  });
+  return result;
+}
+
+// Bounded, log-safe token: UUID/ULID/snowflake-shaped. Rejects whitespace and
+// control characters so a caller cannot inject newlines into the audit trail.
+const IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+const idempotency = z.object({ idempotencyKey: z.string().max(128).regex(IDEMPOTENCY_KEY_PATTERN).optional() });
+
+const spawnInput = idempotency.extend({
+  model: z.string(),
+  task: z.string(),
+  label: z.string().optional(),
+  target: z.string().optional(),
+  workspace: z.string().optional(),
+  cwd: z.string().optional(),
+  timeoutMs: z.number().optional(),
+  executionMode: z.enum(['auto', 'subprocess', 'shepherd']).optional(),
+  intent: z.enum(['read_only', 'mutating', 'high_stakes_mutating', 'external_side_effect']).optional(),
+  scope: scopeSchema,
+});
+
+type SpawnInput = z.infer<typeof spawnInput>;
+const killInput = idempotency.extend({ workerId: z.string(), timeoutMs: z.number().optional() });
+const proposalInput = idempotency.extend({ proposalId: z.string(), reason: z.string() });
+const verifyInput = idempotency.extend({ proposalId: z.string() });
+type KillInput = z.infer<typeof killInput>;
+type ProposalInput = z.infer<typeof proposalInput>;
+type VerifyInput = z.infer<typeof verifyInput>;
+
+function toSpawnReq(input: SpawnInput, operationId: string): OmpSpawnRequest {
+  return { ...input, operationId };
+}
+function toKillReq(input: KillInput, operationId: string): OmpKillRequest {
+  return { ...input, operationId };
+}
+function toApplyReq(input: ProposalInput, operationId: string): OmpApplyRequest {
+  return { ...input, operationId };
+}
+function toDiscardReq(input: ProposalInput, operationId: string): OmpDiscardRequest {
+  return { ...input, operationId };
+}
+function toVerifyReq(input: VerifyInput, operationId: string): OmpVerifyRequest {
+  return { ...input, operationId };
+}
+
+export const ompCommandRouter = router({
+  spawn: protectedProcedure
+    .input(spawnInput)
+    .mutation(({ ctx, input }) => runGuarded(ctx, 'spawn', input, toSpawnReq, (a, req) => a.spawn(req))),
+  kill: protectedProcedure
+    .input(killInput)
+    .mutation(({ ctx, input }) => runGuarded(ctx, 'kill', input, toKillReq, (a, req) => a.kill(req))),
+  applyProposal: protectedProcedure
+    .input(proposalInput)
+    .mutation(({ ctx, input }) => runGuarded(ctx, 'apply', input, toApplyReq, (a, req) => a.apply(req))),
+  discard: protectedProcedure
+    .input(proposalInput)
+    .mutation(({ ctx, input }) => runGuarded(ctx, 'discard', input, toDiscardReq, (a, req) => a.discard(req))),
+  verifyRun: protectedProcedure
+    .input(verifyInput)
+    .mutation(({ ctx, input }) => runGuarded(ctx, 'verifyRun', input, toVerifyReq, (a, req) => a.verifyRun(req))),
+});

--- a/main/src/orchestrator/types.ts
+++ b/main/src/orchestrator/types.ts
@@ -9,6 +9,7 @@ import type { RunQueueRegistry } from './RunQueueRegistry';
 import type { ClaudeManagerLike } from './stuckDetector';
 import type { StuckDetectedEvent } from '../../../shared/types/stuckDetection';
 import type { ReviewItemCreate, ReviewItemTriage } from './reviewItemRouter';
+import type { OmpControlPlaneAdapter } from '../../../shared/types/omp';
 
 // ---------------------------------------------------------------------------
 // DatabaseLike
@@ -88,6 +89,8 @@ export interface OrchestratorDeps {
     projectId: number,
     change: ReviewItemCreate | ReviewItemTriage,
   ) => Promise<{ reviewItemId: string; event: { id: number; seq: number } }>;
+  /** Read-only OMP fleet adapter. Optional (absent => no OMP awareness at the orchestrator layer). */
+  omp?: OmpControlPlaneAdapter;
   /**
    * Optional: the main-process sink for stuck-run notifications (the tRPC
    * router's `stuckEvents`). StuckDetector emits 'runs:stuck' on its own

--- a/main/src/services/__tests__/agentProviderAccess.test.ts
+++ b/main/src/services/__tests__/agentProviderAccess.test.ts
@@ -54,6 +54,7 @@ describe('providerForRuntime / isRuntimeProviderEnabled', () => {
     expect(providerForRuntime('codex-sdk')).toBe('codex');
     expect(providerForRuntime('codex-pty')).toBe('codex');
     expect(providerForRuntime('codex-exec')).toBe('codex');
+    expect(providerForRuntime('omp-fleet')).toBe('omp');
   });
 
   it('gates a runtime on its provider', () => {

--- a/main/src/services/__tests__/configManagerProviderAccess.test.ts
+++ b/main/src/services/__tests__/configManagerProviderAccess.test.ts
@@ -76,11 +76,11 @@ describe('ConfigManager.agentProviderAccess', () => {
     expect(mgr.getAgentProviderAccess()).toEqual({ claude: true, codex: false, omp: false });
   });
 
-  it('degrades an all-off map to both-enabled (never brick every launch seam)', async () => {
+  it('degrades an all-off map to all-enabled (never brick every launch seam)', async () => {
     const mgr = new ConfigManager('/tmp/test-git-path');
     await mgr.initialize();
     // Bypasses the IPC normalization (a hand-edited config.json can do this).
-    await mgr.updateConfig({ agentProviderAccess: { claude: false, codex: false } });
+    await mgr.updateConfig({ agentProviderAccess: { claude: false, codex: false, omp: false } });
 
     expect(mgr.getAgentProviderAccess()).toEqual({ claude: true, codex: true, omp: false });
     expect(mgr.isAgentProviderEnabled('claude')).toBe(true);

--- a/main/src/services/__tests__/worktreeManager.test.ts
+++ b/main/src/services/__tests__/worktreeManager.test.ts
@@ -441,7 +441,11 @@ function commitFile(dir: string, rel: string, content: string, msg: string): voi
 // ---------------------------------------------------------------------------
 
 describe('WorktreeManager.squashAndMergeWorktreeToMain (integration)', () => {
-  it('squashes a clean multi-commit branch into ONE footer-stamped commit and fast-forwards main', async () => {
+  
+  // Same full-suite flake profile as the advanced-tip test below (see its
+  // comment): forks ~15 git subprocesses; 5s default flakes under full-suite
+  // CPU/fork contention while passing in isolation.
+  it('squashes a clean multi-commit branch into ONE footer-stamped commit and fast-forwards main', { timeout: 30_000 }, async () => {
     await withTempDir('worktree-squash-ok-', async (tmpDir) => {
       initRepo(tmpDir);
       const main = headBranch(tmpDir);
@@ -493,7 +497,10 @@ describe('WorktreeManager.squashAndMergeWorktreeToMain (integration)', () => {
     });
   });
 
-  it('squashes atop main\'s advanced tip when main moved past the fork point with a NON-conflicting commit', async () => {
+  // Same full-suite flake profile as the conflict test above (see its comment):
+  // fork ~15 git subprocesses across three worktrees; 5s default flakes under
+  // full-suite CPU/fork contention while passing in isolation.
+  it('squashes atop main\'s advanced tip when main moved past the fork point with a NON-conflicting commit', { timeout: 30_000 }, async () => {
     await withTempDir('worktree-squash-adv-ok-', async (tmpDir) => {
       initRepo(tmpDir);
       const main = headBranch(tmpDir);

--- a/main/src/services/agentProviderGuard.ts
+++ b/main/src/services/agentProviderGuard.ts
@@ -44,6 +44,7 @@ import {
   type AgentProvider,
 } from '../../../shared/types/agentRuntime';
 
+
 /**
  * Thrown when a call is attempted against a provider the user switched off.
  * Carries `provider` so a caller can map it back onto a UI affordance without

--- a/main/src/services/configManager.ts
+++ b/main/src/services/configManager.ts
@@ -526,6 +526,16 @@ export class ConfigManager extends EventEmitter {
   }
 
   /**
+   * Aria mode: this install supervises a REMOTE OMP fleet rather than running
+   * OMP locally (see `AppConfig.ariaMode`). Absent ⇒ false, so an install that
+   * never touched the toggle keeps the local runtimes and grants no supervise
+   * capability — the same absent⇒off policy `agentProviderAccess` uses.
+   */
+  getAriaMode(): boolean {
+    return this.config.ariaMode === true;
+  }
+
+  /**
    * True when `provider` may be used for a run/session. The authoritative read
    * for the launch seams (WorkflowRegistry.createRun, the quick-session IPC
    * handler, the per-step agent resolver) — the renderer's pickers mirror this

--- a/main/src/services/createQuickSessionCore.ts
+++ b/main/src/services/createQuickSessionCore.ts
@@ -354,6 +354,13 @@ export interface QuickSessionRuntimeStampInput {
   sessionAgentRuntime?: SessionAgentRuntime;
   /** Only stamped when explicitly chosen — undefined keeps the global default (NULL). */
   requestedAgentMode?: PermissionMode;
+  /**
+   * Explicit runtime override (OMP fleet). When present it wins over the
+   * substrate-derived Claude runtime — an omp-fleet session has no substrate
+   * axis, so the ordinary `claudeRuntimeFromSubstrate` derivation would stamp
+   * it back to 'claude-sdk' and the dispatch seams would never see omp-fleet.
+   */
+  agentRuntimeOverride?: SessionAgentRuntime;
 }
 
 /**
@@ -390,10 +397,16 @@ export function stampQuickSessionRuntimeConfig(
     );
   }
   const resolvedSessionAgentRuntime =
-    input.sessionAgentRuntime ?? claudeRuntimeFromSubstrate(input.resolvedSubstrate);
-  const resolvedSessionSubstrate = isPtyLane(resolvedSessionAgentRuntime)
-    ? 'interactive'
-    : input.resolvedSubstrate;
+    input.agentRuntimeOverride ??
+    input.sessionAgentRuntime ??
+    claudeRuntimeFromSubstrate(input.resolvedSubstrate);
+  // omp-fleet is NOT a PTY lane (it supervises a remote fleet, not a terminal):
+  // its substrate stays whatever the sentinel resolved, exactly as before the
+  // lane abstraction — isPtyLane covers the PTY-transport runtimes only.
+  const resolvedSessionSubstrate =
+    resolvedSessionAgentRuntime !== 'omp-fleet' && isPtyLane(resolvedSessionAgentRuntime)
+      ? 'interactive'
+      : input.resolvedSubstrate;
   db.prepare(
     `UPDATE sessions
         SET substrate = ?,

--- a/main/src/types/config.ts
+++ b/main/src/types/config.ts
@@ -217,6 +217,26 @@ export interface AppConfig {
   // exercised live. Mirrors the CYBOFLOW_DEV_FORCE_GATE_STREAM_CLOSED env var.
   // Floored to false when unset; never fires in a packaged release.
   forceAskUserQuestionGateFailure?: boolean;
+  /**
+   * Aria mode — which OMP flavor this install runs.
+   *
+   * OFF (default): the LOCAL OMP runtimes (`omp-sdk` / `omp-pty`) are offered
+   * and the fleet supervisor is hidden. ON: Cyboflow supervises a REMOTE OMP
+   * fleet over the Prime bridge (`omp-fleet`) and the local runtimes are hidden.
+   * The two are alternatives, not a stack — one panel is either a local OMP
+   * process or a remote worker, never both.
+   *
+   * This is also the GRANT of the `omp:supervise` capability: spawning and
+   * killing remote workers is authorized by the operator saying so here, not by
+   * the bridge merely being reachable. `CYBOFLOW_OMP_SUPERVISE` remains an
+   * override for headless/CI hosts that have no Settings UI.
+   *
+   * Read at boot when the fleet session manager is constructed, so a change
+   * takes effect on the next launch (like `additionalPaths`). Independent of
+   * the `omp` provider toggle in Settings -> Integrations, which still has to
+   * be on for ANY OMP runtime to appear.
+   */
+  ariaMode?: boolean;
   // Demo mode: boots the app against a throwaway demo database + sandbox repo
   // with scripted agent runs. Read ONCE at startup — toggling relaunches the app.
   demoMode?: boolean;
@@ -332,6 +352,8 @@ export interface UpdateConfigRequest {
   devMode?: boolean;
   // DEV-ONLY testing affordance (see AppConfig.forceAskUserQuestionGateFailure).
   forceAskUserQuestionGateFailure?: boolean;
+  // Aria mode (see AppConfig.ariaMode) — applied on next launch.
+  ariaMode?: boolean;
   // Demo mode (see AppConfig.demoMode) — applied on next launch.
   demoMode?: boolean;
   // Telemetry settings (see AppConfig.telemetry). Opt-OUT model: both flags default

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   },
   "scripts": {
     "dev": "pnpm run electron-dev",
-    "electron-dev": "node scripts/ensure-sqlite-abi.mjs electron && concurrently \"pnpm run --filter frontend dev\" \"wait-on http://localhost:${CYBOFLOW_VITE_PORT:-4521} && electron . --remote-debugging-port=${CYBOFLOW_CDP_PORT:-9223}\"",
-    "electron-dev:custom": "node scripts/ensure-sqlite-abi.mjs electron && concurrently \"pnpm run --filter frontend dev\" \"wait-on http://localhost:${CYBOFLOW_VITE_PORT:-4521} && electron .\"",
+    "electron-dev": "node scripts/ensure-sqlite-abi.mjs electron && concurrently \"pnpm run --filter frontend dev\" \"wait-on http://localhost:${CYBOFLOW_VITE_PORT:-4521} && env -u NODE_OPTIONS electron . --remote-debugging-port=${CYBOFLOW_CDP_PORT:-9223}\"",
+    "electron-dev:custom": "node scripts/ensure-sqlite-abi.mjs electron && concurrently \"pnpm run --filter frontend dev\" \"wait-on http://localhost:${CYBOFLOW_VITE_PORT:-4521} && env -u NODE_OPTIONS electron .\"",
     "dev:perf": "node scripts/ensure-sqlite-abi.mjs electron && concurrently \"pnpm run --filter frontend dev\" \"wait-on http://localhost:${CYBOFLOW_VITE_PORT:-4521} && CYBOFLOW_PERF_TRACE=1 electron . --inspect=${CYBOFLOW_INSPECT_PORT:-9229} --remote-debugging-port=${CYBOFLOW_CDP_PORT:-9223}\"",
     "build": "pnpm run build:frontend && pnpm run build:main && pnpm run build:electron",
     "build:frontend": "pnpm run --filter frontend build",

--- a/scripts/ensure-sqlite-abi.mjs
+++ b/scripts/ensure-sqlite-abi.mjs
@@ -276,6 +276,11 @@ function probe(target, moduleDir) {
     // Electron-as-Node: same binary, same ABI, no window — so the probe measures
     // the ABI the real app will load with, without opening a UI.
     env = { ...process.env, ELECTRON_RUN_AS_NODE: '1' };
+    // The Electron binary rejects --openssl-legacy-provider in NODE_OPTIONS
+    // (even with ELECTRON_RUN_AS_NODE=1), so a host that exports it would make
+    // the probe fail spuriously and force the slow rebuild path on every launch.
+    // The probe only needs a bare ABI check — drop NODE_OPTIONS for this child.
+    delete env.NODE_OPTIONS;
   }
 
   const result = spawnSync(exec, ['-e', source], { cwd: repoRoot, encoding: 'utf8', env });

--- a/shared/types/agentCapabilities.ts
+++ b/shared/types/agentCapabilities.ts
@@ -82,6 +82,12 @@ export const RUNTIME_CAPABILITIES: Readonly<Record<AgentRuntime, AgentRuntimeCap
   // OMP analogue.
   'omp-sdk': { selectableInPickers: true, supportsEffort: true, supportsFastMode: false },
   'omp-pty': { selectableInPickers: true, supportsEffort: false, supportsFastMode: false },
+  // The fleet SUPERVISOR runtime (omp-phase4-coexistence-adr.md §3, §5): offered
+  // in the quick-session picker only, and only while the bridge availability
+  // probe reports configured (SubstrateSelector gates it further). The remote
+  // worker owns its model and thinking level (DEFAULT_OMP_MODEL), so effort and
+  // fast mode are both producer-side and hidden here.
+  'omp-fleet': { selectableInPickers: true, supportsEffort: false, supportsFastMode: false },
 };
 
 /**

--- a/shared/types/agentRuntime.ts
+++ b/shared/types/agentRuntime.ts
@@ -28,6 +28,11 @@ export type AgentProvider = (typeof AGENT_PROVIDERS)[number];
  * SESSION_AGENT_RUNTIMES / WORKFLOW_* this is the FULL set — it exists for
  * validating a runtime read back off a user-editable surface (config.json),
  * where the surface itself is not scoped to one launch kind.
+ *
+ * `omp-fleet` is the fleet-supervisor runtime (Cyboflow supervises a running
+ * OMP fleet through the bridge command adapter); `omp-sdk` and `omp-pty` are
+ * OMP-as-a-runtime sessions (SDK and terminal panels). All three belong to the
+ * `omp` provider via its `omp-` prefix.
  */
 export const ALL_AGENT_RUNTIMES = [
   'claude-sdk',
@@ -37,16 +42,19 @@ export const ALL_AGENT_RUNTIMES = [
   'codex-exec',
   'omp-sdk',
   'omp-pty',
+  'omp-fleet',
 ] as const;
 
 export type AgentRuntime = (typeof ALL_AGENT_RUNTIMES)[number];
 
 /**
  * Every runtime a chat SESSION may run on. Stated as an exclusion because
- * `codex-exec` is the sole runtime with no session manager behind it — both OMP
- * runtimes belong here (they are declared unreachable through
- * {@link AgentProviderDefinition.defaultEnabled} and the picker capability, not
- * by being kept out of the union).
+ * `codex-exec` is the sole runtime with no session manager behind it — every
+ * OMP runtime belongs here: `omp-sdk`/`omp-pty` are declared unreachable
+ * through {@link AgentProviderDefinition.defaultEnabled} and the picker
+ * capability rather than by being kept out of the union, and `omp-fleet` is
+ * the fleet-supervisor session runtime (dispatched to the fleet session
+ * manager, not a panel).
  */
 export type SessionAgentRuntime = Exclude<AgentRuntime, 'codex-exec'>;
 
@@ -57,17 +65,20 @@ export type SessionAgentRuntime = Exclude<AgentRuntime, 'codex-exec'>;
  *
  * Deliberately distinct from {@link WORKFLOW_LAUNCHABLE_RUNTIMES}: a runtime can
  * be storable (so a quick session keeps its identity on the sentinel row)
- * without yet being offered as a workflow launch target. The two sets COINCIDE
- * today — `omp-sdk` was the one divergence and joined the launchable set once
- * its programmatic per-step support landed — but they answer different
- * questions and must stay separately stated: the next provider declared ahead of
- * its workflow lane lands here first and only here, exactly as `omp-sdk` did.
+ * without yet being offered as a workflow launch target. `omp-sdk` was the one
+ * divergence and joined the launchable set once its programmatic per-step
+ * support landed; `omp-fleet` is the other — it mints sentinel rows for
+ * quick-launch fleet sessions, but a fleet supervisor is never a per-step
+ * workflow agent, so it stays out of the launchable set. The two sets answer
+ * different questions and must stay separately stated: the next provider
+ * declared ahead of its workflow lane lands here first and only here.
  */
 export const WORKFLOW_RUN_STORABLE_RUNTIMES = [
   'claude-sdk',
   'claude-interactive',
   'codex-sdk',
   'omp-sdk',
+  'omp-fleet',
 ] as const;
 
 export type WorkflowRunStorableRuntime = (typeof WORKFLOW_RUN_STORABLE_RUNTIMES)[number];
@@ -76,7 +87,9 @@ export type WorkflowRunStorableRuntime = (typeof WORKFLOW_RUN_STORABLE_RUNTIMES)
  * What the workflow pickers offer and `WorkflowRegistry.createRun` accepts for a
  * real (non-sentinel) run — i.e. the runtimes a workflow agent may deploy on.
  * `codex-pty` and `omp-pty` are excluded because workflows need structured
- * events/usage/MCP, which a TUI driven by keystrokes cannot supply.
+ * events/usage/MCP, which a TUI driven by keystrokes cannot supply; `omp-fleet`
+ * is excluded for the same structural reason — it supervises a fleet as a whole
+ * and has no per-step event stream.
  */
 export const WORKFLOW_LAUNCHABLE_RUNTIMES = [
   'claude-sdk',
@@ -113,6 +126,7 @@ export const SESSION_AGENT_RUNTIMES = [
   'codex-pty',
   'omp-sdk',
   'omp-pty',
+  'omp-fleet',
 ] as const;
 
 /** Human labels for the workflow-scoped runtime picker. Single source shared by
@@ -131,10 +145,11 @@ export const WORKFLOW_AGENT_RUNTIME_LABELS: Record<WorkflowLaunchableRuntime, st
  * sessions only"). Exhaustive over `SessionAgentRuntime` — unlike
  * {@link WORKFLOW_AGENT_RUNTIME_LABELS}, which is scoped to the
  * workflow-launchable subset and uses shorter labels for the agent-config
- * editors — so the two terminal-driven runtimes (`codex-pty`, `omp-pty`) are
- * covered too. Any summary echoing a launched runtime (e.g. the wizard's
- * launch-summary Runtime row) should read this instead of hand-rolling a
- * ternary that silently defaults an unhandled runtime to the wrong label.
+ * editors — so the two terminal-driven runtimes (`codex-pty`, `omp-pty`) and
+ * the fleet supervisor (`omp-fleet`) are covered too. Any summary echoing a
+ * launched runtime (e.g. the wizard's launch-summary Runtime row) should read
+ * this instead of hand-rolling a ternary that silently defaults an unhandled
+ * runtime to the wrong label.
  *
  * "(CLI)" — never "(PTY)" — is the user-facing word for a terminal-driven
  * runtime. PTY is the transport's implementation name and stays in code
@@ -148,6 +163,7 @@ export const AGENT_RUNTIME_LABELS: Record<SessionAgentRuntime, string> = {
   'codex-pty': 'Codex (CLI)',
   'omp-sdk': 'OMP',
   'omp-pty': 'OMP (CLI)',
+  'omp-fleet': 'OMP fleet',
 };
 
 // ---------------------------------------------------------------------------
@@ -195,7 +211,10 @@ export const AGENT_PROVIDER_REGISTRY: Readonly<Record<AgentProvider, AgentProvid
   // it takes the absent⇒DISABLED policy this field exists for: every install
   // that has never seen the OMP card in Settings → Integrations keeps OMP off,
   // and nothing about a claude/codex user's app changes because the provider
-  // was declared. See `AgentProviderDefinition.defaultEnabled`.
+  // was declared. This covers every omp- runtime, including the fleet
+  // supervisor (`omp-fleet`) — the fleet status-bar indicator and the
+  // fleet-session launch both respect the same toggle. See
+  // `AgentProviderDefinition.defaultEnabled`.
   omp: { runtimePrefix: 'omp-', defaultEnabled: false },
 };
 
@@ -297,8 +316,8 @@ export function providerForRuntimeIn<P extends string>(
  *
  * The discrimination is opt-IN on `development`/`test` rather than a
  * `!== 'production'` default because a packaged Electron app may leave NODE_ENV
- * unset (index.ts pairs it with `app.isPackaged` for exactly this reason), and a
- * bad persisted value must never take a user's app down. The literal
+ * unset (index.ts pairs it with `app.isPackaged` for exactly this reason), and
+ * a bad persisted value must never take a user's app down. The literal
  * `process.env.NODE_ENV` token is what Vite statically replaces in the renderer
  * bundle, so it has to appear verbatim; the main process reads the live value.
  *

--- a/shared/types/omp.ts
+++ b/shared/types/omp.ts
@@ -1,0 +1,171 @@
+/**
+ * OMP fleet-registry domain types — the Cyboflow-side mirror of the
+ * authoritative producer contract in `OMP-fleet-management`
+ * (`extensions/fleet/registry-contract.ts`).
+ *
+ * The producer module is PURE and explicitly sanctions consumer copies: "a
+ * separate consumer repo can `import type` the shapes — and copy or alias
+ * `parseRegistrySnapshot` verbatim." Cyboflow is not a dependency consumer, so
+ * these shapes are re-declared here and pinned to `SUPPORTED_REGISTRY_VERSION`
+ * (see `main/src/orchestrator/omp/registryContract.ts`).
+ *
+ * ## Drift discipline
+ *
+ * The parser refuses any registry whose `version !== SUPPORTED_REGISTRY_VERSION`.
+ * If the producer bumps the version or changes a field shape, this file and
+ * `registryContract.ts` must be updated TOGETHER, or the reader fails closed
+ * (it reports `unsupported-version` / `malformed`, never mis-renders).
+ *
+ * `ExecutionIntent` and `WorkerScope` are stubbed here because the producer
+ * imports them from its own `./backend`; Cyboflow has no such module. They
+ * mirror the producer's `extensions/fleet/backend.ts` exactly.
+ */
+
+/** Producer-side default fleet model (OMP-fleet-management docs, default worker). */
+export const DEFAULT_OMP_MODEL = "zai/glm-5.2:high";
+
+export type OmpBackend = "subprocess" | "shepherd";
+
+export type WorkerStatus =
+  | "spawning"
+  | "working"
+  | "idle"
+  | "blocked"
+  | "dead"
+  | "evicted"
+  | "proposal_ready"
+  | "killing"
+  | "done"
+  | "failed";
+
+export type FailureReportState = "pending" | "claimed" | "acknowledged";
+
+export type ExecutionIntent =
+  | "read_only"
+  | "mutating"
+  | "high_stakes_mutating"
+  | "external_side_effect";
+
+export interface WorkerScope {
+  repo?: {
+    path: string;
+    access: "none" | "read" | "overlay_write" | "host_write";
+    include?: string[];
+    exclude?: string[];
+  };
+  shell?: { allowed: boolean; commands?: string[] };
+  network?: { allowed: boolean; domains?: string[] };
+  secrets?: { allowed: boolean; names?: string[] };
+}
+
+export interface FailureReportRecord {
+  state: FailureReportState;
+  idempotencyKey: string;
+  transitionStatus: "failed" | "dead";
+  traceId?: string;
+  output: string;
+  claimedBy?: string;
+  claimExpiresAt?: number;
+  acknowledgedAt?: string;
+}
+
+export interface WorkerEntry {
+  id: string;
+  paneId: string | null;
+  workspaceId: string | null;
+  backend: OmpBackend;
+  model: string;
+  task: string;
+  label: string | null;
+  status: WorkerStatus;
+  spawnedAt: string;
+  lastSeenAt: string;
+  leaseExpiresAt: string | null;
+  lastOutput: string | null;
+  sandboxId?: string;
+  runId?: string;
+  traceId?: string;
+  proposalId?: string;
+  baseRevision?: string;
+  repoPath?: string;
+  allowedPaths?: string[];
+  proposalAuthorityFrozen?: boolean;
+  intent?: ExecutionIntent;
+  scope?: WorkerScope;
+  cwd?: string;
+  /** Process instance that owns lifecycle observation for this worker. */
+  ownerProcessId?: string;
+  ownerPid?: number;
+  ownerHeartbeatAt?: number;
+  timeout?: number;
+  queued?: boolean;
+  failureReportSequence?: number;
+  failureReport?: FailureReportRecord;
+  /** Canonical oldest-first queue; failureReport mirrors its current head. */
+  failureReports?: FailureReportRecord[];
+}
+
+export interface RegistrySnapshot {
+  workers: WorkerEntry[];
+  version: 1;
+  savedAt: string;
+}
+
+/**
+ * Result of a fleet snapshot read at the adapter boundary. Distinct from the
+ * parser-level result (`registryContract.ts`): this adds `unavailable` for a
+ * missing/unreadable registry and flattens validation detail into a string so
+ * the renderer never depends on parser internals.
+ */
+export type OmpSnapshotResult =
+  | { ok: true; snapshot: RegistrySnapshot }
+  | {
+      ok: false;
+      error: "unavailable" | "missing" | "unsupported-version" | "malformed";
+      detail: string;
+    };
+
+/**
+ * Renderer-safe worker projection. The full WorkerEntry carries task text,
+ * lastOutput, repoPath, allowedPaths, and failure-report output — none of which
+ * may cross the IPC boundary. This DTO is produced in MAIN before the tRPC
+ * reply; the renderer only ever sees these summary fields.
+ */
+export interface OmpFleetWorkerView {
+  id: string;
+  label: string | null;
+  model: string;
+  status: WorkerStatus;
+  backend: OmpBackend;
+  spawnedAt: string;
+  lastSeenAt: string;
+}
+
+export interface OmpFleetViewSnapshot {
+  version: number;
+  savedAt: string;
+  totalWorkers: number;
+  workers: OmpFleetWorkerView[];
+}
+
+/** Renderer-facing result: a redacted summary, never the raw registry. */
+export type OmpFleetViewResult =
+  | { ok: true; snapshot: OmpFleetViewSnapshot }
+  | {
+      ok: false;
+      error: "unavailable" | "missing" | "unsupported-version" | "malformed";
+      detail: string;
+    };
+
+/**
+ * Read-only control-plane adapter. This is the ONLY surface the renderer/other
+ * code consumes. It deliberately exposes no mutators: proposal/proof read and
+ * command (spawn/kill/verify/apply) surfaces are separate, privileged
+ * increments that arrive later. The `authority` literal is a type-level
+ * guarantee, not a comment.
+ */
+export interface OmpControlPlaneAdapter {
+  readonly version: 1;
+  readonly authority: "read";
+  getFleetSnapshot(): Promise<OmpSnapshotResult>;
+}

--- a/shared/types/ompCommand.ts
+++ b/shared/types/ompCommand.ts
@@ -1,0 +1,141 @@
+/**
+ * OMP command contract — the privileged, supervisor-only surface that Cyboflow
+ * declares but does NOT implement in the first pass (a stub ships; real
+ * commands are a separate ADR with its own go/no-go).
+ *
+ * Authority is encoded as types, not comments:
+ * - `OmpControlPlaneAdapter.authority: 'read'` (shared/types/omp.ts) — read-only.
+ * - `OmpCommandAdapter.authority: 'supervise'` (below) — privileged commands.
+ * Workers never receive the supervise surface.
+ *
+ * The producer's ACTUAL tool surface this mirrors (verified):
+ * - lifecycle: fleet_spawn / fleet_kill (plus list/state/read/wait, which stay
+ *   on the read side)
+ * - proposal: fleet_proposal_apply / fleet_proposal_discard
+ * - verification: fleet_verification_candidate/run/status/proof (candidate-bound)
+ * There is no `fleet_verify`/`fleet_apply` tool; verify is `fleet_verification_*`,
+ * apply is `fleet_proposal_apply`. Callers pass only `proposalId` (+ `reason`
+ * for apply/discard); the producer resolves and binds the candidate digest/proof.
+ *
+ * ## Correlation + idempotency
+ *
+ * Every request carries a required `operationId`, minted by the router (or set
+ * to the client-supplied idempotency key). The adapter MUST echo it verbatim in
+ * `OmpCommandResult.operationId`, so the audit trail and the returned result
+ * correlate on ONE token. The same token is the idempotency handle: the Phase-3
+ * real adapter dedupes and cancel-by-id on it.
+ */
+
+import type { ExecutionIntent, WorkerScope } from './omp';
+
+/** Immutable per-request principal. In v1 it is hardcoded `'local'`; v2 populates it from a session token. */
+export interface OmpPrincipal {
+  readonly userId: string;
+  readonly capabilities: ReadonlySet<string>;
+}
+
+/** The capability a principal must hold to reach any OMP command. */
+export const OMP_SUPERVISE_CAPABILITY = 'omp:supervise' as const;
+
+export function hasSupervise(principal: OmpPrincipal | undefined): boolean {
+  return principal?.capabilities.has(OMP_SUPERVISE_CAPABILITY) === true;
+}
+
+/** Producer execution_mode, carried verbatim. */
+export type OmpExecutionMode = 'auto' | 'subprocess' | 'shepherd';
+
+export interface OmpSpawnRequest {
+  /** Correlation/idempotency token — echoed verbatim in the result. */
+  operationId: string;
+  model: string;
+  task: string;
+  label?: string;
+  /** Pane to split from (producer `target`). */
+  target?: string;
+  workspace?: string;
+  cwd?: string;
+  /** Bounded duration; the producer aborts on expiry. Cancel-by-id rides the operationId. */
+  timeoutMs?: number;
+  executionMode?: OmpExecutionMode;
+  intent?: ExecutionIntent;
+  scope?: WorkerScope;
+}
+
+export interface OmpKillRequest {
+  operationId: string;
+  workerId: string;
+  timeoutMs?: number;
+}
+
+/** Producer `fleet_read` `source`, carried verbatim. */
+export type OmpReadSource = 'visible' | 'recent' | 'recent-unwrapped' | 'detection';
+
+export interface OmpReadRequest {
+  operationId: string;
+  workerId: string;
+  lines?: number;
+  source?: OmpReadSource;
+}
+
+export interface OmpSendRequest {
+  operationId: string;
+  workerId: string;
+  text: string;
+  /** When true, the producer treats `text` as space-separated key-combos. */
+  keys?: boolean;
+}
+
+export interface OmpStateRequest {
+  operationId: string;
+  workerId: string;
+}
+
+export interface OmpApplyRequest {
+  operationId: string;
+  proposalId: string;
+  reason: string;
+}
+
+export interface OmpDiscardRequest {
+  operationId: string;
+  proposalId: string;
+  reason: string;
+}
+
+export interface OmpVerifyRequest {
+  operationId: string;
+  /** The retained proposal to verify. The producer resolves the candidate digest from this; the caller never supplies argv or proof. */
+  proposalId: string;
+}
+
+/**
+ * Result of any OMP command. `operationId` MUST equal the request's token so a
+ * caller can correlate the audit trail and retry idempotently. `blocked` and
+ * `shadow` are distinct from a plain failure: a BLOCKED candidate is not a
+ * PASS, and shadow is not enforcement.
+ */
+export type OmpCommandResult =
+  | { ok: true; operationId: string; detail: string }
+  | {
+      ok: false;
+      operationId: string;
+      error: 'unavailable' | 'forbidden' | 'conflict' | 'blocked' | 'shadow';
+      detail: string;
+    };
+
+/**
+ * The privileged supervisor surface. Declared now, stubbed in the first pass.
+ * Real implementations (Phase 3 ADR) shell to the producer's fleet_* tools
+ * behind this interface, never exposing a worker-reachable path.
+ */
+export interface OmpCommandAdapter {
+  readonly authority: 'supervise';
+  spawn(req: OmpSpawnRequest): Promise<OmpCommandResult>;
+  kill(req: OmpKillRequest): Promise<OmpCommandResult>;
+  apply(req: OmpApplyRequest): Promise<OmpCommandResult>;
+  discard(req: OmpDiscardRequest): Promise<OmpCommandResult>;
+  verifyRun(req: OmpVerifyRequest): Promise<OmpCommandResult>;
+  send(req: OmpSendRequest): Promise<OmpCommandResult>;
+  read(req: OmpReadRequest): Promise<OmpCommandResult>;
+  state(req: OmpStateRequest): Promise<OmpCommandResult>;
+}


### PR DESCRIPTION
Supersedes #10 — same feature, rebased as a single DCO-signed commit onto kesteva/main@23d1b58d so every commit in this PR carries Signed-off-by and the diff applies cleanly against the current line.

## Tested — works

- Full unit gate on the rebase tree: main 11,7xx / frontend 4,6xx green, typecheck + lint clean, schema parity + release-scripts + ABI + test:build pass.
- migration renumbered to **119** (107 taken by bootstrap_proof; tip was 118) with a real-upgrade ledger test: dir-minus-119 → seed → boot with full dir; pins prior widenings survive, rows verbatim incl. status_message, no stale pre-renumber filename.
- This exact content already ships on sorcerai/main via sorcerai/cyboflow#1, where CI ran the same battery plus E2E smoke (macOS) — green.
- Live bridge smoke of the pinned `--session-id` resume contract: turn 2 answered from turn-1 context under the id.

## Fixes carried on top of #10

- **Frozen principal**: createContext resolves OmpPrincipal | thunk per request, so Aria-mode grant/revoke takes effect without relaunch (was contradicting this PR's own no-restart claim). Pinned by contextPrincipal.test.ts.
- Migration numbering per above; guard test rejects resurrected 105/107 filenames.
- Five stray .perf/*.cpuprofile blobs dropped.

Closes #10 once merged. @krermes — mergeable straight from the browser; every commit is signed off (Aria Pramesi <aria@sorcerai.co>).