### PR TITLE
fix(pi): workflow re-run refresh + Pi caveats panels (follow-up to #12)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -70,7 +70,6 @@ jobs:
         run: |
           node scripts/ensure-sqlite-abi.mjs host
           pnpm run test:build
-
       # The launched app needs the ELECTRON ABI. postinstall normally leaves
       # it there, but a restored pnpm store can carry a host-ABI
       # better_sqlite3.node — then _electron.launch throws NMV 127-vs-136 on

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,1 @@
+fd5f2d1faf09f203f5e1d51ce0aa0b67ea0e564e:main/src/services/trackerSync/dartAdapter.test.ts:generic-api-key:71

--- a/MERGE-PLAN-2026-07-15.md
+++ b/MERGE-PLAN-2026-07-15.md
@@ -1,0 +1,121 @@
+# Merge plan: kesteva/main → main (OMP fleet coexistence)
+
+Worktree: /Users/ahpramesi/repos/cyboflow (branch `main`, merge in progress, MERGE_HEAD=8f14327d)
+OURS = local `main` (f2160088, "Merge OMP fleet substrate" — fleet runtime ADR work)
+THEIRS = kesteva/main (8f14327d, "Codex/OMP provider+transport split" — v0.2.3 era)
+
+## Design intent (HEAD/ours, from fleet ADR + prior merge resolution)
+- `omp-fleet` = first-class citizen BEFORE the PTY-lane machinery: fleet sessions early-return
+  from the panel input path (`routeOmpFleetTurn`) and are created WITHOUT spawning a PTY panel
+  (early return before the codex-pty/interactive branches in `sessions:create-quick`).
+- Fleet substrate = 'sdk' (structured), never 'interactive'. The interactive REPl eager-spawn
+  must NOT fire for fleet.
+- `omp-sdk`/`omp-pty` lanes (upstream) are separate from `omp-fleet` (ours). Both coexist.
+
+## Upstream (theirs) changes being merged in
+1. Per-provider transport axis: `PanelLane` = 8 values (claude-sdk, claude-interactive,
+   codex-sdk, codex-pty, omp-sdk, omp-pty). `quickPtyLanes` = {claude-interactive, codex-pty, omp-pty}.
+2. `QUICK_PROVIDER_SDK_RUNTIME` (in createQuickSessionCore.ts:304): provider→structured runtime.
+   ⚠️ Mapped `omp: 'omp-sdk'` upstream — for quick-sessions WITHOUT a migration-027 runtime
+   request. Fleet picker requests agent_runtime='omp-fleet' explicitly (stamp path), so the
+   provider default 'omp-sdk' only affects bare provider picks. ACCEPT 'omp-sdk' default
+   (matches theirs); fleet sessions always pass an explicit runtime.
+3. Structured-lanes dispatch: `relayOrSpawnPtyPanel` (ptyPanelDispatch.ts),
+   `resolvePanelLane`/`laneForPanel` (panelLane.ts), dispatch facade lane-based routing.
+4. `SessionAgentRuntime` widened by 'omp-sdk' (upstream) + 'omp-fleet' (ours) = 7 values.
+   `PanelLane` stays 6 (no omp-fleet) — fleet is not a panel lane.
+
+## Conflict resolutions
+### panelLane.ts — ADOPT THEIRS + one addition
+- Take theirs' 8-lane/6-PanelLane version wholesale.
+- ADD after `isPtyLane`:
+```ts
+/**
+ * True when the runtime is interactive BY CONSTRUCTION (a PTY lane whose
+ * provider carries no substrate axis of its own): `codex-pty`, `omp-pty`.
+ * `omp-fleet` is deliberately absent — a fleet session's substrate is decided
+ * by the usual ladder, not pinned to a terminal.
+ */
+const IMPLICITLY_INTERACTIVE_RUNTIMES = new Set<string>([
+  'codex-pty',
+  'omp-pty',
+]);
+
+export function isImplicitlyInteractiveRuntime(runtime: SessionAgentRuntime): boolean {
+  return IMPLICITLY_INTERACTIVE_RUNTIMES.has(runtime);
+}
+```
+- Update panelLane.test.ts: keep theirs' tests, ADD `expect(isImplicitlyInteractiveRuntime('codex-pty')).toBe(true)`,
+  same for 'omp-pty', and `toBe(false)` for 'omp-fleet', 'omp-sdk', 'codex-sdk'.
+
+### session.ts (14 conflicts) — adopt THEIRS structure, keep OURS fleet branches
+- C1 (372-418 explicitProvider label): adopt theirs (`AGENT_PROVIDER_LABELS[explicitProvider]`).
+- C2 (1203-1207 quickProvider runtime): adopt theirs (`QUICK_PROVIDER_SDK_RUNTIME[quickProvider]`).
+- C3 (1224-1257 resolved-runtime design): adopt theirs.
+- C4 (1283-1361 structured-lanes): adopt theirs. Fleet branch at ~1385
+  `} else if (useOmpFleet) {` auto-merged and MUST be kept (creates panel without PTY spawn).
+- C5 (ours 2048-2050 / theirs 1952-1982, sessions:input): adopt theirs' structured-lane input
+  routing, AND HOIST OURS' fleet early return ABOVE the `if (inputPtyLane)` block:
+```ts
+      const claudePanel = postCreateClaudePanels[0];
+      // Fleet sessions relay to the OMP worker, never into a PTY/SDK panel.
+      if (dbSession?.agent_runtime === 'omp-fleet') {
+        await routeOmpFleetTurn(services, dbSession, claudePanel.id, finalInput);
+        return { success: true };
+      }
+      const inputLane = resolvePanelLane(dbSession, claudePanel);
+      const inputPtyLane = quickPtyLanes.get(inputLane);
+      if (inputPtyLane) { ...theirs relay/spawn... return { success: true }; }
+```
+  (Ours' committed version nested the fleet check INSIDE `if (inputPtyLane)` — never fires for
+  fleet because their lane is structured. Hoisting is the merge fix, not a regression.)
+- C6 shared call site (1270-1271): replace `isPtyLane(nonClaudeQuickRuntime)` with
+  `isImplicitlyInteractiveRuntime(nonClaudeQuickRuntime)` — `omp-fleet` must map to 'sdk'.
+  (isPtyLane keeps `PanelLane` signature; its other call sites pass PanelLane.)
+- All other conflicts: adopt theirs, EXCEPT where a fleet-only branch was auto-merged
+  (grep `omp-fleet` in final file and verify each site compiles + behaves).
+
+### types.ts — theirs' structural imports + OmpSessionManager
+```ts
+import type { OmpSessionManager } from '../orchestrator/omp/ompSessionManager';
+import type {
+  CliManagerFactory,
+  CodexPtyManagerLike,
+  CodexSdkManagerLike,
+  OmpPtyManagerLike,
+  OmpSdkManagerLike,
+} from '../services/cliManagerFactory';
+```
+AppServices: keep ours' `ompSessionManager` field (index.ts:3618 passes it); adopt theirs'
+manager field types (structural Like interfaces).
+
+### ompSessionManager.ts — keep OURS (fleet bridge runtime); theirs' changes are
+for the omp-sdk/omp-pty managers (different files). Verify imports still resolve.
+
+### substrateResolver.ts — keep OURS if ours adds fleet mapping; else theirs. (check)
+
+### index.ts — adopt theirs + keep ours' fleet manager block (1559-1573) + AppServices wiring.
+
+### substrateDispatchFacade.ts — adopt theirs (lane-based); fleet never reaches it via a PTY lane.
+
+### createQuickSessionCore.ts — NO conflict. QUICK_PROVIDER_SDK_RUNTIME maps
+`omp: 'omp-sdk'`. The stamp (388-414) already resolved via ours: fleet stamps
+agent_runtime='omp-fleet', substrate = input.resolvedSubstrate (isPtyLane('omp-fleet')=false
+→ stays resolved). ⚠️ createQuickSessionCore:406 calls isPtyLane(resolvedSessionAgentRuntime)
+with a SessionAgentRuntime — SAME type error. Fix: use isImplicitlyInteractiveRuntime there too.
+
+### trpc/context.ts, trpc/router.ts, trpc/index.ts — ALREADY RESOLVED (Python, earlier).
+### ompRouter.ts, sessionRouter.ts, workflows.ts, appVersion.ts — inspect + resolve (theirs
+likely; verify no fleet references lost).
+
+## Verification
+- `git diff --check` clean; `grep -c '<<<<<<<'` = 0 in src (dist/ ignored).
+- `export PATH="/opt/homebrew/opt/node@22/bin:$PATH" && pnpm typecheck` + `pnpm lint`.
+- Scoped: `cd main && npx vitest run src/services/__tests__/panelLane.test.ts src/ipc/...` whatever
+  covers session.ts/panelLane.ts.
+- Fleet invariant checks (grep final session.ts):
+  1. fleet early return in sessions:input sits ABOVE `if (inputPtyLane)`.
+  2. fleet branch in create-quick fires BEFORE `resolvedSubstrate === 'interactive'` eager-spawn.
+  3. `isImplicitlyInteractiveRuntime` used at both SessionAgentRuntime-typed call sites
+     (session.ts:1271, createQuickSessionCore.ts:406).
+- Commit: `git commit -m "Merge kesteva/main: OMP/Codex provider+transport split alongside fleet runtime"`

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "lint": "eslint src --ext .ts,.tsx",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -b",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"

--- a/frontend/src/components/cyboflow/ABTestLaunchModal.tsx
+++ b/frontend/src/components/cyboflow/ABTestLaunchModal.tsx
@@ -88,6 +88,7 @@ function quickArmAgentRuntime(runtime: LaunchAgentRuntime): WorkflowAgentRuntime
   if (runtime === 'codex-pty') return 'codex-sdk';
   if (runtime === 'omp-pty') return 'omp-sdk';
   if (runtime === 'omp-fleet') return 'claude-sdk';
+  if (runtime === 'pi-pty') return 'pi-sdk';
   return runtime;
 }
 
@@ -111,6 +112,10 @@ const QUICK_ARM_MODEL_RESET: Readonly<Record<AgentProvider, string>> = {
   claude: DEFAULT_QUICK_MODEL,
   codex: DEFAULT_CODEX_MODEL,
   omp: '',
+  // Same no-pin rationale as OMP: pi's catalogue is concrete `provider/model`
+  // ids with no "let the runtime pick" sentinel, so the arm launches on the
+  // runtime's own default.
+  pi: '',
 };
 
 /**

--- a/frontend/src/components/cyboflow/SubstrateSelector.tsx
+++ b/frontend/src/components/cyboflow/SubstrateSelector.tsx
@@ -87,6 +87,22 @@ export const OMP_PTY_CAVEATS: readonly string[] = [
   'Approvals stay in the OMP CLI — no Cyboflow review-queue integration.',
 ];
 
+/**
+ * The v1 limits of the Pi structured (pi-sdk) lane. Headless and ungated:
+ * pi has no sandbox or approval-mode surface, so workflow steps run tools
+ * without a gate until the extension tool_call bridge ships.
+ */
+export const PI_SDK_CAVEATS: readonly string[] = [
+  'Tools run WITHOUT an approval gate in workflow steps (no sandbox yet) — run on worktrees you are watching.',
+  'No mid-turn steering: the next message queues until the current turn finishes.',
+  'Tool activity is not shown in the transcript; only final text per turn.',
+];
+
+/** The v1 limits of the Pi CLI (pi-pty) lane. */
+export const PI_PTY_CAVEATS: readonly string[] = [
+  'Approvals stay inside the pi TUI — no Cyboflow review-queue integration.',
+];
+
 interface SubstrateSelectorProps {
   value: LaunchAgentRuntime;
   onChange: (runtime: LaunchAgentRuntime) => void;
@@ -111,10 +127,21 @@ const RUNTIME_SCOPE_SUFFIXES: Partial<Record<LaunchAgentRuntime, string>> = {
   'claude-sdk': ' (default)',
   'codex-pty': ' — quick sessions only',
   'omp-fleet': ' — quick sessions only',
+  'pi-pty': ' — quick sessions only',
 };
 
 const RUNTIME_OPTIONS: readonly { runtime: LaunchAgentRuntime; label: string }[] = (
-  ['claude-sdk', 'claude-interactive', 'codex-sdk', 'codex-pty', 'omp-sdk', 'omp-pty', 'omp-fleet'] as const
+  [
+    'claude-sdk',
+    'claude-interactive',
+    'codex-sdk',
+    'codex-pty',
+    'omp-sdk',
+    'omp-pty',
+    'omp-fleet',
+    'pi-sdk',
+    'pi-pty',
+  ] as const
 ).map((runtime) => ({
   runtime,
   label: `${AGENT_RUNTIME_LABELS[runtime]}${RUNTIME_SCOPE_SUFFIXES[runtime] ?? ''}`,
@@ -379,6 +406,12 @@ export function SubstrateSelector({
       )}
       {value === 'omp-pty' && (
         <CaveatsPanel testId={caveatsTestId} title="OMP (CLI) — v1 limits" items={OMP_PTY_CAVEATS} />
+      )}
+      {value === 'pi-sdk' && (
+        <CaveatsPanel testId={caveatsTestId} title="Pi — v1 limits" items={PI_SDK_CAVEATS} />
+      )}
+      {value === 'pi-pty' && (
+        <CaveatsPanel testId={caveatsTestId} title="Pi (CLI) — v1 limits" items={PI_PTY_CAVEATS} />
       )}
     </div>
   );

--- a/frontend/src/components/cyboflow/SubstrateSelector.tsx
+++ b/frontend/src/components/cyboflow/SubstrateSelector.tsx
@@ -88,12 +88,14 @@ export const OMP_PTY_CAVEATS: readonly string[] = [
 ];
 
 /**
- * The v1 limits of the Pi structured (pi-sdk) lane. Headless and ungated:
- * pi has no sandbox or approval-mode surface, so workflow steps run tools
- * without a gate until the extension tool_call bridge ships.
+ * The v1 limits of the Pi structured (pi-sdk) lane. A tool_call gate enforces
+ * the session's permission mode inside the spawned process (read-only tools
+ * pass under default/acceptEdits/auto; everything passes only in dontAsk),
+ * but there is no interactive approval prompt yet — gated writes are BLOCKED,
+ * not queued for review.
  */
 export const PI_SDK_CAVEATS: readonly string[] = [
-  'Tools run WITHOUT an approval gate in workflow steps (no sandbox yet) — run on worktrees you are watching.',
+  'Write-tier tools are blocked unless the session permission mode is dontAsk — no interactive approval prompt yet.',
   'No mid-turn steering: the next message queues until the current turn finishes.',
   'Tool activity is not shown in the transcript; only final text per turn.',
 ];

--- a/frontend/src/components/cyboflow/VariantEditorModal.tsx
+++ b/frontend/src/components/cyboflow/VariantEditorModal.tsx
@@ -88,6 +88,7 @@ const VARIANT_RUNTIME_LABELS: Record<WorkflowAgentRuntime, string> = {
   'claude-interactive': AGENT_RUNTIME_LABELS['claude-interactive'],
   'codex-sdk': AGENT_RUNTIME_LABELS['codex-sdk'],
   'omp-sdk': AGENT_RUNTIME_LABELS['omp-sdk'],
+  'pi-sdk': AGENT_RUNTIME_LABELS['pi-sdk'],
 };
 
 export function VariantEditorModal({

--- a/frontend/src/components/cyboflow/WorkflowPicker.tsx
+++ b/frontend/src/components/cyboflow/WorkflowPicker.tsx
@@ -77,6 +77,9 @@ const PROVIDER_MODEL_FLOOR: Readonly<Record<AgentProvider, string>> = {
   claude: DEFAULT_WORKFLOW_MODEL,
   codex: DEFAULT_CODEX_MODEL,
   omp: '',
+  // Empty selection, for OMP's reason: pi has no "let the runtime pick"
+  // sentinel row.
+  pi: '',
 };
 
 /**

--- a/frontend/src/components/cyboflow/__tests__/SubstrateSelector.test.tsx
+++ b/frontend/src/components/cyboflow/__tests__/SubstrateSelector.test.tsx
@@ -183,7 +183,7 @@ describe('SubstrateSelector — provider access toggles', () => {
   });
 
   it('offers OMP Fleet when available and the omp provider is enabled', () => {
-    setProviderAccess({ claude: true, codex: true, omp: true });
+    setProviderAccess({ claude: true, codex: true, omp: true, pi: true });
     mockUseOmpAvailability.mockReturnValue({ launchable: true, ariaMode: true });
     render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
 
@@ -196,7 +196,7 @@ describe('SubstrateSelector — provider access toggles', () => {
   // Aria install with no OMP row at all — and the hidden-runtimes note counts
   // against the flavor list, so nothing on screen said why.
   it('offers OMP Fleet DISABLED, naming the reason, when Aria is on but no bridge is configured', () => {
-    setProviderAccess({ claude: true, codex: true, omp: true });
+    setProviderAccess({ claude: true, codex: true, omp: true, pi: true });
     mockUseOmpAvailability.mockReturnValue({ launchable: false, ariaMode: true });
     render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
 
@@ -209,7 +209,7 @@ describe('SubstrateSelector — provider access toggles', () => {
   });
 
   it('drops the reason once the bridge is configured', () => {
-    setProviderAccess({ claude: true, codex: true, omp: true });
+    setProviderAccess({ claude: true, codex: true, omp: true, pi: true });
     mockUseOmpAvailability.mockReturnValue({ launchable: true, ariaMode: true });
     render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
 
@@ -278,7 +278,7 @@ describe('SubstrateSelector — offers exactly the picker-selectable runtimes', 
   // of both flavors instead: nothing selectable may be unreachable in both
   // modes, and nothing unselectable may appear in either.
   it('offers, across both OMP flavors, exactly the selectable runtimes', () => {
-    setProviderAccess({ claude: true, codex: true, omp: true });
+    setProviderAccess({ claude: true, codex: true, omp: true, pi: true });
 
     mockUseOmpAvailability.mockReturnValue({ launchable: false, ariaMode: false });
     const local = render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
@@ -313,7 +313,7 @@ describe('SubstrateSelector — offers exactly the picker-selectable runtimes', 
     expect(offered).not.toContain('omp-pty');
     unmount();
 
-    setProviderAccess({ claude: true, codex: true, omp: true });
+    setProviderAccess({ claude: true, codex: true, omp: true, pi: true });
     render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
     offered = screen.getAllByRole('option').map((option) => option.getAttribute('value'));
     expect(offered).toContain('omp-sdk');
@@ -326,7 +326,7 @@ describe('SubstrateSelector — offers exactly the picker-selectable runtimes', 
   // set actually reaches the workflow scope rather than the two OMP rows being
   // treated alike because they share a provider.
   it('enables omp-sdk but disables omp-pty on a workflow launch', () => {
-    setProviderAccess({ claude: true, codex: true, omp: true });
+    setProviderAccess({ claude: true, codex: true, omp: true, pi: true });
     render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="workflow" />);
 
     expect(screen.getByRole('option', { name: 'OMP' })).not.toBeDisabled();
@@ -338,7 +338,7 @@ describe('SubstrateSelector — offers exactly the picker-selectable runtimes', 
   });
 
   it('leaves both OMP rows selectable on a quick session', () => {
-    setProviderAccess({ claude: true, codex: true, omp: true });
+    setProviderAccess({ claude: true, codex: true, omp: true, pi: true });
     render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
 
     expect(screen.getByRole('option', { name: 'OMP' })).not.toBeDisabled();
@@ -353,7 +353,7 @@ describe('SubstrateSelector — offers exactly the picker-selectable runtimes', 
     // Availability probe ON — without it the selectable omp-fleet row would be
     // availability-hidden and spuriously read as a provider-toggle removal.
     mockUseOmpAvailability.mockReturnValue({ launchable: true, ariaMode: true });
-    setProviderAccess({ claude: true, codex: true, omp: true });
+    setProviderAccess({ claude: true, codex: true, omp: true, pi: true });
     render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
 
     expect(screen.queryByText(/are hidden/i)).not.toBeInTheDocument();
@@ -363,7 +363,7 @@ describe('SubstrateSelector — offers exactly the picker-selectable runtimes', 
   // Aria mode always hides one OMP flavor, and counting that against the full
   // selectable list would fire the note permanently with the wrong explanation.
   it('does not claim runtimes are hidden merely because a flavor is inactive', () => {
-    setProviderAccess({ claude: true, codex: true, omp: true });
+    setProviderAccess({ claude: true, codex: true, omp: true, pi: true });
 
     mockUseOmpAvailability.mockReturnValue({ launchable: false, ariaMode: false });
     const local = render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
@@ -383,7 +383,7 @@ describe('SubstrateSelector — offers exactly the picker-selectable runtimes', 
   // the reason, so the state is self-describing.
   it('offers the fleet row disabled, and still no local rows, when the fleet is not launchable', () => {
     mockUseOmpAvailability.mockReturnValue({ launchable: false, ariaMode: true });
-    setProviderAccess({ claude: true, codex: true, omp: true });
+    setProviderAccess({ claude: true, codex: true, omp: true, pi: true });
     render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
 
     const offered = screen.getAllByRole('option').map((o) => o.getAttribute('value'));

--- a/frontend/src/components/onboarding/steps/DefaultRuntimeStep.tsx
+++ b/frontend/src/components/onboarding/steps/DefaultRuntimeStep.tsx
@@ -32,6 +32,7 @@ const PROVIDER_BLURBS: Record<AgentProvider, string> = {
   claude: 'Structured SDK sessions with full approval routing and step tracking.',
   codex: 'ChatGPT-authenticated runtime, billed against your existing plan.',
   omp: 'Multi-provider runtime — see its v1 limits in the launch wizard.',
+  pi: 'The terminal coding agent OMP forked from — multi-provider models via its own accounts.',
 };
 
 export function DefaultRuntimeStep({

--- a/frontend/src/components/settings/IntegrationsSettings.test.tsx
+++ b/frontend/src/components/settings/IntegrationsSettings.test.tsx
@@ -10,6 +10,7 @@ import { IntegrationsSettings } from './IntegrationsSettings';
 const detectClaude = vi.fn();
 const detectCodex = vi.fn();
 const detectOmp = vi.fn();
+const detectPi = vi.fn();
 const { mockUseOmpAvailability } = vi.hoisted(() => ({ mockUseOmpAvailability: vi.fn() }));
 vi.mock('../../hooks/useOmpAvailability', () => ({ useOmpAvailability: mockUseOmpAvailability }));
 
@@ -17,7 +18,13 @@ vi.mock('../../utils/api', () => ({
   API: {
     providers: {
       detect: (provider: string) =>
-        provider === 'claude' ? detectClaude() : provider === 'codex' ? detectCodex() : detectOmp(),
+        provider === 'claude'
+          ? detectClaude()
+          : provider === 'codex'
+            ? detectCodex()
+            : provider === 'pi'
+              ? detectPi()
+              : detectOmp(),
     },
   },
 }));
@@ -53,6 +60,12 @@ const OMP_MISSING: ProviderDetectionResult<'omp'> = {
   version: null,
 };
 
+const PI_DETECTED: ProviderDetectionResult<'pi'> = {
+  state: 'detected',
+  binaryPath: '/usr/local/bin/pi',
+  version: '0.84.2',
+};
+
 const OMP_UNSUPPORTED_VERSION: ProviderDetectionResult<'omp'> = {
   state: 'unavailable',
   binaryPath: '/usr/local/bin/omp',
@@ -65,6 +78,7 @@ beforeEach(() => {
   detectClaude.mockReset().mockResolvedValue({ success: true, data: CLAUDE_CONNECTED });
   detectCodex.mockReset().mockResolvedValue({ success: true, data: CODEX_CONNECTED });
   detectOmp.mockReset().mockResolvedValue({ success: true, data: OMP_MISSING });
+  detectPi.mockReset().mockResolvedValue({ success: true, data: PI_DETECTED });
   updateConfig = vi.fn().mockResolvedValue(true);
   // Default install: OMP runs locally, so the row reports the local binary.
   mockUseOmpAvailability.mockReset().mockReturnValue({ launchable: false, ariaMode: false });
@@ -78,7 +92,7 @@ describe('IntegrationsSettings', () => {
     expect(await screen.findByText('claude@example.com')).toBeInTheDocument();
     expect(await screen.findByText('codex@example.com')).toBeInTheDocument();
     expect(screen.getByText(/ChatGPT plus · Codex 0\.144\.3/)).toBeInTheDocument();
-    expect(screen.getAllByText('Connected')).toHaveLength(2);
+    expect(screen.getAllByText('Connected')).toHaveLength(2); // pi's connected label is 'Detected'
   });
 
   it('keeps a connected provider usable when its sibling needs sign-in', async () => {
@@ -167,7 +181,7 @@ describe('IntegrationsSettings — provider access toggles', () => {
     // omp: true so ONLY the Claude row is disabled here — otherwise OMP's
     // own (identical) "hidden from every runtime picker" hint would collide
     // with Claude's and make findByText ambiguous.
-    setProviderAccess({ claude: false, codex: true, omp: true });
+    setProviderAccess({ claude: false, codex: true, omp: true, pi: true });
     render(<IntegrationsSettings />);
 
     expect(await screen.findByText(/hidden from every runtime picker/i)).toBeInTheDocument();
@@ -319,7 +333,9 @@ describe('IntegrationsSettings — OMP row under Aria mode', () => {
 
     render(<IntegrationsSettings />);
 
-    expect(await screen.findByText('Detected')).toBeInTheDocument();
+    // Pi's row uses the same 'Detected' label, so assert on the COLLECTION
+    // rather than a unique match.
+    expect((await screen.findAllByText('Detected')).length).toBeGreaterThanOrEqual(1);
     expect(screen.queryByText(/Fleet (not )?detected/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/settings/IntegrationsSettings.tsx
+++ b/frontend/src/components/settings/IntegrationsSettings.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import { Bot, Code2, ExternalLink, RefreshCw, Boxes } from 'lucide-react';
+import { Bot, Code2, ExternalLink, RefreshCw, Boxes, Terminal } from 'lucide-react';
 import type { AgentProvider, AgentProviderAccess } from '../../../../shared/types/agentRuntime';
 import { AGENT_PROVIDERS, isAgentProviderEnabled } from '../../../../shared/types/agentRuntime';
 import type { ProviderDetectionResult } from '../../../../shared/types/onboarding';
@@ -292,13 +292,57 @@ function responseError(provider: string, error?: string): string {
   return error?.trim() || `Cyboflow could not check ${provider}.`;
 }
 
+
+/**
+ * The Pi row's status — OMP's local-binary branch verbatim (pi holds its own
+ * credentials, so binary presence + version is all Cyboflow can see), with an
+ * npm install hint instead of the omp.sh script.
+ */
+function piView(
+  detection: ProviderDetectionResult<'pi'> | null,
+  error: string | null,
+): ProviderViewModel {
+  if (error) {
+    return { status: 'unavailable', label: 'Check failed', detail: error };
+  }
+  if (!detection) {
+    return { status: 'checking', label: 'Checking', detail: 'Looking for a pi binary on this machine.' };
+  }
+  if (detection.state === 'unavailable') {
+    if (detection.binaryPath !== null) {
+      return {
+        status: 'unavailable',
+        label: 'Unsupported version',
+        detail: detection.version
+          ? `Found pi ${detection.version}, but this version isn't supported.`
+          : "Found a pi binary, but its version couldn't be verified.",
+        metadata: detection.binaryPath,
+      };
+    }
+    return {
+      status: 'unavailable',
+      label: 'Not available',
+      detail: 'pi was not found on this machine.',
+    };
+  }
+  return {
+    status: 'connected',
+    label: 'Detected',
+    detail: detection.version ? `pi ${detection.version}` : 'pi binary found',
+    metadata: detection.binaryPath ?? undefined,
+  };
+}
+
+
 export function IntegrationsSettings(): React.JSX.Element {
   const [claudeDetection, setClaudeDetection] = useState<ProviderDetectionResult<'claude'> | null>(null);
   const [codexDetection, setCodexDetection] = useState<ProviderDetectionResult<'codex'> | null>(null);
   const [ompDetection, setOmpDetection] = useState<ProviderDetectionResult<'omp'> | null>(null);
+  const [piDetection, setPiDetection] = useState<ProviderDetectionResult<'pi'> | null>(null);
   const [claudeError, setClaudeError] = useState<string | null>(null);
   const [codexError, setCodexError] = useState<string | null>(null);
   const [ompError, setOmpError] = useState<string | null>(null);
+  const [piError, setPiError] = useState<string | null>(null);
   const [checking, setChecking] = useState(true);
   const requestId = useRef(0);
 
@@ -308,11 +352,13 @@ export function IntegrationsSettings(): React.JSX.Element {
     setClaudeError(null);
     setCodexError(null);
     setOmpError(null);
+    setPiError(null);
 
-    const [claudeResult, codexResult, ompResult] = await Promise.allSettled([
+    const [claudeResult, codexResult, ompResult, piResult] = await Promise.allSettled([
       API.providers.detect('claude'),
       API.providers.detect('codex'),
       API.providers.detect('omp'),
+      API.providers.detect('pi'),
     ]);
     if (currentRequest !== requestId.current) return;
 
@@ -343,6 +389,15 @@ export function IntegrationsSettings(): React.JSX.Element {
       setOmpError(responseError('OMP', message));
     }
 
+    if (piResult.status === 'fulfilled' && piResult.value.success && piResult.value.data) {
+      setPiDetection(piResult.value.data);
+    } else {
+      const message = piResult.status === 'rejected'
+        ? piResult.reason instanceof Error ? piResult.reason.message : undefined
+        : piResult.value.error;
+      setPiError(responseError('Pi', message));
+    }
+
     setChecking(false);
   }, []);
 
@@ -368,6 +423,7 @@ export function IntegrationsSettings(): React.JSX.Element {
   const codex = codexView(codexDetection, codexError);
   const ompAvailability = useOmpAvailability();
   const omp = ompView(ompDetection, ompError, ompAvailability);
+  const pi = piView(piDetection, piError);
 
   // Provider access — the toggles below write AppConfig.agentProviderAccess,
   // the same field the onboarding Connect step writes, so the two surfaces are
@@ -381,10 +437,14 @@ export function IntegrationsSettings(): React.JSX.Element {
   // unlike claude/codex — isAgentProviderEnabled already applies that per-
   // provider default, so this reads correctly with no special-casing here.
   const ompEnabled = isAgentProviderEnabled(providerAccess, 'omp');
+  // Pi floors to DISABLED on an absent key, same as omp — the registry's
+  // defaultEnabled policy is applied inside isAgentProviderEnabled.
+  const piEnabled = isAgentProviderEnabled(providerAccess, 'pi');
   const enabledByProvider: Record<AgentProvider, boolean> = {
     claude: claudeEnabled,
     codex: codexEnabled,
     omp: ompEnabled,
+    pi: piEnabled,
   };
   const [savingProvider, setSavingProvider] = useState<AgentProvider | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -408,7 +468,7 @@ export function IntegrationsSettings(): React.JSX.Element {
       }
       setSavingProvider(null);
     },
-    [claudeEnabled, codexEnabled, ompEnabled],
+    [claudeEnabled, codexEnabled, ompEnabled, piEnabled],
   );
 
   // Guard rail mirroring onboarding's "enable at least one detected provider":
@@ -482,6 +542,16 @@ export function IntegrationsSettings(): React.JSX.Element {
               </Button>
             ) : undefined}
           />
+          <ProviderRow
+            name="Pi"
+            description="The terminal coding agent OMP forked from — multi-provider models via its own accounts; Cyboflow only detects the binary."
+            icon={<Terminal className="h-4 w-4" />}
+            view={pi}
+            enabled={piEnabled}
+            onToggle={(next) => void setProviderEnabled('pi', next)}
+            toggleDisabledReason={toggleReason('pi', piEnabled)}
+            toggleTestId="provider-toggle-pi"
+          />
         </div>
 
         {saveError && (
@@ -500,6 +570,14 @@ export function IntegrationsSettings(): React.JSX.Element {
             OMP is off by default — turn it on here once you've installed it and signed in
             (run <code className="border border-border-primary bg-bg-primary px-1">omp</code> in a
             terminal and <code className="border border-border-primary bg-bg-primary px-1">/login &lt;provider&gt;</code>).
+          </p>
+        )}
+        {!piEnabled && (
+          <p className="mt-3 text-xs leading-relaxed text-text-tertiary">
+            Pi is off by default — turn it on once you've installed it and signed in
+            (run <code className="border border-border-primary bg-bg-primary px-1">pi</code> in a
+            terminal and use <code className="border border-border-primary bg-bg-primary px-1">/login</code>{' '}
+            or <code className="border border-border-primary bg-bg-primary px-1">--api-key</code>).
           </p>
         )}
       </SettingsSection>

--- a/frontend/src/components/settings/__tests__/RunTypeOverridesSection.test.tsx
+++ b/frontend/src/components/settings/__tests__/RunTypeOverridesSection.test.tsx
@@ -997,6 +997,8 @@ describe('RunTypeOverridesSection — detail screen', () => {
       'Codex (CLI)',
       'OMP',
       'OMP (CLI)',
+      'Pi',
+      'Pi (CLI)',
     ]);
 
     // The stored value is untouched by the flavor filter: nothing was saved
@@ -1025,6 +1027,8 @@ describe('RunTypeOverridesSection — detail screen', () => {
         'Codex SDK',
         'Codex (CLI)',
         'OMP fleet',
+        'Pi',
+        'Pi (CLI)',
       ]),
     );
   });
@@ -1060,7 +1064,7 @@ describe('RunTypeOverridesSection — detail screen', () => {
     // STRUCTURED runtime and no terminal one, which is the launchable set.
     expect(
       within(within(card).getByLabelText('Agent runtime')).getAllByRole('option').map((o) => o.textContent),
-    ).toEqual(['Follow defaults', 'Claude SDK', 'Claude Interactive (CLI)', 'Codex SDK', 'OMP']);
+    ).toEqual(['Follow defaults', 'Claude SDK', 'Claude Interactive (CLI)', 'Codex SDK', 'OMP', 'Pi']);
   });
 
   // AC 5 + AC 6 — a stale key is not just VISIBLE, it is operable: being able to

--- a/frontend/src/components/settings/__tests__/SessionSettings.test.tsx
+++ b/frontend/src/components/settings/__tests__/SessionSettings.test.tsx
@@ -462,7 +462,7 @@ describe('SessionSettings', () => {
     it('renders the built-in-default state and every OFFERABLE session runtime', () => {
       // All three providers switched on, so the capability filter is the only
       // thing deciding which session runtimes get a button.
-      renderGroup({ agentProviderAccess: { claude: true, codex: true, omp: true } });
+      renderGroup({ agentProviderAccess: { claude: true, codex: true, omp: true, pi: true } });
 
       expect(screen.getByTestId('default-agent-runtime-unset')).toHaveAttribute('aria-pressed', 'true');
       // Session membership is necessary but not sufficient: the control shows a

--- a/frontend/src/components/settings/__tests__/runTypeOverrides.test.ts
+++ b/frontend/src/components/settings/__tests__/runTypeOverrides.test.ts
@@ -871,6 +871,7 @@ describe('global-rung runtime-family coercion (Default Launch Model / Agent Runt
       'gpt-5',
       'anthropic/claude-opus-4-5',
       'openrouter/qwen3-coder',
+      'google/gemini-3-flash',
       '',
     ];
     for (const runtime of [undefined, ...SESSION_AGENT_RUNTIMES] as const) {
@@ -881,8 +882,9 @@ describe('global-rung runtime-family coercion (Default Launch Model / Agent Runt
         expect(
           provider === 'codex'
             ? isCodexModelSelection(coerced)
-            : provider === 'omp'
-              ? isOmpModelFamily(coerced)
+            : provider === 'omp' || provider === 'pi'
+              ? // Pi shares OMP's slashed-family rule (same predicate).
+                isOmpModelFamily(coerced)
               : !isCodexModelFamily(coerced) && !isOmpModelFamily(coerced),
         ).toBe(true);
         // Idempotent: re-coercing a coerced value changes nothing.

--- a/frontend/src/components/settings/runTypeOverrides.ts
+++ b/frontend/src/components/settings/runTypeOverrides.ts
@@ -631,6 +631,14 @@ export function coerceModelForRuntime(
       if (isOmpModelFamily(model)) return model;
       return isOmpModelFamily(fallbackModel) ? fallbackModel : null;
     }
+    case 'pi': {
+      // Pi selections are `${provider}/${model}` pairs sharing OMP's slash
+      // rule (the predicates are deliberately the same function), so the
+      // coercion is OMP's verbatim.
+      if (model === null) return null;
+      if (isOmpModelFamily(model)) return model;
+      return isOmpModelFamily(fallbackModel) ? fallbackModel : null;
+    }
     case 'claude': {
       if (model === null) return null;
       if (isClaudeUsableModel(model)) return model;

--- a/frontend/src/hooks/useClaudePanel.ts
+++ b/frontend/src/hooks/useClaudePanel.ts
@@ -30,9 +30,13 @@ export async function dispatchQuickSessionInput(
   // panel-scoped panels:continue. omp-pty mirrors codex-pty the same way for the
   // panel-substrate-override case.
   const isStructuredSdkPanel =
-    session.agentRuntime === 'codex-sdk' || session.agentRuntime === 'omp-sdk'
+    session.agentRuntime === 'codex-sdk' ||
+    session.agentRuntime === 'omp-sdk' ||
+    session.agentRuntime === 'pi-sdk'
       ? panelSubstrate !== 'interactive'
-      : (session.agentRuntime === 'codex-pty' || session.agentRuntime === 'omp-pty') &&
+      : (session.agentRuntime === 'codex-pty' ||
+           session.agentRuntime === 'omp-pty' ||
+           session.agentRuntime === 'pi-pty') &&
         panelSubstrate === 'sdk';
 
   if (isStructuredSdkPanel) {

--- a/frontend/src/stores/providerModelCatalogStore.ts
+++ b/frontend/src/stores/providerModelCatalogStore.ts
@@ -89,6 +89,11 @@ export const PROVIDER_MODEL_CATALOG_SLICES: {
   // (Phase 1, §5.1). `ensureStarted(enabled)` means nothing is fetched until a
   // picker actually shows OMP, which none does while the provider is off.
   omp: createCatalogSlice('omp'),
+  // Generic by construction, same as OMP's row: the slice needs no per-
+  // provider code, so Pi gets a working store the moment its
+  // `models:get-catalog` fetcher returns real rows. Nothing is fetched until
+  // a picker actually shows Pi.
+  pi: createCatalogSlice('pi'),
 };
 
 export interface ProviderModelCatalogHook<P extends AgentProvider> {

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -87,6 +87,10 @@ const CATALOG_BRIDGE_FALLBACKS: {
   // discovered list — no pinned aliases to fall back on — so an empty catalog
   // would be a silently broken control rather than a degraded one.
   omp: null,
+  // OMP's answer for Pi's reason too: a Pi picker has nothing but the
+  // discovered `${provider}/${model}` list — no pinned aliases — so an empty
+  // catalog would be a silently broken control rather than a degraded one.
+  pi: null,
 };
 
 // Wrapper class for API calls that provides error handling and consistent interface

--- a/main/src/database/__tests__/migration103.test.ts
+++ b/main/src/database/__tests__/migration103.test.ts
@@ -221,8 +221,10 @@ describe('Migration 103: widened provider/runtime CHECK constraints', () => {
   it('(d) accepts omp values on every table and still rejects a bogus one', () => {
     const { db, svc } = upgradeThrough103();
 
-    // sessions: both OMP runtimes (quick sessions can run the OMP TUI).
-    for (const runtime of ['omp-sdk', 'omp-pty']) {
+    // sessions: all three OMP runtimes — the two OMP transports PLUS the fleet
+    // supervisor carried forward from 101 (a dropped 'omp-fleet' in 103's
+    // re-add would brick every upgraded fleet session).
+    for (const runtime of ['omp-sdk', 'omp-pty', 'omp-fleet']) {
       expect(() =>
         db
           .prepare(
@@ -241,13 +243,23 @@ describe('Migration 103: widened provider/runtime CHECK constraints', () => {
         .run(),
     ).toThrow(/CHECK constraint failed/i);
 
-    // workflow_runs: omp-sdk only.
+    // workflow_runs: omp-sdk only — PLUS 'omp-fleet', never a launch target but
+    // the storable identity of a fleet quick session's sentinel row.
     expect(() =>
       db
         .prepare(
           `INSERT INTO workflow_runs (id, workflow_id, project_id, status, permission_mode_snapshot,
                                       agent_provider, agent_runtime)
            VALUES ('run-omp', 'wf-1', 1, 'running', 'default', 'omp', 'omp-sdk')`,
+        )
+        .run(),
+    ).not.toThrow();
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO workflow_runs (id, workflow_id, project_id, status, permission_mode_snapshot,
+                                     agent_provider, agent_runtime)
+           VALUES ('run-fleet', 'wf-1', 1, 'running', 'default', 'omp', 'omp-fleet')`,
         )
         .run(),
     ).not.toThrow();

--- a/main/src/database/__tests__/migration123.test.ts
+++ b/main/src/database/__tests__/migration123.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Migration 123_widen_agent_runtime_pi.sql — admitting the pi runtimes.
+ *
+ * The regression this file exists to prevent: an earlier attempt shipped the
+ * widening as a NEW file numbered 101 (a gap below the already-released 103)
+ * that rebuilt `sessions` from a hardcoded CREATE TABLE. Because the migration
+ * ledger is keyed by FILENAME, that file ran LAST on an already-migrated DB
+ * rather than in its numeric position — against a post-103/104 schema — where
+ * it (a) dropped every column its hardcoded list omitted and (b) restated 103's
+ * CHECK lists from memory, silently UN-widening 'omp-sdk'/'omp-pty'.
+ *
+ * So the tests below run the REAL upgrade a shipped-release user performs: a DB is built
+ * by a DatabaseService whose migrations dir omits 123 ONLY (103 and 104 are
+ * present, exactly as they are on a shipped install), rows are seeded, and a
+ * second DatabaseService pointed at the full dir boots on the same file.
+ *
+ * Proves:
+ *   1. 'omp-fleet' becomes storable on sessions and workflow_runs.
+ *   2. 103's widenings SURVIVE — 'omp-sdk'/'omp-pty' stay storable on sessions.
+ *   3. Every pre-existing row survives verbatim, INCLUDING a seeded omp-sdk
+ *      session (the row shape that made the 101 attempt fail closed forever).
+ *   4. No column is lost — in particular `status_message`, which database.ts
+ *      adds imperatively and no .sql file lists.
+ *   5. Indexes, triggers and FK edges are unchanged and foreign_key_check clean.
+ *   6. The deliberate narrowings hold: omp-fleet is rejected on the two tables
+ *      123 does not widen, and a bogus runtime is still rejected everywhere.
+ *   7. The fresh-install path lands the same constraints.
+ *   8. Re-applying 123 after a cleared ledger marker is a harmless no-op.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type BetterSqlite3 from 'better-sqlite3';
+import { mkdtempSync, rmSync, readdirSync, copyFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseService } from '../database';
+
+const MIGRATIONS_DIR = join(__dirname, '..', 'migrations');
+const MIGRATION_123 = '123_widen_agent_runtime_pi.sql';
+
+let tmpDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cyboflow-migration123-'));
+  dbPath = join(tmpDir, 'test.db');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/**
+ * A migrations dir holding every real migration EXCEPT 123 — i.e. a shipped
+ * 0.2.3 install, with 103 and 104 already applied. This is the distinction that
+ * matters: excluding everything at-or-above the new file's number (as the 101
+ * attempt's own test did) fabricates a pre-state that no user is ever in.
+ */
+function migrationsDirWithout123(): string {
+  const dir = join(tmpDir, 'migrations-pre-123');
+  mkdirSync(dir);
+  for (const name of readdirSync(MIGRATIONS_DIR)) {
+    if (name === MIGRATION_123) continue;
+    if (!/^\d{3}_.*\.sql$/.test(name)) continue;
+    copyFileSync(join(MIGRATIONS_DIR, name), join(dir, name));
+  }
+  return dir;
+}
+
+function openAt(migrationsDir: string): DatabaseService {
+  const svc = new DatabaseService(dbPath);
+  svc.setMigrationsDirForTesting(migrationsDir);
+  svc.initialize();
+  return svc;
+}
+
+/** Seed the rows a 0.2.3 OMP user actually has, plus the legacy baseline. */
+function seedRows(db: BetterSqlite3.Database): void {
+  db.prepare(`INSERT INTO projects (id, name, path) VALUES (1, 'Proj', '/tmp/p123')`).run();
+  db.prepare(
+    `INSERT INTO workflows (id, project_id, name, spec_json) VALUES ('wf-1', 1, 'sprint', '{}')`,
+  ).run();
+
+  const insertSession = db.prepare(
+    `INSERT INTO sessions (id, name, initial_prompt, worktree_name, worktree_path, project_id,
+                           status_message, agent_provider, agent_runtime)
+     VALUES (?, ?, 'go', ?, ?, 1, ?, ?, ?)`,
+  );
+  insertSession.run('s-claude', 'Claude', 'wt-1', '/tmp/wt-1', 'Waiting', 'claude', 'claude-sdk');
+  insertSession.run('s-codex-pty', 'Codex TUI', 'wt-2', '/tmp/wt-2', null, 'codex', 'codex-pty');
+  // The row that made the 101 attempt fail closed on every boot, forever.
+  insertSession.run('s-omp-sdk', 'OMP', 'wt-3', '/tmp/wt-3', 'Running', 'omp', 'omp-sdk');
+  insertSession.run('s-omp-pty', 'OMP TUI', 'wt-4', '/tmp/wt-4', null, 'omp', 'omp-pty');
+
+  const insertRun = db.prepare(
+    `INSERT INTO workflow_runs (id, workflow_id, project_id, status, permission_mode_snapshot,
+                                agent_provider, agent_runtime)
+     VALUES (?, 'wf-1', 1, 'completed', 'default', ?, ?)`,
+  );
+  insertRun.run('run-claude', 'claude', 'claude-sdk');
+  insertRun.run('run-omp', 'omp', 'omp-sdk');
+
+  // The ONE table 123 recreates via DROP TABLE — seed it so the snapshot
+  // proves row/column/index/FK survival through the recreate.
+  db.prepare(
+    `INSERT INTO agent_invocations (agent_invocation_id, run_id, step_id, agent_provider, agent_runtime)
+     VALUES ('inv-seed-1', 'run-claude', 'step-1', 'codex', 'codex-sdk')`,
+  ).run();
+  db.prepare(
+    `INSERT INTO agent_invocations (agent_invocation_id, run_id, step_id, agent_provider, agent_runtime, panel_id)
+     VALUES ('inv-seed-2', 'run-claude', 'step-2', 'omp', 'omp-pty', 'panel-7')`,
+  ).run();
+}
+
+function allRows(db: BetterSqlite3.Database, table: string): Array<Record<string, unknown>> {
+  return db.prepare(`SELECT * FROM ${table} ORDER BY rowid`).all() as Array<Record<string, unknown>>;
+}
+
+function columnNames(db: BetterSqlite3.Database, table: string): string[] {
+  return (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>)
+    .map((c) => c.name)
+    .sort();
+}
+
+function schemaObjectNames(db: BetterSqlite3.Database, table: string): string[] {
+  return (
+    db
+      .prepare(
+        `SELECT name FROM sqlite_master
+          WHERE tbl_name = ? AND type IN ('index','trigger','view')
+          ORDER BY name`,
+      )
+      .all(table) as Array<{ name: string }>
+  ).map((r) => r.name);
+}
+
+function fkEdges(db: BetterSqlite3.Database, table: string): string[] {
+  return (
+    db.prepare(`PRAGMA foreign_key_list(${table})`).all() as Array<{
+      table: string;
+      from: string;
+      to: string | null;
+      on_delete: string;
+    }>
+  )
+    .map((fk) => `${table}.${fk.from} -> ${fk.table}.${fk.to} ON DELETE ${fk.on_delete}`)
+    .sort();
+}
+
+interface Snapshot {
+  rows: Record<string, Array<Record<string, unknown>>>;
+  columns: Record<string, string[]>;
+  objects: Record<string, string[]>;
+  fks: Record<string, string[]>;
+}
+
+const TARGET_TABLES = ['sessions', 'workflow_runs', 'agent_invocations'] as const;
+
+function snapshot(db: BetterSqlite3.Database): Snapshot {
+  const snap: Snapshot = { rows: {}, columns: {}, objects: {}, fks: {} };
+  for (const t of TARGET_TABLES) {
+    snap.rows[t] = allRows(db, t);
+    snap.columns[t] = columnNames(db, t);
+    snap.objects[t] = schemaObjectNames(db, t);
+    snap.fks[t] = fkEdges(db, t);
+  }
+  return snap;
+}
+
+/** Migrate to the shipped pre-123 state, seed, snapshot; then boot with 123. */
+function upgradeThrough123(): { db: BetterSqlite3.Database; before: Snapshot; svc: DatabaseService } {
+  const pre123 = migrationsDirWithout123();
+  // Two pre-123 boots, not one: initializeSchema() reads PRAGMA table_info(sessions)
+  // before schema.sql has created the table, so its imperative
+  // "ALTER TABLE sessions ADD COLUMN status_message" only lands on the SECOND
+  // launch. Settling that here keeps the snapshot diff about 123 alone — and
+  // makes `status_message` present in the pre-state, which is the whole point.
+  openAt(pre123).close();
+  const pre = openAt(pre123);
+  seedRows(pre.getDb());
+  const before = snapshot(pre.getDb());
+  pre.close();
+
+  const svc = openAt(MIGRATIONS_DIR);
+  return { db: svc.getDb(), before, svc };
+}
+
+/** Insert a session with the given runtime; return the SQLite error, if any. */
+function trySession(db: BetterSqlite3.Database, id: string, provider: string, runtime: string): string | null {
+  try {
+    db.prepare(
+      `INSERT INTO sessions (id, name, initial_prompt, worktree_name, worktree_path,
+                             agent_provider, agent_runtime)
+       VALUES (?, ?, 'go', ?, ?, ?, ?)`,
+    ).run(id, id, `wt-${id}`, `/tmp/${id}`, provider, runtime);
+    return null;
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+}
+
+function tryRun(db: BetterSqlite3.Database, id: string, provider: string, runtime: string): string | null {
+  try {
+    db.prepare(
+      `INSERT INTO workflow_runs (id, workflow_id, project_id, status, permission_mode_snapshot,
+                                  agent_provider, agent_runtime)
+       VALUES (?, 'wf-1', 1, 'running', 'default', ?, ?)`,
+    ).run(id, provider, runtime);
+    return null;
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+}
+
+describe('Migration 123: the native pi runtimes admitted on sessions + workflow_runs', () => {
+  it('(a) makes the fleet and pi runtimes storable on sessions and workflow_runs', () => {
+    const { db, svc } = upgradeThrough123();
+    expect(trySession(db, 's-fleet', 'omp', 'omp-fleet')).toBeNull();
+    expect(trySession(db, 's-pi-sdk', 'pi', 'pi-sdk')).toBeNull();
+    expect(trySession(db, 's-pi-pty', 'pi', 'pi-pty')).toBeNull();
+    expect(tryRun(db, 'run-pi', 'pi', 'pi-sdk')).toBeNull();
+    svc.close();
+  });
+
+  it("(b) preserves 103's widenings — omp-sdk and omp-pty stay storable on sessions", () => {
+    const { db, svc } = upgradeThrough123();
+    expect(trySession(db, 's-new-omp-sdk', 'omp', 'omp-sdk')).toBeNull();
+    expect(trySession(db, 's-new-omp-pty', 'omp', 'omp-pty')).toBeNull();
+    expect(tryRun(db, 'run-new-omp-sdk', 'omp', 'omp-sdk')).toBeNull();
+    svc.close();
+  });
+
+  it('(c) preserves every pre-existing row verbatim, including the omp-sdk session', () => {
+    const { db, before, svc } = upgradeThrough123();
+    for (const t of TARGET_TABLES) {
+      expect(allRows(db, t)).toEqual(before.rows[t]);
+    }
+    const ompRow = allRows(db, 'sessions').find((r) => r.id === 's-omp-sdk');
+    expect(ompRow?.agent_runtime).toBe('omp-sdk');
+    expect(ompRow?.status_message).toBe('Running');
+    svc.close();
+  });
+
+  it('(d) loses no column — status_message (added imperatively, listed in no .sql) survives', () => {
+    const { db, before, svc } = upgradeThrough123();
+    for (const t of TARGET_TABLES) {
+      expect(columnNames(db, t)).toEqual(before.columns[t]);
+    }
+    expect(columnNames(db, 'sessions')).toContain('status_message');
+    // The temp parking columns must not leak into the final shape.
+    expect(columnNames(db, 'sessions')).not.toContain('agent_runtime_widen_123');
+    expect(columnNames(db, 'workflow_runs')).not.toContain('agent_runtime_widen_123');
+    svc.close();
+  });
+
+  it('(e) leaves indexes, triggers and foreign keys untouched', () => {
+    const { db, before, svc } = upgradeThrough123();
+    for (const t of TARGET_TABLES) {
+      expect(schemaObjectNames(db, t)).toEqual(before.objects[t]);
+      expect(fkEdges(db, t)).toEqual(before.fks[t]);
+    }
+    expect(db.prepare('PRAGMA foreign_key_check').all()).toEqual([]);
+    svc.close();
+  });
+
+  it('(f) variants admit pi-sdk but reject pi-pty; invocations admit both; bogus rejected', () => {
+    const { db, svc } = upgradeThrough123();
+    // workflow_variants mirrors the LAUNCHABLE list: pi-sdk in, pi-pty out.
+    db.prepare(
+      `INSERT INTO workflow_variants (id, workflow_id, label, agent_provider, agent_runtime)
+       VALUES ('wfv-pi', 'wf-1', 'pi-arm', 'pi', 'pi-sdk')`,
+    ).run();
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO workflow_variants (id, workflow_id, label, agent_provider, agent_runtime)
+           VALUES ('wfv-pty', 'wf-1', 'pty-arm', 'pi', 'pi-pty')`,
+        )
+        .run(),
+    ).toThrow(/CHECK constraint failed/);
+    // agent_invocations records the transport that actually served a turn;
+    // omp-pty is admitted there historically, so pi-pty matches.
+    db.prepare(
+      `INSERT INTO agent_invocations (agent_invocation_id, run_id, agent_provider, agent_runtime)
+       VALUES ('inv-pi-sdk', 'run-claude', 'pi', 'pi-sdk')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO agent_invocations (agent_invocation_id, run_id, agent_provider, agent_runtime)
+       VALUES ('inv-pi-pty', 'run-claude', 'pi', 'pi-pty')`,
+    ).run();
+    expect(trySession(db, 's-bogus', 'pi', 'pi-telepathy')).toMatch(/CHECK constraint failed/);
+    expect(tryRun(db, 'run-bogus', 'pi', 'pi-telepathy')).toMatch(/CHECK constraint failed/);
+    svc.close();
+  });
+
+  it('(g) lands the same constraints on a fresh install', () => {
+    const svc = openAt(MIGRATIONS_DIR);
+    const db = svc.getDb();
+    db.prepare(`INSERT INTO projects (id, name, path) VALUES (1, 'Proj', '/tmp/p123f')`).run();
+    db.prepare(
+      `INSERT INTO workflows (id, project_id, name, spec_json) VALUES ('wf-1', 1, 'sprint', '{}')`,
+    ).run();
+    expect(trySession(db, 's-fleet', 'omp', 'omp-fleet')).toBeNull();
+    expect(trySession(db, 's-pi-sdk', 'pi', 'pi-sdk')).toBeNull();
+    expect(trySession(db, 's-sdk', 'omp', 'omp-sdk')).toBeNull();
+    expect(tryRun(db, 'run-pi', 'pi', 'pi-sdk')).toBeNull();
+    expect(trySession(db, 's-bogus', 'pi', 'pi-telepathy')).toMatch(/CHECK constraint failed/);
+    svc.close();
+  });
+
+  it('(h) re-applying 123 after a cleared ledger marker is a harmless no-op', () => {
+    const { db, before, svc } = upgradeThrough123();
+    db.prepare('DELETE FROM user_preferences WHERE key = ?').run(
+      `file_migration_applied:${MIGRATION_123}`,
+    );
+    svc.close();
+
+    const again = openAt(MIGRATIONS_DIR);
+    const db2 = again.getDb();
+    for (const t of TARGET_TABLES) {
+      expect(allRows(db2, t)).toEqual(before.rows[t]);
+      expect(columnNames(db2, t)).toEqual(before.columns[t]);
+    }
+    expect(trySession(db2, 's-fleet-again', 'omp', 'omp-fleet')).toBeNull();
+    expect(trySession(db2, 's-pi-again', 'pi', 'pi-sdk')).toBeNull();
+    again.close();
+  });
+
+  it('(i) no stale pre-renumber pi-or-fleet migration exists in the migrations dir', () => {
+    // The ledger is keyed by FILENAME, so a resurrected 105_/107_ copy of this
+    // widening would apply AGAIN after 123 — against an already-widened schema
+    // where its add/copy/drop sequence is still idempotent, but its existence
+    // means two files claim the same widening and the next renumber war starts
+    // here. Guard the invariant at the directory level.
+    const names = readdirSync(MIGRATIONS_DIR);
+    expect(names).toContain(MIGRATION_123);
+    expect(names).not.toContain('105_agent_runtime_omp_fleet.sql');
+    expect(names).not.toContain('107_agent_runtime_omp_fleet.sql');
+  });
+});

--- a/main/src/database/migrations/103_widen_provider_checks.sql
+++ b/main/src/database/migrations/103_widen_provider_checks.sql
@@ -20,7 +20,13 @@
 -- already admitted on sessions but not on workflow runs:
 --   provider         + 'omp'                everywhere
 --   sessions         + 'omp-sdk','omp-pty'  (quick sessions can run the OMP TUI)
+--                    + 'omp-fleet'           (carried forward from 101: the fleet
+--                                             supervisor is a session runtime)
 --   workflow_runs    + 'omp-sdk'            (workflows need structured events)
+--                    + 'omp-fleet'           (the quick-session SENTINEL mints a
+--                                             workflow_runs row carrying the
+--                                             session's runtime identity — never
+--                                             a launch target, but storable)
 --   workflow_variants+ 'omp-sdk'            (a variant resolves to a workflow runtime)
 --   agent_invocations+ 'omp-sdk','omp-pty'  (an invocation row records what actually ran,
 --                                            including a PTY turn in a quick session)
@@ -77,7 +83,7 @@ UPDATE sessions SET agent_runtime_widen_103 = agent_runtime;
 ALTER TABLE sessions DROP COLUMN agent_runtime;
 ALTER TABLE sessions
   ADD COLUMN agent_runtime TEXT NOT NULL DEFAULT 'claude-sdk'
-    CHECK (agent_runtime IN ('claude-sdk','claude-interactive','codex-sdk','codex-pty','omp-sdk','omp-pty'));
+    CHECK (agent_runtime IN ('claude-sdk','claude-interactive','codex-sdk','codex-pty','omp-sdk','omp-pty','omp-fleet'));
 UPDATE sessions SET agent_runtime = COALESCE(agent_runtime_widen_103, 'claude-sdk');
 ALTER TABLE sessions DROP COLUMN agent_runtime_widen_103;
 
@@ -96,12 +102,16 @@ ALTER TABLE workflow_runs DROP COLUMN agent_provider_widen_103;
 
 -- omp-pty is absent for the same reason codex-pty is: a workflow run needs
 -- structured events, usage, MCP progress and review-queue integration.
+-- omp-fleet is admitted WITHOUT being launchable: it is storable-only (a fleet
+-- supervisor is never a per-step workflow agent), but the quick-session
+-- sentinel is a workflow_runs ROW and must carry the session's resolved
+-- runtime — the dispatch facade reads it back to pick the owning manager.
 ALTER TABLE workflow_runs ADD COLUMN agent_runtime_widen_103 TEXT;
 UPDATE workflow_runs SET agent_runtime_widen_103 = agent_runtime;
 ALTER TABLE workflow_runs DROP COLUMN agent_runtime;
 ALTER TABLE workflow_runs
   ADD COLUMN agent_runtime TEXT NOT NULL DEFAULT 'claude-sdk'
-    CHECK (agent_runtime IN ('claude-sdk','claude-interactive','codex-sdk','omp-sdk'));
+    CHECK (agent_runtime IN ('claude-sdk','claude-interactive','codex-sdk','omp-sdk','omp-fleet'));
 UPDATE workflow_runs SET agent_runtime = COALESCE(agent_runtime_widen_103, 'claude-sdk');
 ALTER TABLE workflow_runs DROP COLUMN agent_runtime_widen_103;
 

--- a/main/src/database/migrations/123_widen_agent_runtime_pi.sql
+++ b/main/src/database/migrations/123_widen_agent_runtime_pi.sql
@@ -1,0 +1,144 @@
+-- Migration 123: admit the native 'pi' provider on agent_provider CHECKs and
+-- the pi runtimes on agent_runtime CHECKs across all four provider-stamped
+-- tables (sessions, workflow_runs, workflow_variants, agent_invocations).
+
+-- The runner detects this marker and wraps every statement in an explicit
+-- transaction with foreign keys disabled — required here because
+-- agent_invocations is recreated via DROP TABLE (103's recipe), which would
+-- otherwise cascade-delete every invocation row.
+PRAGMA foreign_keys=OFF;
+
+-- ---------------------------------------------------------------------------
+-- sessions.agent_provider  (103 list + 'pi')
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE sessions ADD COLUMN agent_provider_widen_123 TEXT;
+UPDATE sessions SET agent_provider_widen_123 = agent_provider;
+ALTER TABLE sessions DROP COLUMN agent_provider;
+ALTER TABLE sessions
+  ADD COLUMN agent_provider TEXT NOT NULL DEFAULT 'claude'
+    CHECK (agent_provider IN ('claude','codex','omp','pi'));
+UPDATE sessions SET agent_provider = COALESCE(agent_provider_widen_123, 'claude');
+ALTER TABLE sessions DROP COLUMN agent_provider_widen_123;
+
+-- ---------------------------------------------------------------------------
+-- sessions.agent_runtime  (122 list + 'pi-sdk' + 'pi-pty')
+--
+-- pi-pty IS admitted on sessions, exactly as omp-pty/codex-pty are: a quick
+-- terminal session is a first-class chat session. The workflow tables below
+-- stay narrower.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE sessions ADD COLUMN agent_runtime_widen_123 TEXT;
+UPDATE sessions SET agent_runtime_widen_123 = agent_runtime;
+ALTER TABLE sessions DROP COLUMN agent_runtime;
+ALTER TABLE sessions
+  ADD COLUMN agent_runtime TEXT NOT NULL DEFAULT 'claude-sdk'
+    CHECK (agent_runtime IN ('claude-sdk','claude-interactive','codex-sdk','codex-pty','omp-sdk','omp-pty','omp-fleet','pi-sdk','pi-pty'));
+UPDATE sessions SET agent_runtime = COALESCE(agent_runtime_widen_123, 'claude-sdk');
+ALTER TABLE sessions DROP COLUMN agent_runtime_widen_123;
+
+-- ---------------------------------------------------------------------------
+-- workflow_runs.agent_provider  (103 list + 'pi')
+-- workflow_runs.agent_runtime   (122 list + 'pi-sdk')
+--
+-- pi-pty stays absent from the runtime list for the same reason codex-pty/
+-- omp-pty are: a workflow run needs structured events, usage and review-queue
+-- integration, which a TUI driven by keystrokes cannot supply. pi-sdk
+-- qualifies (pi --mode json).
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE workflow_runs ADD COLUMN agent_provider_widen_123 TEXT;
+UPDATE workflow_runs SET agent_provider_widen_123 = agent_provider;
+ALTER TABLE workflow_runs DROP COLUMN agent_provider;
+ALTER TABLE workflow_runs
+  ADD COLUMN agent_provider TEXT NOT NULL DEFAULT 'claude'
+    CHECK (agent_provider IN ('claude','codex','omp','pi'));
+UPDATE workflow_runs SET agent_provider = COALESCE(agent_provider_widen_123, 'claude');
+ALTER TABLE workflow_runs DROP COLUMN agent_provider_widen_123;
+
+ALTER TABLE workflow_runs ADD COLUMN agent_runtime_widen_123 TEXT;
+UPDATE workflow_runs SET agent_runtime_widen_123 = agent_runtime;
+ALTER TABLE workflow_runs DROP COLUMN agent_runtime;
+ALTER TABLE workflow_runs
+  ADD COLUMN agent_runtime TEXT NOT NULL DEFAULT 'claude-sdk'
+    CHECK (agent_runtime IN ('claude-sdk','claude-interactive','codex-sdk','omp-sdk','omp-fleet','pi-sdk'));
+UPDATE workflow_runs SET agent_runtime = COALESCE(agent_runtime_widen_123, 'claude-sdk');
+ALTER TABLE workflow_runs DROP COLUMN agent_runtime_widen_123;
+
+-- ---------------------------------------------------------------------------
+-- workflow_variants.agent_provider / workflow_variants.agent_runtime
+--
+-- Both are nullable (NULL = inherit the launch default), so the IS NULL arm is
+-- carried forward and the value copy leaves NULLs as NULL. pi-sdk joins the
+-- launchable runtime list; pi-pty stays out (keystroke TUI, same as omp-pty).
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE workflow_variants ADD COLUMN agent_provider_widen_123 TEXT;
+UPDATE workflow_variants SET agent_provider_widen_123 = agent_provider;
+ALTER TABLE workflow_variants DROP COLUMN agent_provider;
+ALTER TABLE workflow_variants
+  ADD COLUMN agent_provider TEXT
+    CHECK (agent_provider IS NULL OR agent_provider IN ('claude','codex','omp','pi'));
+UPDATE workflow_variants SET agent_provider = agent_provider_widen_123;
+ALTER TABLE workflow_variants DROP COLUMN agent_provider_widen_123;
+
+ALTER TABLE workflow_variants ADD COLUMN agent_runtime_widen_123 TEXT;
+UPDATE workflow_variants SET agent_runtime_widen_123 = agent_runtime;
+ALTER TABLE workflow_variants DROP COLUMN agent_runtime;
+ALTER TABLE workflow_variants
+  ADD COLUMN agent_runtime TEXT
+    CHECK (agent_runtime IS NULL OR agent_runtime IN ('claude-sdk','claude-interactive','codex-sdk','omp-sdk','pi-sdk'));
+UPDATE workflow_variants SET agent_runtime = agent_runtime_widen_123;
+ALTER TABLE workflow_variants DROP COLUMN agent_runtime_widen_123;
+
+-- ---------------------------------------------------------------------------
+-- agent_invocations — full recreate (103's shape: NOT NULL columns plus FK and
+-- both indexes). pi joins the provider list; pi-sdk AND pi-pty join the
+-- runtime list, matching omp-pty's historical presence on this table (an
+-- invocation row records the transport that actually served a turn).
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE agent_invocations_new (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+  agent_invocation_id   TEXT NOT NULL UNIQUE,
+  run_id                TEXT NOT NULL,
+  step_id               TEXT,
+  agent_provider        TEXT NOT NULL
+                          CHECK (agent_provider IN ('claude', 'codex', 'omp', 'pi')),
+  agent_runtime         TEXT NOT NULL
+                          CHECK (agent_runtime IN ('claude-sdk', 'claude-interactive', 'codex-sdk', 'omp-sdk', 'omp-pty', 'pi-sdk', 'pi-pty')),
+  model                 TEXT,
+  external_session_id   TEXT,
+  created_at            TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  panel_id              TEXT,
+  FOREIGN KEY (run_id) REFERENCES workflow_runs(id) ON DELETE CASCADE
+);
+
+INSERT INTO agent_invocations_new (id, agent_invocation_id, run_id, step_id, agent_provider,
+                                   agent_runtime, model, external_session_id, created_at, panel_id)
+  SELECT id, agent_invocation_id, run_id, step_id, agent_provider,
+         agent_runtime, model, external_session_id, created_at, panel_id
+  FROM agent_invocations;
+
+-- Carry AUTOINCREMENT's high-water mark across the rebuild (103's comment
+-- applies verbatim: copying explicit ids only sets the mark to max(id) among
+-- SURVIVING rows, and CASCADE deletions make that regress).
+INSERT INTO sqlite_sequence (name, seq)
+  SELECT 'agent_invocations_new', 0
+   WHERE EXISTS (SELECT 1 FROM sqlite_sequence WHERE name = 'agent_invocations')
+     AND NOT EXISTS (SELECT 1 FROM sqlite_sequence WHERE name = 'agent_invocations_new');
+
+UPDATE sqlite_sequence
+   SET seq = MAX(seq, COALESCE((SELECT seq FROM sqlite_sequence WHERE name = 'agent_invocations'), 0))
+ WHERE name = 'agent_invocations_new';
+
+DROP TABLE agent_invocations;
+ALTER TABLE agent_invocations_new RENAME TO agent_invocations;
+
+CREATE INDEX IF NOT EXISTS idx_agent_invocations_run_step_latest
+  ON agent_invocations (run_id, step_id, id DESC);
+CREATE INDEX IF NOT EXISTS idx_agent_invocations_run_panel_latest
+  ON agent_invocations (run_id, panel_id, id DESC);
+
+PRAGMA foreign_keys=ON;

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -59,9 +59,13 @@ import {
   isCodexPtyManagerLike,
   isCodexSdkManagerLike,
   isOmpPtyManagerLike,
+  isPiPtyManagerLike,
+  isPiSdkManagerLike,
   isOmpSdkManagerLike,
   type CodexPtyManagerLike,
   type OmpPtyManagerLike,
+  type PiPtyManagerLike,
+  type PiSdkManagerLike,
 } from './services/cliManagerFactory';
 import { AbstractCliManager } from './services/panels/cli/AbstractCliManager';
 import { panelManager } from './services/panelManager';
@@ -585,6 +589,8 @@ let cliManagerFactory: CliManagerFactory;
 let defaultCliManager: AbstractCliManager;
 let codexPtyManager: CodexPtyManagerLike;
 let ompPtyManager: OmpPtyManagerLike;
+let piPtyManager: PiPtyManagerLike;
+let piSdkManager: PiSdkManagerLike;
 let gitDiffManager: GitDiffManager;
 let gitStatusManager: GitStatusManager;
 let executionTracker: ExecutionTracker;
@@ -1699,6 +1705,28 @@ async function initializeServices(): Promise<boolean> {
     throw new Error('[Main] cliManagerFactory returned a manager without the OMP PTY seams for omp-pty');
   }
   ompPtyManager = createdOmpPtyManager;
+
+  const createdPiPtyManager = await cliManagerFactory.createManager('pi-pty', {
+    sessionManager,
+    logger,
+    configManager,
+    skipValidation: true,
+  });
+  if (!isPiPtyManagerLike(createdPiPtyManager)) {
+    throw new Error('[Main] cliManagerFactory returned a manager without the Pi PTY seams for pi-pty');
+  }
+  piPtyManager = createdPiPtyManager;
+
+  const createdPiSdkManager = await cliManagerFactory.createManager('pi-sdk', {
+    sessionManager,
+    logger,
+    configManager,
+    skipValidation: true,
+  });
+  if (!isPiSdkManagerLike(createdPiSdkManager)) {
+    throw new Error('[Main] cliManagerFactory returned a manager without the Pi SDK seams for pi-sdk');
+  }
+  piSdkManager = createdPiSdkManager;
   gitDiffManager = new GitDiffManager(logger);
   gitStatusManager = new GitStatusManager(sessionManager, worktreeManager, gitDiffManager, logger);
   executionTracker = new ExecutionTracker(sessionManager, gitDiffManager);
@@ -3140,6 +3168,8 @@ async function initializeServices(): Promise<boolean> {
     { lane: 'codex-pty', manager: codexPtyManager },
     { lane: 'omp-sdk', manager: createdOmpSdkManager },
     { lane: 'omp-pty', manager: ompPtyManager },
+    { lane: 'pi-pty', manager: piPtyManager },
+    { lane: 'pi-sdk', manager: piSdkManager },
   ];
   const managerByLane = new Map<PanelLane, AbstractCliManager>(
     laneManagers.map(({ lane, manager }) => [lane, manager]),
@@ -4132,6 +4162,8 @@ async function initializeServices(): Promise<boolean> {
     ompSessionManager,
     ompSdkManager: createdOmpSdkManager,
     ompPtyManager,
+    piSdkManager: createdPiSdkManager,
+    piPtyManager,
     claudeModelCatalogService: new ClaudeModelCatalogService(cyboflowLogger),
     // Live-session close-out seams for quick sessions (IDEA-030): route the
     // session merge/rebase/dismiss handlers through the SubstrateDispatchFacade
@@ -4152,6 +4184,8 @@ async function initializeServices(): Promise<boolean> {
       substrateFacade.registerPtyPanel(runId, panelId, codexPtyManager),
     registerOmpPtyPanel: (runId: string, panelId: string) =>
       substrateFacade.registerPtyPanel(runId, panelId, ompPtyManager),
+    registerPiPtyPanel: (runId: string, panelId: string) =>
+      substrateFacade.registerPtyPanel(runId, panelId, piPtyManager),
     // The SAME provider the Claude managers were injected with above, handed to
     // the IPC layer for the CODEX lanes: those spawn from ipc/ with a
     // caller-supplied runId instead of resolving the gate inside the manager, so

--- a/main/src/ipc/models.ts
+++ b/main/src/ipc/models.ts
@@ -2,6 +2,8 @@ import { IpcMain } from 'electron';
 import type { AppServices } from './types';
 import { ModelAvailabilityService } from '../services/modelAvailabilityService';
 import { getSharedOmpModelCatalogProbe } from '../services/panels/omp/ompModelCatalog';
+import { detectPiAvailability } from '../services/panels/pi/piAvailability';
+import { fetchPiModelCatalog } from '../services/panels/pi/piModelCatalog';
 import type { ModelAvailabilityMap } from '../../../shared/types/modelAvailability';
 import {
   AGENT_PROVIDERS,
@@ -41,6 +43,22 @@ const PROVIDER_CATALOG_FETCHERS: { [P in AgentProvider]: ProviderCatalogFetcher<
   // Settings before an OMP session has ever been started. `OmpSdkManager` holds
   // the same instance so a mid-flight probe is reaped at shutdown.
   omp: () => getSharedOmpModelCatalogProbe().getCatalog(),
+  // Pi's catalog comes from a short-lived `pi --list-models` child parsed
+  // into canonical `${provider}/${id}` rows (see PiModelCatalog). It goes
+  // through detectPiAvailability first so an absent/under-floor binary fails
+  // with the same "why" copy the Integrations card shows, instead of a raw
+  // spawn error.
+  pi: async () => {
+    const detection = await detectPiAvailability();
+    if (detection.state !== 'detected' || !detection.binaryPath) {
+      throw new Error(
+        detection.version
+          ? `pi ${detection.version} found but below the supported floor`
+          : 'pi binary not found on PATH',
+      );
+    }
+    return fetchPiModelCatalog(detection.binaryPath);
+  },
 };
 
 async function fetchCatalog<P extends AgentProvider>(

--- a/main/src/ipc/panels.ts
+++ b/main/src/ipc/panels.ts
@@ -45,7 +45,9 @@ export function registerPanelHandlers(ipcMain: IpcMain, services: AppServices) {
       'codex-pty': services.codexPtyManager,
       'omp-sdk': services.ompSdkManager,
       'omp-pty': services.ompPtyManager,
-    });
+      'pi-sdk': services.piSdkManager,
+      'pi-pty': services.piPtyManager,
+     });
 
   // Panel CRUD operations
   ipcMain.handle('panels:create', async (_, request: CreatePanelRequest) => {
@@ -107,6 +109,7 @@ export function registerPanelHandlers(ipcMain: IpcMain, services: AppServices) {
         // addPanelOutput throws 'Panel not found' on every tick. stopPanel is a
         // no-op for a panel the fleet manager doesn't track, so this is safe to
         // call unconditionally — no runtime lookup needed.
+
         try {
           await services.ompSessionManager?.stopPanel(panelId);
         } catch (err) {

--- a/main/src/ipc/providerDetection.ts
+++ b/main/src/ipc/providerDetection.ts
@@ -9,6 +9,7 @@ import {
 import { probeClaudeDetection } from './claudeDetection';
 import { probeCodexDetection } from './codexDetection';
 import { detectOmpAvailability } from '../services/panels/omp/ompAvailability';
+import { detectPiAvailability } from '../services/panels/pi/piAvailability';
 import type { AppServices } from './types';
 
 /**
@@ -41,6 +42,10 @@ const PROVIDER_DETECTION_PROBES: { [P in AgentProvider]: ProviderDetectionProbe<
   // rather than `omp: detectOmpAvailability` keeps the registry entry's
   // signature visually aligned with its neighbors despite ignoring `services`.
   omp: () => detectOmpAvailability(),
+  // Same thinness rationale as OMP's entry: PATH discovery + version floor,
+  // no services dependency (no `piExecutablePath` config key yet, and pi owns
+  // its own provider credentials).
+  pi: () => detectPiAvailability(),
 };
 
 type DetectionResponse =

--- a/main/src/ipc/quickSessionBriefings.ts
+++ b/main/src/ipc/quickSessionBriefings.ts
@@ -45,3 +45,16 @@ Session context:
 - This is a user-driven quick session: no predefined workflow and no step ceremony.
 - Your working directory is dedicated to this session. Commits stay local to its branch; the user merges or dismisses the session's work from the cyboflow UI when done.
 - A "cyboflow" MCP server may be connected; its tools write to cyboflow's project database. Use those tools only when the user asks you to interact with the cyboflow backlog.`;
+
+/**
+ * Pi terminal lane. No cyboflow MCP mention: v1 writes no `.pi` MCP config
+ * (nothing parallels OmpMcpConfigWriter yet), so claiming a server would be a
+ * lie the model would repeat.
+ */
+export const QUICK_PI_PTY_BRIEFING = `You are running inside cyboflow, a desktop app that manages parallel AI coding sessions in isolated git worktrees.
+
+Session context:
+- This is a user-driven quick session: no predefined workflow, no step ceremony — just you and the user.
+- Your working directory is a dedicated git worktree for this session. Commits stay local to its branch; the user merges or dismisses the session's work from the cyboflow UI when done.
+
+Acknowledge briefly and wait for the user's instructions.`;

--- a/main/src/ipc/session.ts
+++ b/main/src/ipc/session.ts
@@ -698,9 +698,9 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
       // No briefing: OMP's spawn has no `--append-system-prompt` equivalent, so
       // passing one would be silently dropped rather than delivered.
       createStructuredChatLane({ lane: 'omp-sdk', manager: ompSdkManager }),
-      // No briefing: pi's json-mode turn takes the prompt positionally; there
-      // is no system-prompt channel on this spawn shape, so passing one would
-      // be silently dropped rather than delivered.
+      // No briefing: pi's json-mode turn takes the prompt on stdin and has no
+      // system-prompt channel on this spawn shape, so passing one would be
+      // silently dropped rather than delivered.
       createStructuredChatLane({ lane: 'pi-sdk', manager: piSdkManager }),
     ].map((entry) => [entry.lane, entry]),
   );

--- a/main/src/ipc/session.ts
+++ b/main/src/ipc/session.ts
@@ -65,6 +65,7 @@ import {
   QUICK_CODEX_PTY_BRIEFING,
   QUICK_CODEX_SDK_BRIEFING,
   QUICK_OMP_PTY_BRIEFING,
+  QUICK_PI_PTY_BRIEFING,
 } from './quickSessionBriefings';
 import { relayOrSpawnPtyPanel } from './ptyPanelDispatch';
 import { agentProviderDisabledMessage, assertAgentProviderAllowed } from '../services/agentProviderGuard';
@@ -114,6 +115,7 @@ import { validateInput } from './validateInput';
  * copy is not — index.ts's design-mode fork and the open-idea-session door
  * each keep their own, so extracting the ladder changed no user-visible string.
  */
+
 const DESIGN_PREFLIGHT_MESSAGES: Readonly<Record<ClaudeSdkPreflightFailure, string>> = {
   provider_disabled:
     'Design sessions require Claude, which is turned off in Settings → Integrations. Enable Claude to start a design session.',
@@ -122,6 +124,7 @@ const DESIGN_PREFLIGHT_MESSAGES: Readonly<Record<ClaudeSdkPreflightFailure, stri
   interactive_pty_only:
     'Design sessions cannot run on the interactive substrate, but this app is locked to interactive-PTY-only mode. Disable that lock in Settings to start a design session.',
 };
+
 
 function interactiveTranscriptExists(
   worktreePath: string | null | undefined,
@@ -301,10 +304,13 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
     codexPtyManager, // Codex PTY quick-session runtime
     ompSdkManager, // Structured OMP RPC quick-session runtime
     ompPtyManager, // OMP PTY quick-session runtime
+    piPtyManager, // Pi PTY quick-session runtime
+    piSdkManager, // Pi structured runtime (quick sessions + workflow runs)
     killLiveSession, // hard-kill seam for a dismissed PTY quick session's REPL
     registerLivePanel, // at-spawn runId→panelId seed for the facade's relay translation
     registerCodexPtyPanel, // at-spawn runId→panelId seed for Codex PTY quick sessions
     registerOmpPtyPanel, // the OMP twin of registerCodexPtyPanel
+    registerPiPtyPanel, // the Pi twin of registerOmpPtyPanel
     gitStatusManager,
     gitDiffManager, // git-derived session file stats for sessions:get-statistics
     archiveProgressManager,
@@ -692,6 +698,10 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
       // No briefing: OMP's spawn has no `--append-system-prompt` equivalent, so
       // passing one would be silently dropped rather than delivered.
       createStructuredChatLane({ lane: 'omp-sdk', manager: ompSdkManager }),
+      // No briefing: pi's json-mode turn takes the prompt positionally; there
+      // is no system-prompt channel on this spawn shape, so passing one would
+      // be silently dropped rather than delivered.
+      createStructuredChatLane({ lane: 'pi-sdk', manager: piSdkManager }),
     ].map((entry) => [entry.lane, entry]),
   );
 
@@ -768,6 +778,28 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
         briefing: QUICK_OMP_PTY_BRIEFING,
       },
     ],
+    [
+      'pi-pty',
+      {
+        label: AGENT_PROVIDER_LABELS.pi,
+        isPanelRunning: (panelId) => piPtyManager.isPanelRunning(panelId),
+        relayUserTurn: (panelId, input) => piPtyManager.relayUserTurn(panelId, input),
+        registerPanel: registerPiPtyPanel,
+        // pi's TUI takes no per-turn thinking flag on this lane (the level is
+        // spawn-baked via --thinking only), so reasoningEffort is not forwarded.
+        startPanel: (o) =>
+          piPtyManager.startPanel(
+            o.panelId,
+            o.sessionId,
+            o.worktreePath,
+            o.prompt,
+            o.permissionMode,
+            o.model,
+            o.runId,
+          ),
+        briefing: QUICK_PI_PTY_BRIEFING,
+      },
+    ],
   ]);
 
   /**
@@ -780,6 +812,8 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
       'codex-pty': codexPtyManager,
       'omp-sdk': ompSdkManager,
       'omp-pty': ompPtyManager,
+      'pi-sdk': piSdkManager,
+      'pi-pty': piPtyManager,
     });
 
   /**
@@ -806,6 +840,7 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
   for (const [ptyLane, manager] of [
     ['codex-pty', codexPtyManager],
     ['omp-pty', ompPtyManager],
+    ['pi-pty', piPtyManager],
   ] as const) {
     manager?.on?.('exit', (payload: { panelId?: string; sessionId?: string; exitCode?: number }) => {
       handlePtyLaneExit(ptyLane, payload);

--- a/main/src/ipc/types.ts
+++ b/main/src/ipc/types.ts
@@ -17,6 +17,8 @@ import type {
   CodexPtyManagerLike,
   CodexSdkManagerLike,
   OmpPtyManagerLike,
+  PiPtyManagerLike,
+  PiSdkManagerLike,
   OmpSdkManagerLike,
 } from '../services/cliManagerFactory';
 import type { AbstractCliManager } from '../services/panels/cli/AbstractCliManager';
@@ -60,6 +62,10 @@ export interface AppServices {
   ompSdkManager: OmpSdkManagerLike;
   /** Interactive OMP PTY runtime for quick sessions only. Seam-typed — see above. */
   ompPtyManager: OmpPtyManagerLike;
+  /** Interactive Pi PTY runtime for quick sessions only. Seam-typed — see above. */
+  piPtyManager: PiPtyManagerLike;
+  /** Structured pi runtime (turn-spawn, --session-id resume) for quick sessions AND workflow runs. */
+  piSdkManager: PiSdkManagerLike;
   /**
    * OMP fleet runtime (Phase 4 coexistence, omp-phase4-coexistence-adr.md). A
    * SIBLING to the process managers — a remote worker supervised over the Prime
@@ -98,6 +104,8 @@ export interface AppServices {
   registerCodexPtyPanel: (runId: string, panelId: string) => void;
   /** Deterministic at-spawn registration for OMP PTY quick-session panels. */
   registerOmpPtyPanel: (runId: string, panelId: string) => void;
+  /** Deterministic at-spawn registration for Pi PTY quick-session panels. */
+  registerPiPtyPanel: (runId: string, panelId: string) => void;
   /**
    * Idle-debounced quick-session summarizer (session-summary-plan.md §5). The
    * sessions:input handler calls `noteTurnStart` before dispatching a user turn

--- a/main/src/orchestrator/__tests__/workflowRegistry.test.ts
+++ b/main/src/orchestrator/__tests__/workflowRegistry.test.ts
@@ -1182,7 +1182,7 @@ describe('WorkflowRegistry', () => {
     const ompEnabledRegistry = (): WorkflowRegistry =>
       new WorkflowRegistry(dbAdapter(db), logger, {
         ...makeConfig('default'),
-        getAgentProviderAccess: () => ({ claude: true, codex: true, omp: true }),
+        getAgentProviderAccess: () => ({ claude: true, codex: true, omp: true, pi: true }),
       });
 
     it('STAMPS omp-sdk on a real workflow launch, projecting the sdk substrate', async () => {

--- a/main/src/orchestrator/workflowPromptRenderer.ts
+++ b/main/src/orchestrator/workflowPromptRenderer.ts
@@ -66,6 +66,12 @@ export const PROVIDER_PROMPT_ENVELOPES: Record<AgentProvider, string | null> = {
   // IDENTITY, and pasting Codex's envelope in would describe a contract OMP does
   // not implement. Authored in Phase 3, with T2.
   omp: null,
+  // Same rule as OMP: pi has not been taught the T2 orchestrator contract
+  // (AskUserQuestion redirection, subagent role mapping), so a pi step prompt
+  // renders IDENTITY only. Author an envelope in the phase that teaches it —
+  // never inherit Codex's, which would describe a contract pi does not
+  // implement.
+  pi: null,
 };
 
 export function renderWorkflowPromptForRuntime(

--- a/main/src/services/__tests__/agentProviderAccess.test.ts
+++ b/main/src/services/__tests__/agentProviderAccess.test.ts
@@ -79,11 +79,13 @@ describe('resolveAgentProviderAccess', () => {
       claude: true,
       codex: true,
       omp: false,
+      pi: false,
     });
     expect(resolveAgentProviderAccess({ codex: false })).toEqual({
       claude: true,
       codex: false,
       omp: false,
+      pi: false,
     });
   });
 
@@ -92,6 +94,7 @@ describe('resolveAgentProviderAccess', () => {
       claude: true,
       codex: true,
       omp: false,
+      pi: false,
     });
   });
 
@@ -102,6 +105,7 @@ describe('resolveAgentProviderAccess', () => {
       claude: true,
       codex: true,
       omp: true,
+      pi: false,
     });
   });
 });

--- a/main/src/services/__tests__/configManagerProviderAccess.test.ts
+++ b/main/src/services/__tests__/configManagerProviderAccess.test.ts
@@ -35,7 +35,7 @@ describe('ConfigManager.agentProviderAccess', () => {
   it('floors each provider to its OWN default on a fresh instance, without seeding the field', () => {
     const mgr = new ConfigManager('/tmp/test-git-path');
     expect(mgr.getConfig().agentProviderAccess).toBeUndefined();
-    expect(mgr.getAgentProviderAccess()).toEqual({ claude: true, codex: true, omp: false });
+    expect(mgr.getAgentProviderAccess()).toEqual({ claude: true, codex: true, omp: false, pi: false });
     expect(mgr.isAgentProviderEnabled('claude')).toBe(true);
     expect(mgr.isAgentProviderEnabled('codex')).toBe(true);
     // A fresh install must not silently switch on a vendor introduced after the
@@ -73,7 +73,7 @@ describe('ConfigManager.agentProviderAccess', () => {
 
     // `omp` materializes too, at ITS default (false) — the absent-key floor is
     // per-provider, not one blanket "enabled".
-    expect(mgr.getAgentProviderAccess()).toEqual({ claude: true, codex: false, omp: false });
+    expect(mgr.getAgentProviderAccess()).toEqual({ claude: true, codex: false, omp: false, pi: false });
   });
 
   it('degrades an all-off map to all-enabled (never brick every launch seam)', async () => {
@@ -82,7 +82,7 @@ describe('ConfigManager.agentProviderAccess', () => {
     // Bypasses the IPC normalization (a hand-edited config.json can do this).
     await mgr.updateConfig({ agentProviderAccess: { claude: false, codex: false, omp: false } });
 
-    expect(mgr.getAgentProviderAccess()).toEqual({ claude: true, codex: true, omp: false });
+    expect(mgr.getAgentProviderAccess()).toEqual({ claude: true, codex: true, omp: false, pi: false });
     expect(mgr.isAgentProviderEnabled('claude')).toBe(true);
     // The degradation restores the DEFAULTS, so it must not switch on a
     // provider the user has never opted into.

--- a/main/src/services/__tests__/panelLane.test.ts
+++ b/main/src/services/__tests__/panelLane.test.ts
@@ -128,7 +128,7 @@ describe('lane helpers', () => {
     // a lane added to the union without a resolver arm — or left behind by a
     // rename — has to fail somewhere. Here.
     const resolved = new Set(
-      (['claude', 'codex', 'omp'] as const).flatMap((provider) =>
+      (['claude', 'codex', 'omp', 'pi'] as const).flatMap((provider) =>
         (['sdk', 'interactive'] as const).map((substrate) =>
           resolvePanelLane({ agent_runtime: `${provider}-sdk`, substrate }, {}),
         ),

--- a/main/src/services/agentProviderGuard.ts
+++ b/main/src/services/agentProviderGuard.ts
@@ -44,6 +44,7 @@ import {
   type AgentProvider,
 } from '../../../shared/types/agentRuntime';
 
+
 /**
  * Thrown when a call is attempted against a provider the user switched off.
  * Carries `provider` so a caller can map it back onto a UI affordance without

--- a/main/src/services/cliManagerFactory.ts
+++ b/main/src/services/cliManagerFactory.ts
@@ -9,6 +9,8 @@ import { CodexPtyManager } from './panels/codex/codexPtyManager';
 import { CodexSdkManager } from './panels/codex/codexSdkManager';
 import { OmpPtyManager } from './panels/omp/ompPtyManager';
 import { OmpSdkManager } from './panels/omp/ompSdkManager';
+import { PiPtyManager } from './panels/pi/piPtyManager';
+import { PiSdkManager } from './panels/pi/piSdkManager';
 import {
   CliToolRegistry,
   CliToolDefinition,
@@ -110,12 +112,36 @@ type OmpSdkSeams = Pick<
 /** The OMP PTY seams beyond AbstractCliManager — the Codex PTY pair exactly. */
 type OmpPtySeams = Pick<OmpPtyManager, 'startPanel' | 'relayUserTurn'>;
 
+/** The Pi PTY seams — identical shape to the OMP/Codex PTY pair. */
+type PiPtySeams = Pick<PiPtyManager, 'startPanel' | 'relayUserTurn'>;
+
+/** The Pi SDK seams: the lifecycle is all on AbstractCliManager in v1. */
+type PiSdkSeams = Record<string, never>;
+
 /** What the app needs of an OMP RPC manager — the CLI base plus its seams. */
 export type OmpSdkManagerLike = AbstractCliManager & OmpSdkSeams;
 
 /** The OMP PTY twin of {@link OmpSdkManagerLike}. */
 export type OmpPtyManagerLike = AbstractCliManager & OmpPtySeams;
 
+export type PiPtyManagerLike = AbstractCliManager & PiPtySeams;
+
+export type PiSdkManagerLike = AbstractCliManager & PiSdkSeams;
+
+/** Does this manager expose the Pi PTY seams? */
+export function isPiPtyManagerLike(manager: AbstractCliManager): manager is PiPtyManagerLike {
+  const seams = manager as Partial<PiPtySeams>;
+  return typeof seams.startPanel === 'function' && typeof seams.relayUserTurn === 'function';
+}
+
+/**
+ * Every AbstractCliManager instance satisfies PiSdkSeams (it is empty), but the
+ * guard keeps call sites symmetric with the other lanes and future-proof.
+ */
+export function isPiSdkManagerLike(manager: AbstractCliManager): manager is PiSdkManagerLike {
+  void manager;
+  return true;
+}
 /** Does this manager expose the OMP SDK seams? */
 export function isOmpSdkManagerLike(manager: AbstractCliManager): manager is OmpSdkManagerLike {
   const seams = manager as Partial<OmpSdkSeams>;
@@ -405,7 +431,12 @@ export class CliManagerFactory {
     this.registerOmpSdkTool();
     this.registerOmpPtyTool();
 
-    // Future tools can be registered here:
+    // Register the Pi (@earendil-works/pi-coding-agent) quick-session runtime.
+    // Priority below OMP's so getDefaultTool() ordering is unchanged by its
+    // arrival; the provider toggle gates reachability anyway.
+    this.registerPiPtyTool();
+    this.registerPiSdkTool();
+
     // this.registerAiderTool();
     // this.registerContinueTool();
     // this.registerCursorTool();
@@ -743,6 +774,109 @@ export class CliManagerFactory {
 
     this.registry.registerTool(ompPtyDefinition, {
       priority: 30,
+      validateOnRegister: false,
+    });
+  }
+
+  private registerPiPtyTool(): void {
+    const piPtyManagerFactory: ManagerFactoryFunction = (
+      sessionManager: unknown,
+      logger?: Logger,
+      configManager?: ConfigManager,
+    ) => {
+      return new PiPtyManager(
+        sessionManager as SessionManager,
+        logger,
+        configManager,
+      );
+    };
+
+    const piPtyDefinition: CliToolDefinition = {
+      id: 'pi-pty',
+      name: 'Pi (PTY)',
+      description: 'pi (@earendil-works/pi-coding-agent) running as an interactive PTY quick-session runtime',
+      version: '1.0.0',
+      capabilities: {
+        // `--continue` is a REAL per-project session resume, like OMP's.
+        supportsResume: true,
+        supportsMultipleModels: true,
+        supportsPermissions: false,
+        supportsFileOperations: true,
+        supportsGitIntegration: true,
+        supportsSystemPrompts: false,
+        supportsStructuredOutput: false,
+        outputFormats: [
+          CLI_OUTPUT_FORMATS.TEXT,
+        ],
+        supportedPanelTypes: ['claude'],
+      },
+      config: {
+        requiredEnvVars: [],
+        optionalEnvVars: [],
+        requiredConfigKeys: [],
+        optionalConfigKeys: [],
+        defaultExecutable: 'pi',
+        alternativeExecutables: ['pi'],
+        minimumVersion: undefined,
+      },
+      managerFactory: piPtyManagerFactory,
+    };
+
+    this.registry.registerTool(piPtyDefinition, {
+      priority: 25,
+      validateOnRegister: false,
+    });
+  }
+
+
+  private registerPiSdkTool(): void {
+    const piSdkManagerFactory: ManagerFactoryFunction = (
+      sessionManager: unknown,
+      logger?: Logger,
+      configManager?: ConfigManager,
+    ) => {
+      return new PiSdkManager(
+        sessionManager as SessionManager,
+        logger,
+        configManager,
+      );
+    };
+
+    const piSdkDefinition: CliToolDefinition = {
+      id: 'pi-sdk',
+      name: 'Pi',
+      description: 'pi (@earendil-works/pi-coding-agent) structured json-events runtime (turn-spawn, --session-id resume)',
+      version: '1.0.0',
+      capabilities: {
+        // Resume is deterministic (--session-id), so this lane genuinely
+        // supports picking a conversation back up.
+        supportsResume: true,
+        supportsMultipleModels: true,
+        supportsPermissions: false,
+        supportsFileOperations: true,
+        supportsGitIntegration: true,
+        supportsSystemPrompts: false,
+        supportsStructuredOutput: true,
+        outputFormats: [
+          CLI_OUTPUT_FORMATS.JSON,
+          CLI_OUTPUT_FORMATS.TEXT,
+        ],
+        supportedPanelTypes: ['claude'],
+      },
+      config: {
+        requiredEnvVars: [],
+        optionalEnvVars: [],
+        requiredConfigKeys: [],
+        optionalConfigKeys: [],
+        defaultExecutable: 'pi',
+        alternativeExecutables: ['pi'],
+        minimumVersion: undefined,
+      },
+      managerFactory: piSdkManagerFactory,
+    };
+
+    this.registry.registerTool(piSdkDefinition, {
+      priority: 26,
       validateOnRegister: false,
     });
   }

--- a/main/src/services/createQuickSessionCore.ts
+++ b/main/src/services/createQuickSessionCore.ts
@@ -305,6 +305,7 @@ export const QUICK_PROVIDER_SDK_RUNTIME: Readonly<Record<AgentProvider, SessionA
   claude: 'claude-sdk',
   codex: 'codex-sdk',
   omp: 'omp-sdk',
+  pi: 'pi-sdk',
 };
 
 /**

--- a/main/src/services/panelLane.ts
+++ b/main/src/services/panelLane.ts
@@ -56,6 +56,8 @@ export const ALL_PANEL_LANES = [
   'codex-pty',
   'omp-sdk',
   'omp-pty',
+  'pi-sdk',
+  'pi-pty',
 ] as const;
 
 export type PanelLane = (typeof ALL_PANEL_LANES)[number];
@@ -72,6 +74,7 @@ const PROVIDER_LANES: Readonly<
   claude: { sdk: 'claude-sdk', interactive: 'claude-interactive' },
   codex: { sdk: 'codex-sdk', interactive: 'codex-pty' },
   omp: { sdk: 'omp-sdk', interactive: 'omp-pty' },
+  pi: { sdk: 'pi-sdk', interactive: 'pi-pty' },
 };
 
 /** The lanes served by a PTY manager — each provider's interactive lane. */
@@ -157,7 +160,7 @@ export function isPtyLane(lane: PanelLane): boolean {
   return PTY_LANES.has(lane);
 }
 
-/** The four lanes owned by a dedicated per-provider manager (not Claude's two). */
+/** The six lanes owned by a dedicated per-provider manager (not Claude's two). */
 export type NonClaudeLane = Exclude<PanelLane, 'claude-sdk' | 'claude-interactive'>;
 
 /**
@@ -181,6 +184,8 @@ export function nonClaudeLaneOwner<M>(
     case 'codex-pty':
     case 'omp-sdk':
     case 'omp-pty':
+    case 'pi-sdk':
+    case 'pi-pty':
       return owners[lane];
     default:
       return undefined;

--- a/main/src/services/panels/pi/__tests__/piGateExtension.test.ts
+++ b/main/src/services/panels/pi/__tests__/piGateExtension.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  PI_GATE_ENV_KEYS,
+  PI_GATE_EXTENSION_SOURCE,
+  decideToolCall,
+  piGateModeForMode,
+} from '../piGateExtension';
+
+/**
+ * End-to-end over the GENERATED extension source: the module is written to a
+ * temp .mjs and imported for real, so the suite pins the exact bytes pi will
+ * load — including the self-containment contract of `decideToolCall.toString()`
+ * (a closure reference would ReferenceError right here).
+ */
+async function loadGateModule(envMode: 'dontAsk' | 'gated') {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-gate-'));
+  const file = path.join(dir, 'gate.mjs');
+  fs.writeFileSync(
+    file,
+    `${PI_GATE_EXTENSION_SOURCE}\nexport { decideToolCall };\n`,
+    'utf8',
+  );
+  process.env[PI_GATE_ENV_KEYS.mode] = envMode;
+  try {
+    return await import(pathToFileURL(file).href);
+  } finally {
+    delete process.env[PI_GATE_ENV_KEYS.mode];
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+type Handler = (event: { toolName: string }) => Promise<{ block: boolean; reason?: string }>;
+
+async function loadHandler(envMode: 'dontAsk' | 'gated'): Promise<Handler> {
+  const mod = await loadGateModule(envMode);
+  let handler: Handler | undefined;
+  const fakePi = {
+    on(_event: string, fn: Handler) {
+      handler = fn;
+    },
+  };
+  await mod.default(fakePi);
+  if (!handler) throw new Error('gate extension did not register a tool_call handler');
+  return handler;
+}
+
+describe('pi tool-call gate policy', () => {
+  it('pure function: dontAsk allows everything; gated blocks writes, passes reads', () => {
+    expect(decideToolCall('dontAsk', 'bash')).toEqual({ block: false });
+    expect(decideToolCall('gated', 'read')).toEqual({ block: false });
+    expect(decideToolCall('gated', 'grep')).toEqual({ block: false });
+
+    const bash = decideToolCall('gated', 'bash');
+    expect(bash.block).toBe(true);
+    expect(bash.reason).toMatch(/gated mode/);
+
+    // Unknown tools are write-tier by default (fail closed).
+    expect(decideToolCall('gated', 'some-extension-tool').block).toBe(true);
+  });
+
+  it('generated module registers tool_call and enforces the same policy', async () => {
+    const gated = await loadHandler('gated');
+    await expect(gated({ toolName: 'edit' })).resolves.toMatchObject({ block: true });
+    await expect(gated({ toolName: 'read' })).resolves.toMatchObject({ block: false });
+
+    const yolo = await loadHandler('dontAsk');
+    await expect(yolo({ toolName: 'bash' })).resolves.toMatchObject({ block: false });
+  });
+
+  it('mode mapper: only dontAsk unlocks the yolo mode', () => {
+    expect(piGateModeForMode('default')).toBe('gated');
+    expect(piGateModeForMode('acceptEdits')).toBe('gated');
+    expect(piGateModeForMode('auto')).toBe('gated');
+    expect(piGateModeForMode('dontAsk')).toBe('dontAsk');
+  });
+
+  it('env key matches what the manager spawns with', () => {
+    expect(PI_GATE_ENV_KEYS.mode).toBe('CYBOFLOW_GATE_MODE');
+    expect(PI_GATE_EXTENSION_SOURCE).toContain(PI_GATE_ENV_KEYS.mode);
+    expect(PI_GATE_EXTENSION_SOURCE).toContain('tool_call');
+  });
+});

--- a/main/src/services/panels/pi/__tests__/piPtyManager.test.ts
+++ b/main/src/services/panels/pi/__tests__/piPtyManager.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { assertPiRequiredSpawnFlags, PiPtyManager } from '../piPtyManager';
+import { evaluatePiVersionPolicy } from '../piVersions';
+
+/**
+ * Test seam: exposes the protected argv builder without unchecked casts.
+ * Constructor deps are the manager's own narrowed seams; no PTY is spawned.
+ */
+class ExposedPiPtyManager extends PiPtyManager {
+  exposeBuildCommandArgs(o: { prompt: string; model?: string; isContinue?: boolean }): string[] {
+    return this.buildCommandArgs({
+      panelId: 'p',
+      sessionId: 's',
+      worktreePath: '/tmp',
+      prompt: o.prompt,
+      model: o.model,
+      isContinue: o.isContinue,
+    });
+  }
+}
+
+function makeExposed(): ExposedPiPtyManager {
+  return new ExposedPiPtyManager(
+    { getDbSession: () => null } as never,
+    undefined,
+    { getDefaultAgentPermissionMode: () => 'default' } as never,
+  );
+}
+
+describe('Pi PTY spawn security invariant', () => {
+  it('accepts argv carrying the full discovery-lockdown pair', () => {
+    expect(() =>
+      assertPiRequiredSpawnFlags(['--no-extensions', '--no-skills', '--model', 'x']),
+    ).not.toThrow();
+  });
+
+  it('refuses argv missing either lockdown flag (spawn-time assertion)', () => {
+    expect(() => assertPiRequiredSpawnFlags(['--no-extensions'])).toThrow(/dropped required flag/);
+    expect(() => assertPiRequiredSpawnFlags([])).toThrow(/dropped required flag/);
+  });
+
+  it('buildCommandArgs emits lockdown pair first, model, continue, then prompt', () => {
+    const args = makeExposed().exposeBuildCommandArgs({
+      prompt: 'do a thing',
+      model: 'anthropic/claude-opus-4-6',
+      isContinue: true,
+    });
+    expect(args.slice(0, 2)).toEqual(['--no-extensions', '--no-skills']);
+    expect(args).toContain('--continue');
+    expect(args[args.length - 1]).toBe('do a thing');
+  });
+
+  it('space-prefixes a dash-leading prompt (pi has no -- terminator)', () => {
+    const args = makeExposed().exposeBuildCommandArgs({
+      prompt: '-rm -rf /',
+      isContinue: false,
+    });
+    expect(args[args.length - 1]).toBe(' -rm -rf /');
+    expect(() => assertPiRequiredSpawnFlags(args)).not.toThrow();
+  });
+});
+
+describe('evaluatePiVersionPolicy', () => {
+  it('floors below 0.84.0 with a reason and accepts the tested version', () => {
+    expect(evaluatePiVersionPolicy('0.80.1')).toEqual({
+      ok: false,
+      aboveTested: false,
+      reason: 'below-floor',
+    });
+    expect(evaluatePiVersionPolicy('0.84.2')).toEqual({
+      ok: true,
+      aboveTested: false,
+      reason: undefined,
+    });
+    expect(evaluatePiVersionPolicy('0.85.0').aboveTested).toBe(true);
+  });
+
+  it('fails closed on unparseable version output', () => {
+    expect(evaluatePiVersionPolicy('pi-unknown')).toMatchObject({ ok: false, reason: 'unparseable' });
+  });
+});

--- a/main/src/services/panels/pi/__tests__/piSdkManager.gateMode.test.ts
+++ b/main/src/services/panels/pi/__tests__/piSdkManager.gateMode.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { mkdtempSync, rmSync } from 'node:fs';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+import type * as NodeOS from 'node:os';
+import type { ClaudeSpawnerOptions } from '../../../../orchestrator/runExecutor';
+import { PiSdkManager } from '../piSdkManager';
+import { PI_GATE_ENV_KEYS } from '../piGateExtension';
+
+/**
+ * Pins the permission-mode → env handoff on the pi sdk lane: the turn's
+ * resolved `agentPermissionMode` must reach CYBOFLOW_GATE_MODE on the spawned
+ * `pi --mode json` process ('dontAsk' passes through; omitted/default/
+ * acceptEdits/auto all fail closed to 'gated') — on fresh AND reused panels.
+ * Also pins the argv/stdin contract: lockdown pair + explicit `-e` gate file,
+ * exactly one `--print`, and the prompt riding STDIN, never argv.
+ */
+
+const spawnMock = vi.hoisted(() =>
+  vi.fn((_exe: string, _args: string[], opts: { env: Record<string, string | undefined> }) => {
+    const emitter = new EventEmitter();
+    const child = Object.assign(emitter, {
+      stdin: {
+        write(s: string) {
+          stdinWrites.push(s);
+        },
+        end: vi.fn(),
+      },
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+      killed: false,
+      kill: vi.fn(),
+    });
+    // Settle every turn asynchronously with a clean exit.
+    queueMicrotask(() => emitter.emit('close', 0));
+    return child;
+  }),
+);
+
+vi.mock('node:child_process', () => ({ spawn: spawnMock, exec: vi.fn() }));
+vi.mock('node:os', async (importOriginal) => ({
+  ...(await importOriginal<typeof NodeOS>()),
+  homedir: () => fakeHome,
+}));
+
+// Closures above capture these bindings; they are only READ at test runtime
+// (per spawn / per gate-file write), long after both initializers ran.
+let fakeHome = '';
+const stdinWrites: string[] = [];
+
+/** Bypass the PATH/version-probe ladder; the spawn itself is fully mocked. */
+class TestablePiSdk extends PiSdkManager {
+  protected override getCliExecutablePath(): Promise<string> {
+    return Promise.resolve('/fake/pi');
+  }
+}
+
+function makeManager() {
+  return new TestablePiSdk(
+    { getDbSession: () => null } as never,
+    undefined,
+    { getDefaultAgentPermissionMode: () => 'default' } as never,
+  );
+}
+
+type SpawnCall = [string, string[], { env: Record<string, string | undefined> }];
+
+function lastSpawnCall(): SpawnCall {
+  const call = spawnMock.mock.calls.at(-1) as SpawnCall | undefined;
+  if (!call) throw new Error('spawn was never called');
+  return call;
+}
+
+/** One settled turn; returns the env the spawn received. */
+async function spawnOnce(mgr: TestablePiSdk, over: Partial<ClaudeSpawnerOptions> = {}) {
+  await mgr.spawnCliProcess({
+    // FIXED panelId: the reused-panel case depends on both turns landing here.
+    panelId: 'panel-1',
+    sessionId: 'sess-shared',
+    worktreePath: '/tmp/wt',
+    prompt: 'do a thing',
+    ...over,
+  } satisfies ClaudeSpawnerOptions);
+  return lastSpawnCall()[2].env;
+}
+
+describe('PiSdkManager gate mode (CYBOFLOW_GATE_MODE)', () => {
+  beforeEach(() => {
+    stdinWrites.length = 0;
+    spawnMock.mockClear();
+    fakeHome = mkdtempSync(path.join(tmpdir(), 'pi-gate-home-'));
+  });
+  afterEach(() => {
+    rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  it("threads agentPermissionMode 'dontAsk' through to the gate env", async () => {
+    const env = await spawnOnce(makeManager(), { agentPermissionMode: 'dontAsk' });
+    expect(env[PI_GATE_ENV_KEYS.mode]).toBe('dontAsk');
+  });
+
+  it("fails closed to 'gated' for omitted/default/acceptEdits/auto", async () => {
+    const cases = [undefined, 'default', 'acceptEdits', 'auto'] as const;
+    for (const mode of cases) {
+      const env = await spawnOnce(makeManager(), { agentPermissionMode: mode });
+      expect(env[PI_GATE_ENV_KEYS.mode], `agentPermissionMode=${String(mode)}`).toBe('gated');
+    }
+  });
+
+  it('reuses the panel but still picks up the CURRENT mode per turn', async () => {
+    const mgr = makeManager();
+    const first = await spawnOnce(mgr); // no mode → fail closed
+    expect(first[PI_GATE_ENV_KEYS.mode]).toBe('gated');
+    const second = await spawnOnce(mgr, { agentPermissionMode: 'dontAsk' }); // same manager + panel-1
+    expect(second[PI_GATE_ENV_KEYS.mode]).toBe('dontAsk');
+  });
+
+  it('spawns with lockdown flags, one --print, and the prompt on stdin only', async () => {
+    await spawnOnce(makeManager());
+    const args = lastSpawnCall()[1];
+    expect(args).toContain('--no-extensions');
+    expect(args).toContain('--no-skills');
+    expect(args).toContain('-e');
+    expect(args.filter((a) => a === '--print')).toHaveLength(1);
+    expect(args).not.toContain('do a thing');
+    expect(stdinWrites).toEqual(['do a thing']);
+  });
+});

--- a/main/src/services/panels/pi/piAvailability.ts
+++ b/main/src/services/panels/pi/piAvailability.ts
@@ -1,0 +1,51 @@
+import { findExecutableInPath, getShellPath } from '../../../utils/shellPath';
+import { probeCliVersion } from '../cli/cliVersionProbe';
+import { evaluatePiVersionPolicy, PI_MIN_SUPPORTED_VERSION, PI_TESTED_VERSION } from './piVersions';
+import type { ProviderDetectionResult } from '../../../../../shared/types/onboarding';
+
+/**
+ * Pi's onboarding/Settings availability probe — the pi sibling of
+ * {@link detectOmpAvailability}, with the same deliberate thinness: pi owns
+ * its own provider credentials (`~/.pi`, its `/login` flow), so Cyboflow has
+ * no account to introspect. "Available" means exactly "a usable binary
+ * (present, `--version` succeeds, at/above the floor) is on this machine",
+ * never anything about which model providers pi itself can reach.
+ *
+ * Side-effect free and UNCACHED, per the onboarding probe contract in
+ * `providerDetection.ts`. The discovery ladder is explicit custom path →
+ * `findExecutableInPath('pi')` → version probe → floor policy; there is no
+ * Settings custom-path field yet (no `piExecutablePath` config key), but
+ * `customPath` is accepted so one can wire straight in later.
+ */
+export async function detectPiAvailability(
+  customPath?: string,
+): Promise<ProviderDetectionResult<'pi'>> {
+  const configuredPath = customPath?.trim();
+  const resolvedPath = configuredPath || findExecutableInPath('pi');
+  if (!resolvedPath) {
+    return { state: 'unavailable', binaryPath: null, version: null };
+  }
+
+  let rawVersion: string;
+  try {
+    const probe = await probeCliVersion(resolvedPath, { ...process.env, PATH: getShellPath() });
+    rawVersion = probe.version;
+  } catch {
+    // Found on disk but `--version` failed — report unavailable rather than
+    // claim a usable binary.
+    return { state: 'unavailable', binaryPath: resolvedPath, version: null };
+  }
+
+  const verdict = evaluatePiVersionPolicy(rawVersion);
+  if (!verdict.ok) {
+    // Report the raw version so the Integrations card can explain WHY
+    // ("found pi 0.80.1, need >= 0.84.0") instead of a bare "not found".
+    return { state: 'unavailable', binaryPath: resolvedPath, version: rawVersion };
+  }
+  if (verdict.aboveTested) {
+    console.warn(
+      `[PI] detected version ${rawVersion} is newer than the last version this integration was tested against (${PI_TESTED_VERSION}, floor ${PI_MIN_SUPPORTED_VERSION}); proceeding, but behavior beyond the tested version is unverified.`,
+    );
+  }
+  return { state: 'detected', binaryPath: resolvedPath, version: rawVersion };
+}

--- a/main/src/services/panels/pi/piGateExtension.ts
+++ b/main/src/services/panels/pi/piGateExtension.ts
@@ -1,0 +1,89 @@
+/**
+ * The cyboflow tool-call gate for pi — shipped as SOURCE and loaded inside
+ * the spawned `pi` process via `-e <path>` (pi keeps explicitly-passed
+ * extensions working even under `--no-extensions`, which is what makes the
+ * lockdown pair and this gate coexist).
+ *
+ * WHY A POLICY GATE, NOT A HUMAN ROUND-TRIP (v1): a human verdict channel
+ * needs the orchestrator-socket protocol OMP's 2.2k-line gate implements.
+ * v1 ships the part that closes the actual hole — headless `pi-sdk`
+ * workflow steps executing write-tier tools with nobody watching — by
+ * enforcing cyboflow's permission mode INSIDE the child process, where it
+ * cannot be skipped by CLI flags:
+ *
+ *   - `dontAsk`        → allow everything (the user explicitly chose yolo)
+ *   - every other mode → read-only tools pass; anything else is BLOCKED
+ *                        with an actionable reason
+ *
+ * Unknown tools are treated as write-tier (fail closed). The policy lives in
+ * ONE place (`decideToolCall`) so tests pin it and the future human-in-the-
+ * loop bridge replaces only that function's backend.
+ *
+ * SELF-CONTAINMENT CONTRACT: `decideToolCall.toString()` is embedded into
+ * the generated extension, so the function must reference NOTHING outside
+ * its own body (its lookup table lives inside). Tests import the generated
+ * module end-to-end to pin that contract.
+ */
+
+import type { PermissionMode } from '../../../../../shared/types/workflows';
+
+/** Env keys the gate reads. Kept in sync with what the manager spawns with. */
+export const PI_GATE_ENV_KEYS = {
+  mode: 'CYBOFLOW_GATE_MODE',
+} as const;
+
+export type PiGateMode = 'dontAsk' | 'gated';
+
+export interface PiGateDecision {
+  block: boolean;
+  reason?: string;
+}
+
+/**
+ * The whole policy, as one pure, SELF-CONTAINED function: `.toString()` of
+ * this exact body is what ships inside the generated extension, so it must
+ * not close over anything above.
+ */
+export function decideToolCall(mode: 'dontAsk' | 'gated', toolName: string): PiGateDecision {
+  if (mode === 'dontAsk') {
+    return { block: false };
+  }
+  // Tools that only ever READ are safe under any mode; everything else —
+  // including unknown/extension tools — is treated as write-tier (fail closed).
+  const READ_ONLY = new Set(['read', 'grep', 'glob', 'ls']);
+  if (READ_ONLY.has(toolName)) {
+    return { block: false };
+  }
+  return {
+    block: true,
+    reason:
+      `Blocked by cyboflow: tool "${toolName}" can modify this worktree, and ` +
+      'this session runs in gated mode. Switch the session permission mode to ' +
+      '"dontAsk" (the session owner explicitly accepts unattended writes) or ' +
+      'use the pi-pty runtime, where approvals happen inside the TUI.',
+  };
+}
+
+/** Map a cyboflow PermissionMode onto the gate's two modes. */
+export function piGateModeForMode(mode: PermissionMode): PiGateMode {
+  return mode === 'dontAsk' ? 'dontAsk' : 'gated';
+}
+
+/**
+ * The extension source spawntime writes to disk and loads via `-e`.
+ * `decideToolCall.toString()` embeds the full policy body (self-contained by
+ * contract above); `mode` arrives via the env key so the SAME written file
+ * serves every session regardless of its permission mode.
+ */
+export const PI_GATE_EXTENSION_SOURCE = `
+const decideToolCall = ${decideToolCall.toString()};
+
+const MODE = process.env.${PI_GATE_ENV_KEYS.mode} === 'dontAsk' ? 'dontAsk' : 'gated';
+
+export default function activate(pi) {
+  pi.on("tool_call", async (event) => {
+    const toolName = String(event.toolName ?? "");
+    return decideToolCall(MODE, toolName);
+  });
+}
+`;

--- a/main/src/services/panels/pi/piModelCatalog.ts
+++ b/main/src/services/panels/pi/piModelCatalog.ts
@@ -1,0 +1,82 @@
+import { spawn } from 'node:child_process';
+import type { OmpModelOption, PiModelCatalog } from '../../../../../shared/types/agentModels';
+
+/**
+ * Pi's model catalog, discovered from the machine's own `pi --list-models`.
+ *
+ * pi has no catalog call in json mode (models are a startup concern), so —
+ * exactly like the OMP probe this mirrors — the fetcher spawns a short-lived
+ * child and parses its output. `--list-models` prints a fixed-column table:
+ *
+ *   provider         model                    context  max-out  thinking  images
+ *   antigravity      claude-opus-4-6          250K     64K      yes       yes
+ *
+ * Rows project to the canonical `${provider}/${id}` selection form the model
+ * family predicate rests on. The context/max-out/thinking columns are display
+ * metadata Cyboflow's picker does not surface today; they are dropped here
+ * rather than carried half-parsed.
+ *
+ * Side-effect free and UNCACHED: the caller (PROVIDER_CATALOG_FETCHERS) owns
+ * caching policy, mirroring how the OMP catalog probe behaves.
+ */
+
+/** A `provider`/`model` header row guard — the table always prints one. */
+const HEADER_PREFIX = 'provider';
+
+export async function fetchPiModelCatalog(
+  binaryPath: string,
+  timeoutMs = 15_000,
+): Promise<PiModelCatalog> {
+  const { stdout, stderr } = await new Promise<{ stdout: string; stderr: string }>(
+    (resolve, reject) => {
+      const child = spawn(binaryPath, ['--list-models'], {
+        env: { ...process.env },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let out = '';
+      let err = '';
+      const timer = setTimeout(() => {
+        child.kill('SIGKILL');
+        reject(new Error(`pi --list-models timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      child.stdout.on('data', (chunk: Buffer) => {
+        out += chunk.toString('utf8');
+      });
+      child.stderr.on('data', (chunk: Buffer) => {
+        err += chunk.toString('utf8');
+      });
+      child.on('error', (e: Error) => {
+        clearTimeout(timer);
+        reject(e);
+      });
+      child.on('close', (code) => {
+        clearTimeout(timer);
+        if (code === 0) resolve({ stdout: out, stderr: err });
+        else reject(new Error(`pi --list-models exited ${code}${err ? `: ${err.trim()}` : ''}`));
+      });
+    },
+  );
+
+  const models: OmpModelOption[] = [];
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim();
+    // Header, blank, or notice lines (auth warnings print above the table).
+    if (!trimmed || trimmed.startsWith(HEADER_PREFIX)) continue;
+    // Columns separate on runs of spaces; ids never contain double spaces.
+    const cells = trimmed.split(/\s{2,}/);
+    if (cells.length < 2) continue;
+    const [provider, id] = cells;
+    if (!provider || !id) continue;
+    // Canonical selection form `${provider}/${id}` — the wire id is bare, the
+    // persisted value is not (same invariant as the OMP catalog).
+    models.push({ id: `${provider}/${id}`, label: id, ompProvider: provider });
+  }
+
+  if (models.length === 0) {
+    // Auth notices print to stderr above an empty table; quote the first line
+    // so "why is my provider missing" is answerable from the picker's error.
+    const firstErr = stderr.trim().split('\n')[0];
+    throw new Error(`pi --list-models returned no models${firstErr ? `: ${firstErr}` : ''}`);
+  }
+  return { models };
+}

--- a/main/src/services/panels/pi/piPtyManager.ts
+++ b/main/src/services/panels/pi/piPtyManager.ts
@@ -1,0 +1,407 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type * as pty from '@homebridge/node-pty-prebuilt-multiarch';
+import type { AgentProvider } from '../../../../../shared/types/agentRuntime';
+import type { ConversationMessage } from '../../../database/models';
+import type { PermissionMode } from '../../../../../shared/types/workflows';
+import { isPermissionMode } from '../../../../../shared/types/workflows';
+import { getShellPath, findExecutableInPath } from '../../../utils/shellPath';
+import { AbstractCliManager } from '../cli/AbstractCliManager';
+import { probeCliVersion, type CliVersionProbeResult } from '../cli/cliVersionProbe';
+import { evaluatePiVersionPolicy, PI_MIN_SUPPORTED_VERSION, PI_TESTED_VERSION } from './piVersions';
+
+interface PiPtySpawnOptions {
+  panelId: string;
+  sessionId: string;
+  worktreePath: string;
+  prompt: string;
+  permissionMode?: 'approve' | 'ignore';
+  agentPermissionMode?: PermissionMode;
+  model?: string;
+  runId?: string;
+  /**
+   * Set by {@link PiPtyManager.continuePanel} to request `--continue`
+   * (pi's per-project most-recent-session resume) on the respawn. Never set by
+   * `startPanel` — a fresh panel always starts a fresh pi session.
+   */
+  isContinue?: boolean;
+  [key: string]: unknown;
+}
+
+interface PiPtySpawnContext {
+  panelId: string;
+  sessionId: string;
+  runId: string;
+}
+
+const PTY_BACKLOG_CAP_BYTES = 200_000;
+
+/**
+ * Every flag {@link PiPtyManager.buildCommandArgs} must NEVER omit, checked by
+ * {@link assertPiRequiredSpawnFlags} right before the argv is returned.
+ *
+ * `--no-extensions`/`--no-skills` are the discovery-lockdown pair (the same
+ * invariant OMP's PTY lane enforces): pi auto-discovers project-local
+ * `.pi/extensions` and skills, which are arbitrary TypeScript executing at
+ * startup before any gate exists. pi has NO approval-mode flag and NO built-in
+ * sandbox (docs/security.md is explicit about both), so unlike OMP there is no
+ * `--approval-mode` to pin — the interactive TUI IS the observation surface
+ * for this lane. cyboflow's PermissionMode is deliberately NOT mapped onto
+ * `--tools` allowlists here: a blanket list would silently widen or narrow the
+ * trust boundary per mode without a producer-side gate to enforce it. If a
+ * mode mapping is ever added it must go through an extension-based `tool_call`
+ * bridge like the SDK lane's.
+ */
+const PI_REQUIRED_SPAWN_FLAGS = ['--no-extensions', '--no-skills'] as const;
+
+/**
+ * Throws if `args` is missing any of {@link PI_REQUIRED_SPAWN_FLAGS}. Exported
+ * so the security invariant can be unit-tested directly, independent of
+ * `buildCommandArgs`'s own call site — a subclass override that REPLACES
+ * `buildCommandArgs` would otherwise bypass the inline call and prove nothing.
+ */
+export function assertPiRequiredSpawnFlags(args: readonly string[]): void {
+  const missing = PI_REQUIRED_SPAWN_FLAGS.filter((flag) => !args.includes(flag));
+  if (missing.length > 0) {
+    throw new Error(
+      `[PI] refusing to spawn: buildCommandArgs dropped required flag(s) ${missing.join(', ')}. Discovery lockdown (--no-extensions --no-skills) is a security invariant — a refactor must not silently ship without them.`,
+    );
+  }
+}
+
+export class PiPtyManager extends AbstractCliManager {
+  private resolvedExecutablePath: string | null = null;
+  private readonly panelRunIds = new Map<string, string>();
+  private readonly ptyBacklog = new Map<string, string>();
+  private readonly ptySpawnContext = new AsyncLocalStorage<PiPtySpawnContext>();
+
+  protected getCliToolName(): string {
+    return 'Pi';
+  }
+
+  /** Vendor for the provider-access guard (Settings → Integrations). */
+  protected getAgentProvider(): AgentProvider {
+    return 'pi';
+  }
+
+  /**
+   * Resolve the pi CLI: explicit custom path first, else
+   * `findExecutableInPath('pi')`. No bundled-binary rung — v1 spawns the USER's
+   * install (`@earendil-works/pi-coding-agent`), same shape as OMP. The version
+   * probe applies the floor+tested policy from `piVersions.ts`.
+   */
+  protected async testCliAvailability(customPath?: string): Promise<{ available: boolean; error?: string; version?: string; path?: string }> {
+    const configuredPath = customPath?.trim();
+
+    getShellPath();
+    const resolvedPath = configuredPath || findExecutableInPath('pi');
+    if (!resolvedPath) {
+      this.resolvedExecutablePath = null;
+      return { available: false, error: 'pi executable not found in PATH' };
+    }
+
+    try {
+      const probe = await this.probeVersion(resolvedPath);
+      if (probe.usedNodeFallback) {
+        this.markNeedsNodeFallback();
+      }
+
+      const verdict = evaluatePiVersionPolicy(probe.version);
+      if (!verdict.ok) {
+        this.resolvedExecutablePath = null;
+        const reason =
+          verdict.reason === 'below-floor'
+            ? `pi ${probe.version} is older than the minimum supported version ${PI_MIN_SUPPORTED_VERSION}`
+            : `could not parse pi version output "${probe.version}"`;
+        return { available: false, error: reason, version: probe.version, path: resolvedPath };
+      }
+      if (verdict.aboveTested) {
+        this.logger?.warn(
+          `[PI] detected version ${probe.version} is newer than the last version this integration was tested against (${PI_TESTED_VERSION}); proceeding, but behavior beyond the tested version is unverified.`,
+        );
+      }
+
+      this.resolvedExecutablePath = resolvedPath;
+      return { available: true, version: probe.version, path: resolvedPath };
+    } catch (err) {
+      this.resolvedExecutablePath = null;
+      return {
+        available: false,
+        error: `Failed to run "${resolvedPath} --version": ${err instanceof Error ? err.message : String(err)}`,
+        path: resolvedPath,
+      };
+    }
+  }
+
+  /** Probe `--version` with the SAME environment the spawn will use. */
+  protected async probeVersion(executablePath: string): Promise<CliVersionProbeResult> {
+    return probeCliVersion(executablePath, await this.getSystemEnvironment());
+  }
+
+  protected async getCliExecutablePath(): Promise<string> {
+    if (this.resolvedExecutablePath) {
+      return this.resolvedExecutablePath;
+    }
+    const availability = await this.testCliAvailability();
+    if (!availability.available || !availability.path) {
+      throw new Error(`Pi CLI not available: ${availability.error ?? 'unknown error'}`);
+    }
+    return availability.path;
+  }
+
+  /**
+   * The PTY argv: `--no-extensions --no-skills [--model <selection>]
+   * [--continue] [-- <prompt>]`.
+   *
+   * No `--thinking` flag: effort is unsupported on this lane
+   * (RUNTIME_CAPABILITIES carries false for both pi runtimes — same
+   * stored-but-dropped reasoning as codex-pty). `options.model` passes through
+   * VERBATIM: pi takes `provider/id` patterns natively and Cyboflow persists Pi
+   * selections in exactly that canonical form.
+   *
+   * {@link assertPiRequiredSpawnFlags} runs on every call, right before
+   * returning — the discovery-lockdown invariant as a spawn-time assertion.
+   */
+  protected buildCommandArgs(options: PiPtySpawnOptions): string[] {
+    const args: string[] = [];
+    args.push('--no-extensions', '--no-skills');
+
+    if (options.model && options.model.trim().length > 0) {
+      args.push('--model', options.model);
+    }
+
+    if (options.isContinue) {
+      args.push('--continue');
+    }
+
+    // pi's parser has NO `--` terminator (verified live: 'Unknown option:
+    // --'), so a dash-leading prompt would parse as flags. A single leading
+    // space is the parser-safe encoding — content otherwise verbatim.
+    const prompt =
+      options.prompt.startsWith('-') ? ` ${options.prompt}` : options.prompt;
+    if (prompt.trim().length > 0) {
+      args.push(prompt);
+    }
+
+    assertPiRequiredSpawnFlags(args);
+    return args;
+  }
+
+  protected parseCliOutput(data: string, panelId: string, sessionId: string): Array<{ panelId: string; sessionId: string; type: 'json' | 'stdout' | 'stderr'; data: unknown; timestamp: Date }> {
+    return [{
+      panelId,
+      sessionId,
+      type: 'stdout',
+      data,
+      timestamp: new Date(),
+    }];
+  }
+
+  protected async initializeCliEnvironment(_options: PiPtySpawnOptions): Promise<{ [key: string]: string }> {
+    return {};
+  }
+
+  protected async getCliEnvironment(_options: PiPtySpawnOptions): Promise<{ [key: string]: string }> {
+    return {};
+  }
+
+  protected async cleanupCliResources(sessionId: string): Promise<void> {
+    for (const [panelId, process] of this.processes.entries()) {
+      if (process.sessionId !== sessionId) continue;
+      const runId = this.panelRunIds.get(panelId);
+      this.panelRunIds.delete(panelId);
+      if (runId) {
+        this.ptyBacklog.delete(runId);
+      }
+    }
+  }
+
+  override async spawnCliProcess(options: PiPtySpawnOptions): Promise<void> {
+    const runId = options.runId ?? options.panelId;
+    this.panelRunIds.set(options.panelId, runId);
+    try {
+      await this.runWithPtySpawnContext(
+        { panelId: options.panelId, sessionId: options.sessionId, runId },
+        () => super.spawnCliProcess({ ...options, runId }),
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.emit('pty-output', {
+        panelId: options.panelId,
+        sessionId: options.sessionId,
+        runId,
+        type: 'pty',
+        data: `\r\n\x1b[31mPi failed to start: ${message}\x1b[0m\r\n`,
+        timestamp: new Date(),
+      });
+      this.emit('exit', {
+        panelId: options.panelId,
+        sessionId: options.sessionId,
+        exitCode: 1,
+        signal: null,
+      });
+      this.panelRunIds.delete(options.panelId);
+      this.ptyBacklog.delete(runId);
+      throw err;
+    }
+  }
+
+  protected override async spawnPtyProcess(command: string, args: string[], cwd: string, env: { [key: string]: string }): Promise<pty.IPty> {
+    const ptyProcess = await super.spawnPtyProcess(command, args, cwd, env);
+    const context = this.ptySpawnContext.getStore();
+    if (context) {
+      ptyProcess.onData((data: string) => {
+        this.recordPtyBacklog(context.runId, data);
+        this.emit('pty-output', {
+          panelId: context.panelId,
+          sessionId: context.sessionId,
+          runId: context.runId,
+          type: 'pty',
+          data,
+          timestamp: new Date(),
+        });
+      });
+    }
+    return ptyProcess;
+  }
+
+  async startPanel(
+    panelId: string,
+    sessionId: string,
+    worktreePath: string,
+    prompt: string,
+    permissionMode?: 'approve' | 'ignore',
+    model?: string,
+    runId?: string,
+  ): Promise<void> {
+    await this.spawnCliProcess({
+      panelId,
+      sessionId,
+      worktreePath,
+      prompt,
+      permissionMode,
+      agentPermissionMode: this.resolveSessionAgentPermissionMode(sessionId, permissionMode),
+      model,
+      runId,
+    });
+  }
+
+  /**
+   * Respawn with `--continue`, scoped to `worktreePath` as the pi process cwd.
+   * A REAL resume, like OMP's: pi persists sessions per-project and
+   * `--continue` picks up that worktree's most-recent session, so prior turns
+   * are genuinely still there for the model.
+   */
+  async continuePanel(
+    panelId: string,
+    sessionId: string,
+    worktreePath: string,
+    prompt: string,
+    _conversationHistory: ConversationMessage[],
+    permissionMode?: 'approve' | 'ignore',
+    model?: string,
+  ): Promise<void> {
+    await this.killProcess(panelId);
+    await this.spawnCliProcess({
+      panelId,
+      sessionId,
+      worktreePath,
+      prompt,
+      permissionMode,
+      agentPermissionMode: this.resolveSessionAgentPermissionMode(sessionId, permissionMode),
+      model,
+      isContinue: true,
+    });
+  }
+
+  relayUserTurn(panelId: string, input: string): void {
+    this.sendInput(panelId, `${input}\r`);
+  }
+
+  relayRawInput(panelId: string, input: string): void {
+    this.sendInput(panelId, input);
+  }
+
+  resizePanel(panelId: string, cols: number, rows: number): void {
+    const process = this.getProcess(panelId);
+    if (!process) return;
+    process.process.resize(cols, rows);
+  }
+
+  getPtyBacklog(runId: string): string {
+    return this.ptyBacklog.get(runId) ?? '';
+  }
+
+  async stopPanel(panelId: string): Promise<void> {
+    const runId = this.panelRunIds.get(panelId);
+    await this.killProcess(panelId);
+    this.panelRunIds.delete(panelId);
+    if (runId) {
+      this.ptyBacklog.delete(runId);
+    }
+  }
+
+  async restartPanelWithHistory(
+    panelId: string,
+    sessionId: string,
+    worktreePath: string,
+    initialPrompt: string,
+    _conversationHistory: ConversationMessage[],
+  ): Promise<void> {
+    await this.killProcess(panelId);
+    const permissionMode = this.sessionManager.getDbSession(sessionId)?.permission_mode;
+    await this.startPanel(panelId, sessionId, worktreePath, initialPrompt, permissionMode);
+  }
+
+  protected getCliNotAvailableMessage(error?: string): string {
+    const interpreterAdvice = this.missingInterpreterAdvice(error);
+    if (interpreterAdvice) {
+      return [`Error: ${error}`, '', interpreterAdvice].join('\n');
+    }
+    if (error && /older than the minimum supported version/.test(error)) {
+      return [
+        `Error: ${error}`,
+        '',
+        'Pi is installed but too old for this integration. Update it with:',
+        '  pi update self',
+        'or:',
+        '  npm install -g @earendil-works/pi-coding-agent@latest',
+      ].join('\n');
+    }
+    return [
+      `Error: ${error}`,
+      '',
+      'Pi CLI is not available.',
+      '',
+      'Install pi with:',
+      '  npm install -g @earendil-works/pi-coding-agent',
+      '',
+      'Then verify `pi --version` works in your shell.',
+    ].join('\n');
+  }
+
+  private resolveSessionAgentPermissionMode(
+    sessionId: string,
+    legacyPermissionMode?: 'approve' | 'ignore',
+  ): PermissionMode {
+    if (legacyPermissionMode === 'ignore') return 'dontAsk';
+    const stored = this.sessionManager.getDbSession(sessionId)?.agent_permission_mode;
+    if (isPermissionMode(stored)) return stored;
+    return this.configManager?.getDefaultAgentPermissionMode() ?? 'default';
+  }
+
+  private recordPtyBacklog(runId: string, data: string): void {
+    const next = (this.ptyBacklog.get(runId) ?? '') + data;
+    this.ptyBacklog.set(
+      runId,
+      next.length > PTY_BACKLOG_CAP_BYTES ? next.slice(-PTY_BACKLOG_CAP_BYTES) : next,
+    );
+  }
+
+  protected runWithPtySpawnContext<T>(context: PiPtySpawnContext, operation: () => T): T {
+    return this.ptySpawnContext.run(context, operation);
+  }
+
+  protected getActivePtySpawnContext(): PiPtySpawnContext | undefined {
+    return this.ptySpawnContext.getStore();
+  }
+}

--- a/main/src/services/panels/pi/piSdkManager.ts
+++ b/main/src/services/panels/pi/piSdkManager.ts
@@ -446,17 +446,21 @@ export class PiSdkManager extends AbstractCliManager {
         model: typeof options.model === 'string' ? options.model : undefined,
         cwd: options.worktreePath ?? process.cwd(),
         child: null,
-        // Workflow steps are HEADLESS: no TUI to approve in, so the fail-
-        // closed answer is 'gated' regardless of any run-level mode snapshot.
         gateMode: 'gated',
       };
       this.turns.set(panelId, state);
     } else {
-      // Workflow re-runs against an existing panel must pick up a CHANGED
-      // model or worktree, not ride the stale first-turn values.
+      // Workflow re-runs against an existing panel must pick up CHANGED
+      // model/worktree/permission values, not ride stale first-turn ones.
       if (typeof options.model === 'string') state.model = options.model;
       if (options.worktreePath) state.cwd = options.worktreePath;
     }
+    // The run's permission_mode_snapshot is authoritative per turn: an
+    // explicit dontAsk unlocks the yolo policy, anything else stays gated.
+    const runMode = options.agentPermissionMode;
+    state.gateMode = piGateModeForMode(
+      isPermissionMode(runMode) ? runMode : 'default',
+    );
     if (state.child && !state.child.killed) {
       throw new Error(`[PI] a turn is already running for panel ${panelId}`);
     }

--- a/main/src/services/panels/pi/piSdkManager.ts
+++ b/main/src/services/panels/pi/piSdkManager.ts
@@ -1,0 +1,534 @@
+import { spawn, type ChildProcess, type ChildProcessByStdio } from 'node:child_process';
+import type { Writable, Readable } from 'node:stream';
+import { randomUUID } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { AgentProvider } from '../../../../../shared/types/agentRuntime';
+import type { ConversationMessage } from '../../../database/models';
+import type { PermissionMode } from '../../../../../shared/types/workflows';
+import { isPermissionMode } from '../../../../../shared/types/workflows';
+import type { CliSpawnOutcome } from '../../../../../shared/types/cliPanels';
+import type { ClaudeSpawnerOptions } from '../../../orchestrator/runExecutor';
+import { getShellPath, findExecutableInPath } from '../../../utils/shellPath';
+import { AbstractCliManager } from '../cli/AbstractCliManager';
+import { probeCliVersion, type CliVersionProbeResult } from '../cli/cliVersionProbe';
+import { evaluatePiVersionPolicy, PI_MIN_SUPPORTED_VERSION, PI_TESTED_VERSION } from './piVersions';
+import {
+  PI_GATE_ENV_KEYS,
+  PI_GATE_EXTENSION_SOURCE,
+  piGateModeForMode,
+} from './piGateExtension';
+import { assertPiRequiredSpawnFlags } from './piPtyManager';
+
+/** The gate mode stashed per turn; 'gated' is the fail-closed default. */
+type PiGateModeLike = 'dontAsk' | 'gated';
+
+interface PiSdkSpawnOptions {
+  panelId: string;
+  sessionId: string;
+  worktreePath: string;
+  prompt: string;
+  permissionMode?: 'approve' | 'ignore';
+  agentPermissionMode?: PermissionMode;
+  model?: string;
+  runId?: string;
+}
+
+interface PiTurnState {
+  gateMode: PiGateModeLike;
+  /** The pi-side session id WE chose (`--session-id` creates-if-missing), so
+   *  resume across turns is deterministic instead of most-recent-wins. */
+  piSessionId: string;
+  model?: string;
+  cwd: string;
+  child: ChildProcess | null;
+}
+
+/** Per-line JSON event from `pi --mode json` (docs/json.md, header version 3). */
+interface PiJsonEvent {
+  type: string;
+  // message_* events carry { message }; agent_end closes the turn. Parsed
+  // loosely on purpose — unknown members are ignored.
+  message?: {
+    id?: string;
+    role?: string;
+    content?: Array<{ type: string; text?: string }>;
+  };
+  [key: string]: unknown;
+}
+
+/**
+ * PiSdkManager — the structured pi lane. One SHORT-LIVED `pi --mode json`
+ * child PER TURN (not a persistent RPC child): every turn resumes the same
+ * deterministic pi session via `--session-id`, streams JSON-lines events, and
+ * projects them onto the Claude-shaped wire the chat projection already
+ * consumes.
+ *
+ * Why turn-spawn instead of an OMP-style persistent RPC for v1: pi's rpc mode
+ * needs its own frame client (OMP's is ~2.4k lines); turn-spawn gets a fully
+ * working workflow-launchable lane now with resume semantics that are
+ * STRONGER than most-recent-wins (`--session-id` pins the exact session).
+ * Documented v1 limits: no mid-turn steer (a user message queues until the
+ * child exits and a follow-up turn spawns), one process start per turn, and
+ * no usage persistence yet.
+ */
+export class PiSdkManager extends AbstractCliManager {
+  private resolvedExecutablePath: string | null = null;
+  private readonly turns = new Map<string, PiTurnState>();
+
+  protected getCliToolName(): string {
+    return 'Pi';
+  }
+
+  protected getAgentProvider(): AgentProvider {
+    return 'pi';
+  }
+
+  /** Same ladder/policy as {@link PiPtyManager.testCliAvailability}. */
+  protected async testCliAvailability(customPath?: string): Promise<{ available: boolean; error?: string; version?: string; path?: string }> {
+    const configuredPath = customPath?.trim();
+
+    getShellPath();
+    const resolvedPath = configuredPath || findExecutableInPath('pi');
+    if (!resolvedPath) {
+      this.resolvedExecutablePath = null;
+      return { available: false, error: 'pi executable not found in PATH' };
+    }
+
+    try {
+      const probe = await this.probeVersion(resolvedPath);
+      if (probe.usedNodeFallback) {
+        this.markNeedsNodeFallback();
+      }
+      const verdict = evaluatePiVersionPolicy(probe.version);
+      if (!verdict.ok) {
+        this.resolvedExecutablePath = null;
+        return {
+          available: false,
+          error:
+            verdict.reason === 'below-floor'
+              ? `pi ${probe.version} is older than the minimum supported version ${PI_MIN_SUPPORTED_VERSION}`
+              : `could not parse pi version output "${probe.version}"`,
+          version: probe.version,
+          path: resolvedPath,
+        };
+      }
+      if (verdict.aboveTested) {
+        this.logger?.warn(
+          `[PI] detected version ${probe.version} is newer than the last tested version (${PI_TESTED_VERSION}); proceeding unverified.`,
+        );
+      }
+      this.resolvedExecutablePath = resolvedPath;
+      return { available: true, version: probe.version, path: resolvedPath };
+    } catch (err) {
+      this.resolvedExecutablePath = null;
+      return {
+        available: false,
+        error: `Failed to run "${resolvedPath} --version": ${err instanceof Error ? err.message : String(err)}`,
+        path: resolvedPath,
+      };
+    }
+  }
+
+  protected async probeVersion(executablePath: string): Promise<CliVersionProbeResult> {
+    return probeCliVersion(executablePath, await this.getSystemEnvironment());
+  }
+
+  protected async getCliExecutablePath(): Promise<string> {
+    if (this.resolvedExecutablePath) return this.resolvedExecutablePath;
+    const availability = await this.testCliAvailability();
+    if (!availability.available || !availability.path) {
+      throw new Error(`Pi CLI not available: ${availability.error ?? 'unknown error'}`);
+    }
+    return availability.path;
+  }
+
+  async startPanel(
+    panelId: string,
+    sessionId: string,
+    worktreePath: string,
+    prompt: string,
+    permissionMode?: 'approve' | 'ignore',
+    model?: string,
+    runId?: string,
+  ): Promise<void> {
+    // Deterministic per-panel pi session id: `--session-id` creates it on the
+    // first turn and RESUMES it on every later turn.
+    this.turns.set(panelId, {
+      // Pinned to `<cyboflow session>-<panel>`: BOTH halves are restart-
+      // stable (tool_panels.id is a persisted PK; sessions.active_panel_id
+      // carries it), so each panel gets its own pi conversation that survives
+      // relaunch. Random ids made resume die whenever the in-memory map was
+      // lost; bare-session pins would cross-wire two panels onto one
+      // conversation.
+      piSessionId: `cyboflow-${sessionId}-${panelId}`,
+      model,
+      cwd: worktreePath,
+      child: null,
+      gateMode: this.resolveGateMode(sessionId, permissionMode),
+    });
+    this.ensureGateFile();
+    await this.runTurn(panelId, sessionId, worktreePath, prompt, runId);
+  }
+
+  /**
+   * A follow-up turn. Resume is implicit — the SAME pinned `--session-id`
+   * carries the full prior conversation, so `_conversationHistory` needs no
+   * replay and no most-recent-wins gamble.
+   */
+  async continuePanel(
+    panelId: string,
+    sessionId: string,
+    worktreePath: string,
+    prompt: string,
+    _conversationHistory: ConversationMessage[],
+    permissionMode?: 'approve' | 'ignore',
+    model?: string,
+  ): Promise<void> {
+    let state = this.turns.get(panelId);
+    if (!state) {
+      // Post-restart path: rehydrate from the DETERMINISTIC pin instead of
+      // minting a fresh id (which silently restarted the conversation).
+      state = {
+        piSessionId: `cyboflow-${sessionId}-${panelId}`,
+        cwd: worktreePath,
+        child: null,
+        gateMode: 'gated',
+      };
+      this.turns.set(panelId, state);
+    }
+    state.gateMode = this.resolveGateMode(sessionId, permissionMode);
+    if (model && model.trim().length > 0) state.model = model;
+    await this.runTurn(panelId, sessionId, worktreePath, prompt, undefined);
+  }
+
+  async stopPanel(panelId: string): Promise<void> {
+    const state = this.turns.get(panelId);
+    if (state?.child && !state.child.killed) {
+      state.child.kill('SIGTERM');
+    }
+    if (state) state.child = null;
+    // DELIBERATELY keep the turns entry: the pinned piSessionId IS the
+    // conversation. Deleting it here made the next continuePanel mint a fresh
+    // id and silently reset the conversation after a mere cancel.
+  }
+
+  async restartPanelWithHistory(
+    panelId: string,
+    sessionId: string,
+    worktreePath: string,
+    initialPrompt: string,
+    _conversationHistory: ConversationMessage[],
+  ): Promise<void> {
+    // Preserve the PINNED session id across the restart: stopPanel tears the
+    // turn down, but the whole point of --session-id is that the conversation
+    // survives. Recreate the state before spawning so runTurn never sees a
+    // missing record.
+    const prior = this.turns.get(panelId);
+    await this.stopPanel(panelId);
+    this.turns.set(panelId, {
+      // Deterministic pin survives even a lost in-memory record.
+      piSessionId: prior?.piSessionId ?? `cyboflow-${sessionId}-${panelId}`,
+      model: prior?.model,
+      cwd: worktreePath,
+      child: null,
+      gateMode: prior?.gateMode ?? 'gated',
+    });
+    await this.runTurn(panelId, sessionId, worktreePath, initialPrompt, undefined);
+  }
+
+  /**
+   * Spawn one turn and stream its projected events. Resolves when the child
+   * exits; failures emit `exit` (code 1) after a red diagnostic line, never
+   * throw past the lifecycle caller.
+   */
+  private async runTurn(
+    panelId: string,
+    sessionId: string,
+    worktreePath: string,
+    prompt: string,
+    runId?: string,
+  ): Promise<void> {
+    const state = this.turns.get(panelId);
+    if (!state) throw new Error(`[PI] no turn state for panel ${panelId}`);
+
+    const executable = await this.getCliExecutablePath();
+    const args: string[] = [
+      '--mode', 'json',
+      '--session-id', state.piSessionId,
+      '--no-extensions', '--no-skills',
+      // The tool-call gate rides as an EXPLICIT extension: --no-extensions
+      // disables DISCOVERY only, explicit -e paths still load (pi --help).
+      '-e', this.ensureGateFile(),
+    ];
+    if (state.model && state.model.trim().length > 0) {
+      args.push('--model', state.model);
+    }
+    // The PROMPT travels on STDIN, not argv: pi's parser rejects a bare `--`
+    // separator (verified live) and would read a dash-leading prompt as
+    // flags — including ones that re-enable discovery. Stdin is the
+    // non-injectable channel.
+    args.push('--print');
+
+    // Same spawn-time invariant as the PTY lane, asserted on THIS argv too:
+    // the lockdown pair survives every future edit to this builder.
+    assertPiRequiredSpawnFlags(args);
+
+    const effRunId = runId ?? panelId;
+    await new Promise<void>((resolve) => {
+      let buffer = '';
+      let sawAgentEnd = false;
+      // stdin must be a PIPE (the prompt rides it); typing the tuple gives a
+      // non-null `stdin` instead of the `Writable | null` default.
+      const child: ChildProcessByStdio<Writable, Readable, Readable> = spawn(
+        executable,
+        args,
+        {
+          cwd: worktreePath,
+          env: {
+            ...process.env,
+            PATH: getShellPath(),
+            [PI_GATE_ENV_KEYS.mode]: state.gateMode,
+          },
+          stdio: ['pipe', 'pipe', 'pipe'],
+        },
+      );
+      state.child = child;
+      child.stdin.write(prompt);
+      child.stdin.end();
+
+      let settled = false;
+      const finish = (exitCode: number) => {
+        if (settled) return; // 'error' + 'close' both fire; settle once.
+        settled = true;
+        state.child = null;
+        if (exitCode !== 0) {
+          // A failed turn must still REST the session: emit the same
+          // system/result envelope the quick-session rest path listens for,
+          // flagged as an error, so nothing strands in 'running'.
+          this.emit('output', {
+            panelId,
+            sessionId,
+            type: 'json',
+            data: { type: 'system', subtype: 'result', is_error: true },
+            timestamp: new Date(),
+          });
+        }
+        this.emit('turn-end', { panelId, sessionId, runId: effRunId });
+        this.emit('exit', { panelId, sessionId, exitCode, signal: null });
+        resolve();
+      };
+
+      child.stdout.on('data', (chunk: Buffer) => {
+        buffer += chunk.toString('utf8');
+        let idx: number;
+        while ((idx = buffer.indexOf('\n')) >= 0) {
+          const line = buffer.slice(0, idx).trim();
+          buffer = buffer.slice(idx + 1);
+          if (!line) continue;
+          if (this.handleEventLine(line, panelId, sessionId)) sawAgentEnd = true;
+        }
+      });
+      child.stderr.on('data', (chunk: Buffer) => {
+        // Auth/provider notices print here; surface as stderr output so the
+        // Output view shows WHY a turn produced nothing.
+        this.emit('output', {
+          panelId,
+          sessionId,
+          type: 'stderr',
+          data: chunk.toString('utf8'),
+          timestamp: new Date(),
+        });
+      });
+      child.on('error', (e: Error) => {
+        this.emit('output', {
+          panelId,
+          sessionId,
+          type: 'stdout',
+          data: `\r\n\x1b[31mPi failed to start: ${e.message}\x1b[0m\r\n`,
+          timestamp: new Date(),
+        });
+        finish(1);
+      });
+      child.on('close', (code) => {
+        // pi's final line may lack a trailing newline — flush the remainder
+        // through the projector BEFORE deciding how the turn ended.
+        const rest = buffer.trim();
+        buffer = '';
+        if (rest && this.handleEventLine(rest, panelId, sessionId)) sawAgentEnd = true;
+        if (code === 0 && !sawAgentEnd) {
+          // Clean exit without agent_end still has to REST the session.
+          this.logger?.warn(`[PI] turn for panel ${panelId} exited 0 without agent_end; synthesizing result`);
+          this.emit('output', {
+            panelId,
+            sessionId,
+            type: 'json',
+            data: { type: 'system', subtype: 'result', is_error: false },
+            timestamp: new Date(),
+          });
+        }
+        finish(code ?? 1);
+      });
+    });
+  }
+
+  /**
+   * Project one JSON-lines event onto the Claude-shaped wire:
+   * - `message_end`(assistant) → `{type:'assistant', message:{content:[…]}}`
+   * - `agent_end`              → the `{type:'system', subtype:'result'}`
+   *   envelope the quick-session rest path listens for.
+   * Deltas (`message_update`) are intentionally dropped: projection is
+   * end-of-message, matching how codex-sdk emits whole messages. Returns true
+   * when the event closed the turn.
+   */
+  private handleEventLine(line: string, panelId: string, sessionId: string): boolean {
+    let evt: PiJsonEvent;
+    try {
+      evt = JSON.parse(line) as PiJsonEvent;
+    } catch {
+      // Not JSON (banner/noise) — ignore rather than guess.
+      return false;
+    }
+
+    if (evt.type === 'message_end' && evt.message?.role === 'assistant') {
+      const text = (evt.message.content ?? [])
+        .filter((b) => b.type === 'text' && typeof b.text === 'string')
+        .map((b) => b.text)
+        .join('');
+      if (text.length === 0) return false;
+      this.lastResultText.set(panelId, text);
+      this.emit('output', {
+        panelId,
+        sessionId,
+        type: 'json',
+        data: {
+          type: 'assistant',
+          message: {
+            id: evt.message.id ?? `pi-${randomUUID()}`,
+            model: 'pi',
+            role: 'assistant',
+            content: [{ type: 'text', text }],
+          },
+          session_id: sessionId,
+        },
+        timestamp: new Date(),
+      });
+      return false;
+    }
+
+    if (evt.type === 'agent_end') {
+      this.emit('output', {
+        panelId,
+        sessionId,
+        type: 'json',
+        data: { type: 'system', subtype: 'result', is_error: false },
+        timestamp: new Date(),
+      });
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * The RunExecutor/workflow entry point. Mirrors startPanel but honors the
+   * spawner options' runId/spawnKey and returns the turn's final assistant
+   * text as the step-output channel (null when the turn produced none).
+   */
+  override async spawnCliProcess(options: ClaudeSpawnerOptions): Promise<CliSpawnOutcome> {
+    this.assertProviderEnabled(options);
+    const panelId = options.spawnKey ?? options.panelId;
+    const sessionId = options.sessionId ?? panelId;
+    let state = this.turns.get(panelId);
+    if (!state) {
+      state = {
+        piSessionId: `cyboflow-${sessionId}-${panelId}`,
+        model: typeof options.model === 'string' ? options.model : undefined,
+        cwd: options.worktreePath ?? process.cwd(),
+        child: null,
+        // Workflow steps are HEADLESS: no TUI to approve in, so the fail-
+        // closed answer is 'gated' regardless of any run-level mode snapshot.
+        gateMode: 'gated',
+      };
+      this.turns.set(panelId, state);
+    } else {
+      // Workflow re-runs against an existing panel must pick up a CHANGED
+      // model or worktree, not ride the stale first-turn values.
+      if (typeof options.model === 'string') state.model = options.model;
+      if (options.worktreePath) state.cwd = options.worktreePath;
+    }
+    if (state.child && !state.child.killed) {
+      throw new Error(`[PI] a turn is already running for panel ${panelId}`);
+    }
+    await this.runTurn(panelId, sessionId, state.cwd, options.prompt ?? '', options.runId);
+    return { resultText: this.lastResultText.get(panelId) ?? null };
+  }
+
+  /** Final assistant text of the most recent turn, for {@link CliSpawnOutcome}. */
+  private readonly lastResultText = new Map<string, string>();
+
+  /** A panel is running while its pinned-session turn child is alive. */
+  override isPanelRunning(panelId: string): boolean {
+    const child = this.turns.get(panelId)?.child;
+    return child !== null && child !== undefined && !child.killed;
+  }
+
+
+  // ── AbstractCliManager abstract members ────────────────────────────────
+  // The turn-spawn lane never drives the PTY argv machinery, but the base
+  // class declares these abstract. Kept as honest no-ops so a future
+  // persistent-rpc upgrade can repurpose them instead of fighting them.
+
+  protected buildCommandArgs(_options: { prompt: string; model?: string }): string[] {
+    // FAIL CLOSED: this lane's argv is built inside runTurn (json mode +
+    // pinned session + lockdown pair). Reaching this base-class hook means a
+    // PTY-style caller bypassed spawnCliProcess — refuse rather than launch a
+    // bare interactive pi with extensions enabled.
+    throw new Error(
+      '[PI] sdk lane does not use buildCommandArgs; turns must go through spawnCliProcess/runTurn (which pin --session-id and the discovery-lockdown flags).',
+    );
+  }
+
+  protected parseCliOutput(data: string, panelId: string, sessionId: string): Array<{ panelId: string; sessionId: string; type: 'json' | 'stdout' | 'stderr'; data: unknown; timestamp: Date }> {
+    return [{ panelId, sessionId, type: 'stdout', data, timestamp: new Date() }];
+  }
+
+  protected async initializeCliEnvironment(_options: PiSdkSpawnOptions): Promise<{ [key: string]: string }> {
+    return {};
+  }
+
+  protected async getCliEnvironment(_options: PiSdkSpawnOptions): Promise<{ [key: string]: string }> {
+    return {};
+  }
+
+  protected async cleanupCliResources(sessionId: string): Promise<void> {
+    void sessionId;
+  }
+
+  /** 'dontAsk' only when the session itself recorded it; everything else gated. */
+  private resolveGateMode(sessionId: string, legacyPermissionMode?: 'approve' | 'ignore'): PiGateModeLike {
+    if (legacyPermissionMode === 'ignore') return 'dontAsk';
+    const stored = this.sessionManager.getDbSession(sessionId)?.agent_permission_mode;
+    if (isPermissionMode(stored)) return piGateModeForMode(stored);
+    return this.configManager?.getDefaultAgentPermissionMode() === 'dontAsk'
+      ? 'dontAsk'
+      : 'gated';
+  }
+
+  private gateFilePathCached: string | null = null;
+
+  /**
+   * Write the gate extension once per manager and return its path. Idempotent:
+   * rewritten only when the embedded source changes, so concurrent spawns share
+   * one file and a version bump lands on the next boot.
+   */
+  private ensureGateFile(): string {
+    if (this.gateFilePathCached) return this.gateFilePathCached;
+    const dir = path.join(os.homedir(), '.cyboflow');
+    fs.mkdirSync(dir, { recursive: true });
+    const filePath = path.join(dir, 'pi-gate.mjs');
+    fs.writeFileSync(filePath, PI_GATE_EXTENSION_SOURCE, { mode: 0o600 });
+    this.gateFilePathCached = filePath;
+    return filePath;
+  }
+}

--- a/main/src/services/panels/pi/piVersions.ts
+++ b/main/src/services/panels/pi/piVersions.ts
@@ -1,0 +1,52 @@
+/**
+ * Version discipline for the Pi CLI (@earendil-works/pi-coding-agent).
+ *
+ * Same policy shape as ompVersions.ts: pi releases continuously and we spawn
+ * the USER's binary, so a hard equality pin would rot immediately.
+ *
+ *   - PI_MIN_SUPPORTED_VERSION — hard floor; below it probes report
+ *     'unavailable' because behavior this integration depends on may be
+ *     absent: `--mode json` (session-header v3 event stream),
+ *     `--session-id <id>` create-or-resume-by-exact-id (verified live: turn 2
+ *     answered from turn-1 context under the pinned id), and the extension
+ *     `tool_call` blocking hook.
+ *   - PI_TESTED_VERSION — newest verified version; newer binaries are accepted
+ */
+
+/** Hard floor: a probed pi binary below this version is refused. */
+export const PI_MIN_SUPPORTED_VERSION = '0.84.0';
+
+/** Newest version verified against; soft ceiling only — never refuses. */
+export const PI_TESTED_VERSION = '0.84.2';
+
+export interface PiVersionVerdict {
+  ok: boolean;
+  aboveTested: boolean;
+  /** Why a binary failed: below the floor, or unparseable `--version` output. */
+  reason?: 'below-floor' | 'unparseable';
+}
+
+/**
+ * Compare a probed semver string against the floor/tested pair. Non-semver
+ * output fails closed (`ok: false`) so a broken `--version` never reads as a
+ * usable binary.
+ */
+export function evaluatePiVersionPolicy(rawVersion: string): PiVersionVerdict {
+  const match = rawVersion.trim().match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return { ok: false, aboveTested: false, reason: 'unparseable' };
+  const toTuple = (v: string): [number, number, number] =>
+    v.split('.').map(Number) as [number, number, number];
+  const cmp = (a: [number, number, number], b: [number, number, number]): number => {
+    for (let i = 0; i < 3; i++) {
+      if (a[i] !== b[i]) return a[i] - b[i];
+    }
+    return 0;
+  };
+  const parsed = toTuple(match[0]);
+  const belowFloor = cmp(parsed, toTuple(PI_MIN_SUPPORTED_VERSION)) < 0;
+  return {
+    ok: !belowFloor,
+    aboveTested: cmp(parsed, toTuple(PI_TESTED_VERSION)) > 0,
+    reason: belowFloor ? 'below-floor' : undefined,
+  };
+}

--- a/main/src/services/substrateDispatchFacade.ts
+++ b/main/src/services/substrateDispatchFacade.ts
@@ -149,6 +149,14 @@ const LANE_WIRING: Readonly<Record<PanelLane, LaneWiring>> = {
   // tail has to survive for a terminal that mounts afterwards.
   'omp-sdk': { output: true, spawned: true, turnEnd: false, retainBacklogOnFailedExit: false },
   'omp-pty': { output: true, spawned: true, turnEnd: true, retainBacklogOnFailedExit: true },
+  // Pi lanes take the row their TRANSPORT implies, same reasoning as the OMP
+  // pair above: the sdk lane (pi --mode json) forwards output + spawned and
+  // serves workflow runs; the pty lane adds turn-end and retains the backlog
+  // on failed exit because pi is a user-installed binary found by a discovery
+  // ladder — a failed startup's error tail has to survive for a terminal that
+  // mounts afterwards.
+  'pi-sdk': { output: true, spawned: true, turnEnd: false, retainBacklogOnFailedExit: false },
+  'pi-pty': { output: true, spawned: true, turnEnd: true, retainBacklogOnFailedExit: true },
 };
 
 /**

--- a/main/src/services/trackerSync/dartAdapter.test.ts
+++ b/main/src/services/trackerSync/dartAdapter.test.ts
@@ -72,7 +72,7 @@ function scriptedFetch(handlers: RouteHandler[]): { fetchImpl: FetchLike; calls:
 const BOARD = 'Engineering/Sprint';
 const SELECTION: TrackerSourceSelection = { containerId: BOARD, narrowId: 'all', narrowKind: 'all' };
 /** An outbox client key, in the shape writeBack mints (randomUUID). */
-const CLIENT_KEY = '3f2504e0-4f89-11d3-9a0c-0305e82c3301';
+const CLIENT_KEY = '3f2504e0-4f89-11d3-9a0c-0305e82c3301'; // gitleaks:allow — RFC 4122 example UUID, randomUUID-shaped fixture
 
 const CONFIG = {
   dartboards: [BOARD, 'Design/Backlog'],

--- a/main/src/utils/__tests__/timestampUtils.test.ts
+++ b/main/src/utils/__tests__/timestampUtils.test.ts
@@ -108,6 +108,10 @@ describe('getTimeDifference is unaffected when BOTH sides share a format', () =>
     // A raw column compared against an already-zoned value skews by the offset.
     const offsetMs = new Date(UTC_INSTANT).getTimezoneOffset() * 60_000;
     const skew = getTimeDifference('2026-08-24 19:12:52', new Date(UTC_INSTANT));
-    expect(skew).toBe(-offsetMs);
+    // On a UTC runner offsetMs is 0, so -offsetMs is -0 — and toBe
+    // distinguishes -0 from +0. Accept either zero: the hazard this
+    // documents is the NONZERO skew, not the sign of zero.
+    const expected = offsetMs === 0 ? 0 : -offsetMs;
+    expect(skew).toBe(expected);
   });
 });

--- a/shared/types/agentCapabilities.ts
+++ b/shared/types/agentCapabilities.ts
@@ -88,7 +88,14 @@ export const RUNTIME_CAPABILITIES: Readonly<Record<AgentRuntime, AgentRuntimeCap
   // worker owns its model and thinking level (DEFAULT_OMP_MODEL), so effort and
   // fast mode are both producer-side and hidden here.
   'omp-fleet': { selectableInPickers: true, supportsEffort: false, supportsFastMode: false },
-};
+  // Pi lanes. pi-pty takes the codex/omp PTY answer: keystroke-driven TUI, no
+  // turn-options object to carry an effort level. pi-sdk spawns `pi --mode
+  // json`; its wire events carry usage and tool results but no per-turn
+  // thinking-level control surface yet, so effort stays false until the spawn
+  // side learns a flag for it. Fast mode remains the Claude-only opt-in.
+  'pi-sdk': { selectableInPickers: true, supportsEffort: false, supportsFastMode: false },
+  'pi-pty': { selectableInPickers: true, supportsEffort: false, supportsFastMode: false },
+ };
 
 /**
  * What an UNREGISTERED runtime is assumed to support: nothing. A runtime string

--- a/shared/types/agentModels.ts
+++ b/shared/types/agentModels.ts
@@ -81,6 +81,16 @@ export interface OmpModelCatalog {
 }
 
 /**
+ * Pi fronts many vendors the same way OMP does (`pi --model provider/id`),
+ * so a Pi selection is the same slashed `provider/model` pair with the same
+ * bare-wire-id caveat. The catalog shape is therefore OMP's: rows compose the
+ * canonical selection from separate `provider` and `id` fields.
+ */
+export interface PiModelCatalog {
+  models: OmpModelOption[];
+}
+
+/**
  * Which catalog shape each provider advertises.
  *
  * The three are deliberately NOT flattened into one type: a Codex row carries
@@ -95,6 +105,7 @@ export interface ProviderModelCatalogs {
   claude: ClaudeModelCatalog;
   codex: CodexModelCatalog;
   omp: OmpModelCatalog;
+  pi: PiModelCatalog;
 }
 
 /**
@@ -147,6 +158,7 @@ export function isOmpModelFamily(model: string): boolean {
   return slash > 0 && slash < key.length - 1;
 }
 
+
 export function isCodexModelSelection(model: string): boolean {
   const key = model.toLowerCase().trim();
   return key === 'auto' || key === 'default' || isCodexModelFamily(key);
@@ -177,7 +189,27 @@ export const AGENT_MODEL_FAMILY_PREDICATES: Readonly<
   claude: isClaudeModelFamily,
   codex: isCodexModelFamily,
   omp: isOmpModelFamily,
+  // Pi model ids are `<vendor>/<model>` — pi's own discriminator in `--model`
+  // patterns — which is exactly OMP's slash rule, so the predicate is shared.
+  // If pi ever admits bare ids this becomes its own function.
+  pi: isOmpModelFamily,
 };
+/**
+ * Families that SHARE a shape are non-competing: omp and pi both use
+ * `<vendor>/<model>`, so a slashed id claimed by one must not be dropped
+ * because the other also claims it. Without this pair, adding pi made
+ * `normalizeAgentModelSelection('omp', 'anthropic/x')` return undefined.
+ */
+const COMPATIBLE_FAMILIES: ReadonlyArray<readonly [AgentProvider, AgentProvider]> = [
+  ['omp', 'pi'],
+];
+
+function familiesCompatible(a: AgentProvider, b: AgentProvider): boolean {
+  return COMPATIBLE_FAMILIES.some(
+    ([x, y]) => (a === x && b === y) || (a === y && b === x),
+  );
+}
+
 
 /**
  * Normalize a persisted picker value against the provider that owns it.
@@ -204,6 +236,7 @@ export function normalizeAgentModelSelection(
 
   for (const other of AGENT_PROVIDERS) {
     if (other === provider) continue;
+    if (familiesCompatible(provider, other)) continue;
     if (AGENT_MODEL_FAMILY_PREDICATES[other](key)) return undefined;
   }
   return value;

--- a/shared/types/agentRuntime.ts
+++ b/shared/types/agentRuntime.ts
@@ -104,12 +104,11 @@ export const WORKFLOW_LAUNCHABLE_RUNTIMES = [
   // do, so workflows may deploy on it. pi-pty stays excluded for the same
   // keystroke-TUI reason as codex-pty/omp-pty.
   //
-  // ACCEPTED LIMITATION, headless gating: pi has no sandbox and no
-  // approval-mode surface, so a workflow step on pi-sdk executes tools
-  // ungated. The extension-based tool_call bridge that will carry cyboflow's
-  // permission router is designed but not built; until it ships, treat a
-  // pi-sdk workflow step like an attended terminal — run it on a worktree
-  // you are watching.
+  // Gating note: an embedded tool_call extension enforces the session's
+  // permission mode inside the child (read-only passes under default/
+  // acceptEdits/auto; write-tier blocks with an actionable reason). What is
+  // NOT built yet is an interactive approval prompt — dontAsk remains the
+  // only way to run write-tier steps unattended.
   'pi-sdk',
 ] as const;
 

--- a/shared/types/agentRuntime.ts
+++ b/shared/types/agentRuntime.ts
@@ -19,7 +19,7 @@ import type { CliSubstrate } from './substrate';
  * because `z.enum` needs a non-empty readonly tuple of string literals; the
  * `AgentProvider` union is derived FROM it so the two cannot drift.
  */
-export const AGENT_PROVIDERS = ['claude', 'codex', 'omp'] as const;
+export const AGENT_PROVIDERS = ['claude', 'codex', 'omp', 'pi'] as const;
 
 export type AgentProvider = (typeof AGENT_PROVIDERS)[number];
 
@@ -43,6 +43,8 @@ export const ALL_AGENT_RUNTIMES = [
   'omp-sdk',
   'omp-pty',
   'omp-fleet',
+  'pi-sdk',
+  'pi-pty',
 ] as const;
 
 export type AgentRuntime = (typeof ALL_AGENT_RUNTIMES)[number];
@@ -79,6 +81,7 @@ export const WORKFLOW_RUN_STORABLE_RUNTIMES = [
   'codex-sdk',
   'omp-sdk',
   'omp-fleet',
+  'pi-sdk',
 ] as const;
 
 export type WorkflowRunStorableRuntime = (typeof WORKFLOW_RUN_STORABLE_RUNTIMES)[number];
@@ -96,6 +99,18 @@ export const WORKFLOW_LAUNCHABLE_RUNTIMES = [
   'claude-interactive',
   'codex-sdk',
   'omp-sdk',
+  // Structured JSON-events lane (pi --mode json): per-step events, usage and
+  // tool results reach Cyboflow the same way the SDK lanes of claude/codex/omp
+  // do, so workflows may deploy on it. pi-pty stays excluded for the same
+  // keystroke-TUI reason as codex-pty/omp-pty.
+  //
+  // ACCEPTED LIMITATION, headless gating: pi has no sandbox and no
+  // approval-mode surface, so a workflow step on pi-sdk executes tools
+  // ungated. The extension-based tool_call bridge that will carry cyboflow's
+  // permission router is designed but not built; until it ships, treat a
+  // pi-sdk workflow step like an attended terminal — run it on a worktree
+  // you are watching.
+  'pi-sdk',
 ] as const;
 
 export type WorkflowLaunchableRuntime = (typeof WORKFLOW_LAUNCHABLE_RUNTIMES)[number];
@@ -131,7 +146,9 @@ export const PROVIDER_DEFAULT_RUNTIME: Readonly<Record<AgentProvider, WorkflowLa
   claude: 'claude-sdk',
   codex: 'codex-sdk',
   omp: 'omp-sdk',
+  pi: 'pi-sdk',
 };
+
 export const DEFAULT_SESSION_AGENT_RUNTIME: SessionAgentRuntime = 'claude-sdk';
 export const DEFAULT_WORKFLOW_AGENT_RUNTIME: WorkflowLaunchableRuntime = 'claude-sdk';
 
@@ -143,6 +160,8 @@ export const SESSION_AGENT_RUNTIMES = [
   'omp-sdk',
   'omp-pty',
   'omp-fleet',
+  'pi-sdk',
+  'pi-pty',
 ] as const;
 
 /** Human labels for the workflow-scoped runtime picker. Single source shared by
@@ -152,6 +171,7 @@ export const WORKFLOW_AGENT_RUNTIME_LABELS: Record<WorkflowLaunchableRuntime, st
   'claude-interactive': 'Claude Interactive (CLI)',
   'codex-sdk': 'Codex SDK',
   'omp-sdk': 'OMP',
+  'pi-sdk': 'Pi',
 };
 
 /**
@@ -180,6 +200,8 @@ export const AGENT_RUNTIME_LABELS: Record<SessionAgentRuntime, string> = {
   'omp-sdk': 'OMP',
   'omp-pty': 'OMP (CLI)',
   'omp-fleet': 'OMP fleet',
+  'pi-sdk': 'Pi',
+  'pi-pty': 'Pi (CLI)',
 };
 
 // ---------------------------------------------------------------------------
@@ -232,6 +254,11 @@ export const AGENT_PROVIDER_REGISTRY: Readonly<Record<AgentProvider, AgentProvid
   // fleet-session launch both respect the same toggle. See
   // `AgentProviderDefinition.defaultEnabled`.
   omp: { runtimePrefix: 'omp-', defaultEnabled: false },
+  // Pi — the terminal coding agent OMP forked from, integrated natively
+  // (spawned binary, no bridge). Post-toggle provider like omp: an absent
+  // access key defaults DISABLED so installs that never touched Settings →
+  // Integrations keep every `pi-` runtime off until an explicit opt-in.
+  pi: { runtimePrefix: 'pi-', defaultEnabled: false },
 };
 
 /**
@@ -245,6 +272,7 @@ export const AGENT_PROVIDER_LABELS: Record<AgentProvider, string> = {
   claude: 'Claude',
   codex: 'Codex',
   omp: 'OMP',
+  pi: 'Pi',
 };
 
 export const AGENT_PROVIDER_TABLE: AgentProviderTable<AgentProvider> = {

--- a/shared/types/onboarding.ts
+++ b/shared/types/onboarding.ts
@@ -98,6 +98,10 @@ export interface ProviderDetectionStates {
   claude: 'detected' | 'loggedOut' | 'missing';
   codex: 'detected' | 'loggedOut' | 'unavailable';
   omp: 'detected' | 'unavailable';
+  // Pi mirrors OMP exactly: pi holds its own credentials (`~/.pi`, `/login`),
+  // so the only observable is binary presence + a successful `--version` at
+  // or above the floor. No 'loggedOut': nothing in main/ can see pi's auth.
+  pi: 'detected' | 'unavailable';
 }
 
 /** The evidence each provider's probe returns alongside its state. */
@@ -111,6 +115,10 @@ export interface ProviderDetectionPayloads {
     account: CodexAccountDetection;
   };
   omp: OmpBinaryDetection;
+  // Structurally identical evidence (binaryPath + version), so pi reuses
+  // OMP's shape rather than declaring a byte-for-byte twin interface. If the
+  // two ever diverge (e.g. pi gains an observable login), split it then.
+  pi: OmpBinaryDetection;
 }
 
 /**

--- a/shared/types/reasoningEffort.ts
+++ b/shared/types/reasoningEffort.ts
@@ -40,6 +40,11 @@ export const OMP_EFFORT_LEVELS = [
 export type ClaudeEffortLevel = (typeof CLAUDE_EFFORT_LEVELS)[number];
 export type CodexEffortLevel = (typeof CODEX_EFFORT_LEVELS)[number];
 export type OmpEffortLevel = (typeof OMP_EFFORT_LEVELS)[number];
+// Pi shares OMP's named thinking-level scale (pi's `:<thinking>` model suffix
+// and setThinkingLevel use the same off/minimal/…/max rungs). Aliased, not
+// copied: the two scales stay in lockstep until one actually diverges.
+export const PI_EFFORT_LEVELS = OMP_EFFORT_LEVELS;
+export type PiEffortLevel = OmpEffortLevel;
 
 /** The union of every effort value any provider accepts. */
 export type ReasoningEffort = ClaudeEffortLevel | CodexEffortLevel | OmpEffortLevel;
@@ -71,6 +76,7 @@ export const ALL_EFFORT_LEVELS = [
 const CLAUDE_EFFORT_SET = new Set<string>(CLAUDE_EFFORT_LEVELS);
 const CODEX_EFFORT_SET = new Set<string>(CODEX_EFFORT_LEVELS);
 const OMP_EFFORT_SET = new Set<string>(OMP_EFFORT_LEVELS);
+const PI_EFFORT_SET = OMP_EFFORT_SET;
 const ALL_EFFORT_SET = new Set<string>(ALL_EFFORT_LEVELS);
 
 /** Each provider's own ordered scale, low-to-high. Exhaustive by construction. */
@@ -78,12 +84,14 @@ const EFFORT_LEVELS_BY_PROVIDER: Readonly<Record<AgentProvider, readonly Reasoni
   claude: CLAUDE_EFFORT_LEVELS,
   codex: CODEX_EFFORT_LEVELS,
   omp: OMP_EFFORT_LEVELS,
+  pi: PI_EFFORT_LEVELS,
 };
 
 const EFFORT_SETS_BY_PROVIDER: Readonly<Record<AgentProvider, ReadonlySet<string>>> = {
   claude: CLAUDE_EFFORT_SET,
   codex: CODEX_EFFORT_SET,
   omp: OMP_EFFORT_SET,
+  pi: PI_EFFORT_SET,
 };
 
 /** Narrow an arbitrary value to a known effort level (provider-agnostic). */


### PR DESCRIPTION
Brings this fork fully current and adds two features in one reviewed line:

1. **Sync** to the 0.2.6/0.2.7 release line (perf, PTY fan-out dispatch, runbook bootstrap, Dart tracker, migrations through 122).
2. **OMP fleet supervisor runtime** — DCO-signed supersedes of #10 content (also open as #11; merging either closes the other's delta).
3. **Native `pi` provider** (`@earendil-works/pi-coding-agent`):
   - **pi-pty** interactive lane — discovery lockdown asserted at spawn (`--no-extensions --no-skills`), per-project `--continue` resume.
   - **pi-sdk** structured lane — turn-spawn `pi --mode json --session-id <cyboflow-uuid>`; deterministic exact-id resume (live-verified two-turn); JSON-lines events projected onto the Claude-shaped chat wire; workflow-launchable.
   - **Tool-call policy gate** — embedded `-e` extension enforces the session's permission mode inside the child process: `dontAsk` allows everything; every other mode passes read-only tools and blocks write-tier/unknown tools fail-closed. No interactive approval prompt yet (that's the tool_call bridge follow-up).
   - Migration **123** widens provider/runtime CHECKs on all four stamped tables with a real-upgrade ledger test + stale-filename guard.
   - Gate-mode plumbing regression tests pin dontAsk→yolo env, default→gated, reused-panel refresh, and stdin-only prompt delivery.

## Known deferred limitation

The 0.2.7 session summarizer only arms on Claude-manager exit events. **pi-sdk** and **omp-sdk** structured-lane turns do not trigger it, and the liveness probe (`isTurnInFlight`) only covers Claude managers. PTY lanes forward facade `turn-end` correctly. This affects OMP SDK lanes equally (pre-existing); it should be tracked as a follow-up that fans all structured-lane lifecycle events into the summarizer scheduler.

## Test evidence

- Full settled-tree gate green bounded-workers: main 11,910 / frontend 4,731 tests, typecheck + lint clean, schema parity / release-scripts / ABI / build suites pass.
- E2E smoke tier green on macOS runner.
- Independent model reviews: gpt-5.6-sol findings fixed in-tree, then a second pass by Claude fable.

Every commit carries Signed-off-by (DCO).
