### PR TITLE
fix(ui): remember window size and position; fix cramped first-run layout

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -198,7 +198,7 @@ export const Sidebar = memo(function Sidebar({
         data-testid="sidebar"
         className="bg-surface-primary text-text-primary h-full flex flex-col pt-4 relative flex-shrink-0 border-r border-border-primary"
         // The persisted drag width (up to 600px) is set on a large window; on a
-        // narrow one an unclamped 500px sidebar + the fixed 296px right rail
+        // narrow one an unclamped 500px sidebar + the default-width right rail
         // starve the center column to ~0 (composer collapses). Clamp to a
         // viewport fraction so the center always keeps usable width.
         // `collapsed` hides this box only — the dialogs below stay renderable.

--- a/frontend/src/components/agentRail/AgentRail.test.tsx
+++ b/frontend/src/components/agentRail/AgentRail.test.tsx
@@ -120,16 +120,16 @@ describe('AgentRail — width resize', () => {
     fireEvent.mouseUp(document);
   }
 
-  it('defaults to 320px', () => {
+  it('defaults to 360px', () => {
     render(<AgentRail />);
-    expect(railWidth()).toBe(320);
+    expect(railWidth()).toBe(360);
   });
 
   it('grows the rail on a leftward drag and persists the width', () => {
     render(<AgentRail />);
     dragHandle(-100); // 100px LEFT → +100 width
-    expect(railWidth()).toBe(420);
-    expect(localStorage.getItem(WIDTH_KEY)).toBe('420');
+    expect(railWidth()).toBe(460);
+    expect(localStorage.getItem(WIDTH_KEY)).toBe('460');
   });
 
   it('clamps to the minimum on a large rightward drag', () => {

--- a/frontend/src/components/agentRail/AgentRail.test.tsx
+++ b/frontend/src/components/agentRail/AgentRail.test.tsx
@@ -24,7 +24,12 @@ vi.mock('./AgentThreadView', () => ({
   AgentThreadView: () => <div data-testid="agent-thread-view-stub">AgentThreadView</div>,
 }));
 
-import { AgentRail, clampAgentRailWidth, shouldShowAgentRail } from './AgentRail';
+import {
+  AgentRail,
+  clampAgentRailWidth,
+  initialAgentRailWidth,
+  shouldShowAgentRail,
+} from './AgentRail';
 import { useLayoutStore } from '../../stores/layoutStore';
 
 const WIDTH_KEY = 'cyboflow.agentRail.width';
@@ -107,6 +112,15 @@ describe('AgentRail — collapse', () => {
   });
 });
 
+describe('initialAgentRailWidth', () => {
+  it('takes a stored width, ignores the superseded default, and survives junk', () => {
+    expect(initialAgentRailWidth('420')).toBe(420);
+    expect(initialAgentRailWidth('320')).toBe(360);
+    expect(initialAgentRailWidth(null)).toBe(360);
+    expect(initialAgentRailWidth('not-a-number')).toBe(360);
+  });
+});
+
 describe('AgentRail — width resize', () => {
   function railWidth(): number {
     return parseInt((screen.getByTestId('agent-rail') as HTMLElement).style.width, 10);
@@ -123,6 +137,27 @@ describe('AgentRail — width resize', () => {
   it('defaults to 360px', () => {
     render(<AgentRail />);
     expect(railWidth()).toBe(360);
+  });
+
+  it('does not write a width to localStorage until the user resizes', () => {
+    render(<AgentRail />);
+    // A mount write would stamp the current default into every install and
+    // stop any later default change from reaching anyone.
+    expect(localStorage.getItem(WIDTH_KEY)).toBeNull();
+    dragHandle(-40);
+    expect(localStorage.getItem(WIDTH_KEY)).toBe('400');
+  });
+
+  it('opens at the current default when storage holds the superseded 320', () => {
+    localStorage.setItem(WIDTH_KEY, '320');
+    render(<AgentRail />);
+    expect(railWidth()).toBe(360);
+  });
+
+  it('honours a width the user actually chose', () => {
+    localStorage.setItem(WIDTH_KEY, '420');
+    render(<AgentRail />);
+    expect(railWidth()).toBe(420);
   });
 
   it('grows the rail on a leftward drag and persists the width', () => {

--- a/frontend/src/components/agentRail/AgentRail.tsx
+++ b/frontend/src/components/agentRail/AgentRail.tsx
@@ -29,6 +29,10 @@ import { useLayoutStore } from '../../stores/layoutStore';
 /** Default expanded rail width. Wide enough for the thread view's composer
  * chrome on first run (users who drag it get their own persisted width). */
 const RAIL_DEFAULT_WIDTH = 360;
+/** The previous default. A stored width of exactly this was stamped by the
+ * mount write below, not chosen by anyone, so it does not outrank the current
+ * default. See initialAgentRailWidth. */
+const SUPERSEDED_DEFAULT_WIDTH = 320;
 /** Resize clamp: never shrink below a usable column. */
 const RAIL_MIN_WIDTH = 260;
 /** Resize clamp: cap at the smaller of an absolute ceiling or ~50% of viewport. */
@@ -51,6 +55,16 @@ export function clampAgentRailWidth(w: number): number {
   return Math.max(RAIL_MIN_WIDTH, Math.min(maxAgentRailWidth(), w));
 }
 
+/** The width to open at: a stored width, unless it is the superseded default,
+ * which every existing install holds whether or not its user ever resized. */
+export function initialAgentRailWidth(stored: string | null): number {
+  const parsed = stored !== null ? parseInt(stored, 10) : NaN;
+  if (!Number.isFinite(parsed) || parsed === SUPERSEDED_DEFAULT_WIDTH) {
+    return clampAgentRailWidth(RAIL_DEFAULT_WIDTH);
+  }
+  return clampAgentRailWidth(parsed);
+}
+
 /**
  * Gate predicate for the App.tsx mount: the rail shows on every
  * landing-family surface — everywhere except the session workspace (which
@@ -66,17 +80,22 @@ export function AgentRail() {
   // 'cyboflow.agentRail.collapsed' key as before) so ⌘] can reach it.
   const collapsed = useLayoutStore((s) => s.agentRailCollapsed);
   const handleToggleCollapse = useLayoutStore((s) => s.toggleAgentRail);
-  const [width, setWidth] = useState<number>(() => {
-    const saved = typeof localStorage !== 'undefined' ? localStorage.getItem(WIDTH_KEY) : null;
-    const parsed = saved !== null ? parseInt(saved, 10) : NaN;
-    return clampAgentRailWidth(Number.isFinite(parsed) ? parsed : RAIL_DEFAULT_WIDTH);
-  });
+  const [width, setWidth] = useState<number>(() =>
+    initialAgentRailWidth(typeof localStorage !== 'undefined' ? localStorage.getItem(WIDTH_KEY) : null),
+  );
   const [isResizing, setIsResizing] = useState(false);
   const startXRef = useRef<number>(0);
   const startWidthRef = useRef<number>(0);
 
-  // Persist the chosen width. (Brand-new key — no migrateLocalStorageKey needed.)
+  // Persist the chosen width, but not on mount. The mount write stamped the
+  // current default into storage on every install, so a later default change
+  // reached nobody who had ever opened the app.
+  const widthPersistArmed = useRef(false);
   useEffect(() => {
+    if (!widthPersistArmed.current) {
+      widthPersistArmed.current = true;
+      return;
+    }
     if (typeof localStorage !== 'undefined') {
       localStorage.setItem(WIDTH_KEY, width.toString());
     }

--- a/frontend/src/components/agentRail/AgentRail.tsx
+++ b/frontend/src/components/agentRail/AgentRail.tsx
@@ -26,8 +26,9 @@ import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { AgentThreadView } from './AgentThreadView';
 import { useLayoutStore } from '../../stores/layoutStore';
 
-/** Default expanded rail width. */
-const RAIL_DEFAULT_WIDTH = 320;
+/** Default expanded rail width. Wide enough for the thread view's composer
+ * chrome on first run (users who drag it get their own persisted width). */
+const RAIL_DEFAULT_WIDTH = 360;
 /** Resize clamp: never shrink below a usable column. */
 const RAIL_MIN_WIDTH = 260;
 /** Resize clamp: cap at the smaller of an absolute ceiling or ~50% of viewport. */

--- a/frontend/src/components/cyboflow/CyboflowRoot.tsx
+++ b/frontend/src/components/cyboflow/CyboflowRoot.tsx
@@ -392,8 +392,8 @@ export function CyboflowRoot({ projectId }: CyboflowRootProps) {
       {/* Main content area — two-column flex-row layout */}
       <div className="flex flex-row flex-1 overflow-hidden">
         {/* Left column — fluid; hosts empty-state CTA, RunBottomPane, or Canvas+RunBottomPane.
-            min-w floor: with the app sidebar at its clamped max and the fixed
-            296px right rail, an unfloored flex-1 column can collapse to ~0 on a
+            min-w floor: with the app sidebar at its clamped max and the
+            360px default right rail, an unfloored flex-1 column can collapse to ~0 on a
             narrow window (dead composer). Overflowing clips the rail instead —
             it has its own collapse affordance. */}
         <PerfProfiler id="center">
@@ -522,9 +522,10 @@ export function CyboflowRoot({ projectId }: CyboflowRootProps) {
         </div>
         </PerfProfiler>
 
-        {/* Right rail — always rendered as layout shell (296px fixed, or a thin
-            collapsed strip). Collapse state lives in layoutStore (persisted
-            there, and toggleable by ⌘] from the global shortcut handler).
+        {/* Right rail — always rendered as layout shell (360px default,
+            user-resizable, or a thin collapsed strip). Collapse state lives in
+            layoutStore (persisted there, and toggleable by ⌘] from the global
+            shortcut handler).
             quickSessionProjectId lets the Artifacts tab work with no active flow
             run (mirroring the Diff tab's session fallback) — gated on
             !isMainRepo because the main-repo session has a panels-only layout

--- a/frontend/src/components/cyboflow/RunRightRail.tsx
+++ b/frontend/src/components/cyboflow/RunRightRail.tsx
@@ -83,6 +83,10 @@ const TABS: Tab[] = [
 /** Default expanded rail width. Wide enough for its tab headers on first run
  * (users who drag it get their own persisted width instead). */
 const RAIL_DEFAULT_WIDTH = 360;
+/** The previous default. A stored width of exactly this was stamped by the
+ * mount write below, not chosen by anyone, so it does not outrank the current
+ * default. See initialRunRightRailWidth. */
+const SUPERSEDED_DEFAULT_WIDTH = 296;
 /** Resize clamp: never shrink below a usable column. */
 const RAIL_MIN_WIDTH = 240;
 /** Resize clamp: cap at the smaller of an absolute ceiling or ~50% of viewport. */
@@ -102,6 +106,16 @@ function maxRailWidth(): number {
 /** Clamp a candidate width into [min, max]. */
 function clampRailWidth(w: number): number {
   return Math.max(RAIL_MIN_WIDTH, Math.min(maxRailWidth(), w));
+}
+
+/** The width to open at: a stored width, unless it is the superseded default,
+ * which every existing install holds whether or not its user ever resized. */
+export function initialRunRightRailWidth(stored: string | null): number {
+  const parsed = stored !== null ? parseInt(stored, 10) : NaN;
+  if (!Number.isFinite(parsed) || parsed === SUPERSEDED_DEFAULT_WIDTH) {
+    return clampRailWidth(RAIL_DEFAULT_WIDTH);
+  }
+  return clampRailWidth(parsed);
 }
 
 /**
@@ -151,18 +165,24 @@ export function RunRightRail({
 
   // User-resizable width: seed from localStorage (default RAIL_DEFAULT_WIDTH),
   // always clamped. Mirrors TerminalDock's height-resize pattern, horizontal.
-  const [width, setWidth] = useState<number>(() => {
-    const saved =
-      typeof localStorage !== 'undefined' ? localStorage.getItem(RAIL_WIDTH_KEY) : null;
-    const parsed = saved !== null ? parseInt(saved, 10) : NaN;
-    return clampRailWidth(Number.isFinite(parsed) ? parsed : RAIL_DEFAULT_WIDTH);
-  });
+  const [width, setWidth] = useState<number>(() =>
+    initialRunRightRailWidth(
+      typeof localStorage !== 'undefined' ? localStorage.getItem(RAIL_WIDTH_KEY) : null,
+    ),
+  );
   const [isResizing, setIsResizing] = useState(false);
   const startXRef = useRef<number>(0);
   const startWidthRef = useRef<number>(0);
 
-  // Persist the chosen width. (Brand-new key — no migrateLocalStorageKey needed.)
+  // Persist the chosen width, but not on mount. The mount write stamped the
+  // current default into storage on every install, so a later default change
+  // reached nobody who had ever opened the app.
+  const widthPersistArmed = useRef(false);
   useEffect(() => {
+    if (!widthPersistArmed.current) {
+      widthPersistArmed.current = true;
+      return;
+    }
     if (typeof localStorage !== 'undefined') {
       localStorage.setItem(RAIL_WIDTH_KEY, width.toString());
     }

--- a/frontend/src/components/cyboflow/RunRightRail.tsx
+++ b/frontend/src/components/cyboflow/RunRightRail.tsx
@@ -80,8 +80,9 @@ const TABS: Tab[] = [
   },
 ];
 
-/** Default expanded rail width (the former fixed Tailwind width). */
-const RAIL_DEFAULT_WIDTH = 296;
+/** Default expanded rail width. Wide enough for its tab headers on first run
+ * (users who drag it get their own persisted width instead). */
+const RAIL_DEFAULT_WIDTH = 360;
 /** Resize clamp: never shrink below a usable column. */
 const RAIL_MIN_WIDTH = 240;
 /** Resize clamp: cap at the smaller of an absolute ceiling or ~50% of viewport. */

--- a/frontend/src/components/cyboflow/__tests__/RunRightRail.test.tsx
+++ b/frontend/src/components/cyboflow/__tests__/RunRightRail.test.tsx
@@ -98,7 +98,7 @@ vi.mock('../../../hooks/useArtifactsList', () => ({
 }));
 
 // Import after mocks
-import { RunRightRail } from '../RunRightRail';
+import { RunRightRail, initialRunRightRailWidth } from '../RunRightRail';
 import { useCyboflowStore } from '../../../stores/cyboflowStore';
 import { useCenterPaneStore } from '../../../stores/centerPaneStore';
 import type { UseWorkflowPhaseStateResult } from '../../../hooks/useWorkflowPhaseState';
@@ -465,6 +465,34 @@ describe('RunRightRail — width resize', () => {
     dragHandle(-100); // 100px LEFT → +100 width
     expect(railWidth()).toBe(460);
     expect(localStorage.getItem(WIDTH_KEY)).toBe('460');
+  });
+
+  it('does not write a width to localStorage until the user resizes', () => {
+    renderRail(EMPTY_PHASE_STATE);
+    // A mount write would stamp the current default into every install and
+    // stop any later default change from reaching anyone.
+    expect(localStorage.getItem(WIDTH_KEY)).toBeNull();
+    dragHandle(-40);
+    expect(localStorage.getItem(WIDTH_KEY)).toBe('400');
+  });
+
+  it('opens at the current default when storage holds the superseded 296', () => {
+    localStorage.setItem(WIDTH_KEY, '296');
+    renderRail(EMPTY_PHASE_STATE);
+    expect(railWidth()).toBe(360);
+  });
+
+  it('honours a width the user actually chose', () => {
+    localStorage.setItem(WIDTH_KEY, '420');
+    renderRail(EMPTY_PHASE_STATE);
+    expect(railWidth()).toBe(420);
+  });
+
+  it('initialRunRightRailWidth: stored wins, superseded default does not, junk falls back', () => {
+    expect(initialRunRightRailWidth('420')).toBe(420);
+    expect(initialRunRightRailWidth('296')).toBe(360);
+    expect(initialRunRightRailWidth(null)).toBe(360);
+    expect(initialRunRightRailWidth('not-a-number')).toBe(360);
   });
 
   it('clamps to the minimum on a large rightward drag', () => {

--- a/frontend/src/components/cyboflow/__tests__/RunRightRail.test.tsx
+++ b/frontend/src/components/cyboflow/__tests__/RunRightRail.test.tsx
@@ -196,8 +196,8 @@ describe('RunRightRail', () => {
     expect(screen.getByTestId('run-right-rail-workflow-progress-empty')).toBeInTheDocument();
 
     const root = screen.getByTestId('run-right-rail');
-    // Width is now an inline style (user-resizable), defaulting to 296px.
-    expect((root as HTMLElement).style.width).toBe('296px');
+    // Width is now an inline style (user-resizable), defaulting to 360px.
+    expect((root as HTMLElement).style.width).toBe('360px');
     expect(root).toHaveClass('shrink-0');
     expect(root).toHaveClass('border-l');
     // A left-edge drag handle is present for resizing.
@@ -461,10 +461,10 @@ describe('RunRightRail — width resize', () => {
 
   it('grows the rail on a leftward drag and persists the width', () => {
     renderRail(EMPTY_PHASE_STATE);
-    expect(railWidth()).toBe(296);
+    expect(railWidth()).toBe(360);
     dragHandle(-100); // 100px LEFT → +100 width
-    expect(railWidth()).toBe(396);
-    expect(localStorage.getItem(WIDTH_KEY)).toBe('396');
+    expect(railWidth()).toBe(460);
+    expect(localStorage.getItem(WIDTH_KEY)).toBe('460');
   });
 
   it('clamps to the minimum on a large rightward drag', () => {

--- a/frontend/src/components/cyboflow/unified/UnifiedChatView.tsx
+++ b/frontend/src/components/cyboflow/unified/UnifiedChatView.tsx
@@ -371,7 +371,7 @@ export function UnifiedChatView({
 
   // Auto-hide the fixed-width (230px) prompt rail when the chat host is too
   // narrow to fit it AND a usable transcript/composer. The host width depends on
-  // the window, the resizable app sidebar, and the 296px right rail, so this is
+  // the window, the resizable app sidebar, and the right rail, so this is
   // measured on the element (ResizeObserver), not a window breakpoint. Below the
   // threshold the rail would squeeze the main column toward 0 (dead composer).
   const rootRef = useRef<HTMLDivElement | null>(null);

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -1234,13 +1234,6 @@ async function createWindow() {
   // Each panel can register multiple event listeners
   mainWindow.webContents.setMaxListeners(100);
 
-  // A maximized previous session comes back maximized — the restored x/y/w/h
-  // above are the window's NORMAL (restore) geometry, so un-maximizing later
-  // lands where the user left it.
-  if (savedWindowState?.maximized) {
-    mainWindow.maximize();
-  }
-
   // Persist bounds so the next launch restores them. resize/move fire in a
   // flood during interactive drags, so they only arm a 500ms debounce; close
   // flushes immediately (and cancels the pending timer) so a quick open→close
@@ -1276,6 +1269,14 @@ async function createWindow() {
   // kick off the deferrable startup work at that point. Registered BEFORE
   // loadURL/loadFile so the one-shot 'ready-to-show' is never missed.
   mainWindow.once('ready-to-show', () => {
+    // A maximized previous session comes back maximized — the restored x/y/w/h
+    // are the window's NORMAL (restore) geometry, so un-maximizing later lands
+    // where the user left it. maximize() shows the window itself, so it belongs
+    // inside this gate: called earlier it reveals the unpainted frame the gate
+    // exists to hide.
+    if (savedWindowState?.maximized) {
+      mainWindow?.maximize();
+    }
     mainWindow?.show();
     runDeferredStartupWork();
   });

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -8,6 +8,7 @@ import {
   app,
   BrowserWindow,
   ipcMain,
+  screen,
   shell,
   dialog,
   systemPreferences,
@@ -36,6 +37,13 @@ import { detectArchMismatch, formatArchMismatchLog, formatArchMismatchDialog } f
 import { setTelemetrySink, setSeamErrorSink } from './orchestrator/telemetrySink';
 import { getCurrentWorktreeName } from './utils/worktreeUtils';
 import { installApplicationMenu } from './menu';
+import {
+  clampWindowBounds,
+  defaultWindowBounds,
+  loadWindowState,
+  saveWindowState,
+  type WindowRect,
+} from './utils/windowState';
 import { registerIpcHandlers } from './ipc';
 import { QUICK_PTY_BRIEFING } from './ipc/quickSessionBriefings';
 import { registerArtifactImageHandlers } from './ipc/artifactImages';
@@ -1170,9 +1178,30 @@ function runDeferredStartupWork(): void {
 }
 
 async function createWindow() {
+  // Window geometry (see utils/windowState.ts): restore the previous session's
+  // bounds from <userData>/window-state.json, or — when nothing trustworthy is
+  // saved (first run, corrupt file) — size to THIS display. Restored bounds are
+  // clamped against the work area of the display they last lived on, so a
+  // monitor unplug or resolution change can never resurrect an off-screen
+  // window. Any failure downgrades to first-run sizing, never a crash.
+  const windowStateDir = app.getPath('userData');
+  const savedWindowState = loadWindowState(windowStateDir);
+  let windowBounds: WindowRect;
+  if (savedWindowState) {
+    windowBounds = clampWindowBounds(
+      savedWindowState.bounds,
+      screen.getDisplayMatching(savedWindowState.bounds).workArea,
+    );
+  } else {
+    const workArea = screen.getPrimaryDisplay().workArea;
+    windowBounds = clampWindowBounds(defaultWindowBounds(workArea), workArea);
+  }
+
   mainWindow = new BrowserWindow({
-    width: 1400,
-    height: 900,
+    x: windowBounds.x,
+    y: windowBounds.y,
+    width: windowBounds.width,
+    height: windowBounds.height,
     icon: path.join(__dirname, '../assets/icon.png'),
     // First-paint: start hidden and paint the renderer's root background so the
     // window never flashes an empty white frame while the (heavy) renderer boots;
@@ -1204,6 +1233,44 @@ async function createWindow() {
   // Increase max listeners to prevent warning when many panels are active
   // Each panel can register multiple event listeners
   mainWindow.webContents.setMaxListeners(100);
+
+  // A maximized previous session comes back maximized — the restored x/y/w/h
+  // above are the window's NORMAL (restore) geometry, so un-maximizing later
+  // lands where the user left it.
+  if (savedWindowState?.maximized) {
+    mainWindow.maximize();
+  }
+
+  // Persist bounds so the next launch restores them. resize/move fire in a
+  // flood during interactive drags, so they only arm a 500ms debounce; close
+  // flushes immediately (and cancels the pending timer) so a quick open→close
+  // still records the final geometry. getNormalBounds() — NOT getBounds() —
+  // so a maximized window stores its restore size, not the maximized rect.
+  const WINDOW_STATE_SAVE_DEBOUNCE_MS = 500;
+  let windowStateSaveTimer: NodeJS.Timeout | null = null;
+  const persistWindowState = (): void => {
+    if (!mainWindow || mainWindow.isDestroyed()) return;
+    saveWindowState(windowStateDir, {
+      bounds: mainWindow.getNormalBounds(),
+      maximized: mainWindow.isMaximized(),
+    });
+  };
+  const scheduleWindowStateSave = (): void => {
+    if (windowStateSaveTimer) clearTimeout(windowStateSaveTimer);
+    windowStateSaveTimer = setTimeout(() => {
+      windowStateSaveTimer = null;
+      persistWindowState();
+    }, WINDOW_STATE_SAVE_DEBOUNCE_MS);
+  };
+  mainWindow.on('resize', scheduleWindowStateSave);
+  mainWindow.on('move', scheduleWindowStateSave);
+  mainWindow.on('close', () => {
+    if (windowStateSaveTimer) {
+      clearTimeout(windowStateSaveTimer);
+      windowStateSaveTimer = null;
+    }
+    persistWindowState();
+  });
 
   // Reveal the window only once the renderer has painted its first frame, and
   // kick off the deferrable startup work at that point. Registered BEFORE

--- a/main/src/utils/__tests__/windowState.test.ts
+++ b/main/src/utils/__tests__/windowState.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Behavioral tests for the window-state geometry helpers
+ * (main/src/utils/windowState.ts) — pure functions, no electron import, no
+ * mocks. Every rejection path of sanitizeWindowState, the clamp/ceiling/center
+ * math of the geometry helpers, and the fs round-trip incl. its failure modes
+ * (missing file, corrupt JSON, wrong shape) read as first-run defaults, never
+ * a crash.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  MIN_WINDOW_HEIGHT,
+  MIN_WINDOW_WIDTH,
+  clampWindowBounds,
+  defaultWindowBounds,
+  loadWindowState,
+  saveWindowState,
+  sanitizeWindowState,
+  windowStateFilePath,
+  type WindowRect,
+} from '../windowState';
+
+const WORK_AREA: WindowRect = { x: 0, y: 0, width: 1920, height: 1080 };
+
+/** The MIN_VISIBLE_PX invariant from clampWindowBounds: at least 120px of the
+ * window must overlap the work area on every edge. */
+function clampedIsVisible(b: WindowRect, area: WindowRect = WORK_AREA): boolean {
+  const overlapX = Math.min(b.x + b.width, area.x + area.width) - Math.max(b.x, area.x);
+  const overlapY = Math.min(b.y + b.height, area.y + area.height) - Math.max(b.y, area.y);
+  return overlapX >= 120 && overlapY >= 120;
+}
+
+describe('sanitizeWindowState', () => {
+  it('accepts a valid state, preserving every field', () => {
+    const raw = {
+      bounds: { x: -1920, y: 0, width: 1400, height: 900 },
+      maximized: true,
+    };
+    expect(sanitizeWindowState(raw)).toEqual({
+      bounds: { x: -1920, y: 0, width: 1400, height: 900 },
+      maximized: true,
+    });
+  });
+
+  it('rounds non-integer fields to integers', () => {
+    const r = sanitizeWindowState({
+      bounds: { x: 10.4, y: -20.6, width: 800.4, height: 600.5 },
+      maximized: false,
+    });
+    expect(r).toEqual({ bounds: { x: 10, y: -21, width: 800, height: 601 }, maximized: false });
+  });
+
+  it.each([
+    ['not an object', 'nope'],
+    ['a bare number', 42],
+    ['null', null],
+    ['undefined', undefined],
+    ['an array (no usable bounds)', [1, 2, 3]],
+    ['missing bounds', { maximized: false }],
+    ['null bounds', { bounds: null }],
+    ['bounds not an object', { bounds: '1400x900' }],
+  ])('rejects %s', (_name, raw) => {
+    expect(sanitizeWindowState(raw)).toBeNull();
+  });
+
+  it.each(['x', 'y', 'width', 'height'] as const)('rejects non-finite bounds.%s', (field) => {
+    for (const bad of [NaN, Infinity]) {
+      const bounds: Record<string, number> = { x: 0, y: 0, width: 1400, height: 900 };
+      bounds[field] = bad;
+      expect(sanitizeWindowState({ bounds })).toBeNull();
+    }
+  });
+
+  it.each(['x', 'y', 'width', 'height'] as const)('rejects a string in bounds.%s', (field) => {
+    const bounds: Record<string, unknown> = { x: 0, y: 0, width: 1400, height: 900 };
+    bounds[field] = '100';
+    expect(sanitizeWindowState({ bounds })).toBeNull();
+  });
+
+  it('rejects a sliver rect (width or height below 200) and accepts exactly 200', () => {
+    expect(sanitizeWindowState({ bounds: { x: 0, y: 0, width: 199, height: 600 } })).toBeNull();
+    expect(sanitizeWindowState({ bounds: { x: 0, y: 0, width: 800, height: 199 } })).toBeNull();
+    expect(sanitizeWindowState({ bounds: { x: 0, y: 0, width: 200, height: 200 } })).not.toBeNull();
+  });
+
+  it('rejects absurd dimensions (corruption, not a real display)', () => {
+    expect(
+      sanitizeWindowState({ bounds: { x: 0, y: 0, width: 1_000_000, height: 600 } }),
+    ).toBeNull();
+  });
+
+  it('rejects absurd coordinates but accepts the 100000 boundary', () => {
+    expect(sanitizeWindowState({ bounds: { x: 100_001, y: 0, width: 800, height: 600 } })).toBeNull();
+    expect(sanitizeWindowState({ bounds: { x: 0, y: -100_001, width: 800, height: 600 } })).toBeNull();
+    const ok = sanitizeWindowState({ bounds: { x: 100_000, y: -100_000, width: 800, height: 600 } });
+    expect(ok?.bounds).toEqual({ x: 100_000, y: -100_000, width: 800, height: 600 });
+  });
+
+  it('treats maximized as a strict boolean (anything but true is false)', () => {
+    expect(
+      sanitizeWindowState({ bounds: { x: 0, y: 0, width: 800, height: 600 }, maximized: 'yes' }),
+    ).toEqual({ bounds: { x: 0, y: 0, width: 800, height: 600 }, maximized: false });
+    expect(sanitizeWindowState({ bounds: { x: 0, y: 0, width: 800, height: 600 } })?.maximized).toBe(
+      false,
+    );
+  });
+});
+
+describe('defaultWindowBounds', () => {
+  it('sizes 80% of a large work area, clamped to the 1600×1000 ceiling, centered', () => {
+    // 3440×1440 display → 2752×1152 wanted, clamped to 1600×1000.
+    const b = defaultWindowBounds({ x: 0, y: 0, width: 3440, height: 1440 });
+    expect(b).toEqual({ x: 920, y: 220, width: 1600, height: 1000 });
+  });
+
+  it('stays inside a 1366×768 laptop work area (80% figure, minimum height)', () => {
+    const b = defaultWindowBounds({ x: 0, y: 0, width: 1366, height: 728 });
+    expect(b.width).toBe(1093); // round(1366 * 0.8)
+    expect(b.height).toBe(640); // 728 * 0.8 = 582 → lifted to the minimum
+    expect(b.x).toBe(137); // centered: round((1366 - 1093) / 2)
+    expect(b.y).toBe(44);
+    // Fully inside the work area.
+    expect(b.x).toBeGreaterThanOrEqual(0);
+    expect(b.y).toBeGreaterThanOrEqual(0);
+    expect(b.x + b.width).toBeLessThanOrEqual(1366);
+    expect(b.y + b.height).toBeLessThanOrEqual(728);
+  });
+
+  it('honors the 960×640 minimum on a tiny work area (still centered)', () => {
+    const b = defaultWindowBounds({ x: 0, y: 0, width: 800, height: 500 });
+    expect(b.width).toBe(MIN_WINDOW_WIDTH);
+    expect(b.height).toBe(MIN_WINDOW_HEIGHT);
+    expect(b.x).toBe(Math.round((800 - MIN_WINDOW_WIDTH) / 2));
+    expect(b.y).toBe(Math.round((500 - MIN_WINDOW_HEIGHT) / 2));
+  });
+
+  it('centers within an offset work area (secondary display)', () => {
+    const area: WindowRect = { x: -1920, y: 600, width: 1920, height: 1080 };
+    const b = defaultWindowBounds(area);
+    // 80% = 1536×864 (inside the ceiling); centered on the area's origin.
+    expect(b).toEqual({ x: -1728, y: 708, width: 1536, height: 864 });
+  });
+
+});
+
+describe('clampWindowBounds', () => {
+  it('preserves already-valid input', () => {
+    const bounds = { x: 100, y: 80, width: 1280, height: 800 };
+    expect(clampWindowBounds(bounds, WORK_AREA)).toEqual(bounds);
+  });
+
+  it('shifts a window hanging off any edge back into the 120px visibility band', () => {
+    const lt = clampWindowBounds({ x: -1500, y: -1400, width: 960, height: 640 }, WORK_AREA);
+    expect(lt.x).toBe(-840);
+    expect(lt.y).toBe(-520);
+    expect(clampedIsVisible(lt)).toBe(true);
+    const rb = clampWindowBounds({ x: 1900, y: 1070, width: 960, height: 640 }, WORK_AREA);
+    expect(rb.x).toBe(WORK_AREA.width - 120);
+    expect(rb.y).toBe(WORK_AREA.height - 120);
+    expect(clampedIsVisible(rb)).toBe(true);
+  });
+
+  it('honors the 120px visibility band boundary: exactly 120px visible passes, 119 shifts', () => {
+    // x = -840 → right edge at 120 → exactly MIN_VISIBLE_PX visible → preserved.
+    expect(clampWindowBounds({ x: -840, y: 0, width: 960, height: 640 }, WORK_AREA).x).toBe(-840);
+    // One pixel further out → shifted back to the band edge.
+    expect(clampWindowBounds({ x: -841, y: 0, width: 960, height: 640 }, WORK_AREA).x).toBe(-840);
+    // Right edge exactly at area-width - 120 → preserved; one further → shifted.
+    expect(clampWindowBounds({ x: 1800, y: 0, width: 960, height: 640 }, WORK_AREA).x).toBe(1800);
+    expect(clampWindowBounds({ x: 1801, y: 0, width: 960, height: 640 }, WORK_AREA).x).toBe(1800);
+    // Same band on the y axis (top edge and bottom edge).
+    expect(clampWindowBounds({ x: 0, y: -520, width: 960, height: 640 }, WORK_AREA).y).toBe(-520);
+    expect(clampWindowBounds({ x: 0, y: 961, width: 960, height: 640 }, WORK_AREA).y).toBe(960);
+    // One pixel past the top band edge → shifted back in.
+    expect(clampWindowBounds({ x: 0, y: -521, width: 960, height: 640 }, WORK_AREA).y).toBe(-520);
+  });
+
+  it('pins a window larger than the work area to the work-area origin', () => {
+    const clamped = clampWindowBounds({ x: 300, y: 200, width: 2400, height: 1500 }, WORK_AREA);
+    expect(clamped).toEqual({ x: 0, y: 0, width: 2400, height: 1500 });
+  });
+
+  it('raises undersized dimensions to the minimums', () => {
+    const clamped = clampWindowBounds({ x: 0, y: 0, width: 500, height: 400 }, WORK_AREA);
+    expect(clamped.width).toBe(MIN_WINDOW_WIDTH);
+    expect(clamped.height).toBe(MIN_WINDOW_HEIGHT);
+  });
+
+  it('works against an offset (multi-monitor) work area', () => {
+    const area: WindowRect = { x: -1920, y: -1080, width: 1920, height: 1080 };
+    const clamped = clampWindowBounds({ x: 500, y: 500, width: 960, height: 640 }, area);
+    expect(clamped.x).toBe(-1920 + 1920 - 120);
+    expect(clamped.y).toBe(-1080 + 1080 - 120);
+  });
+});
+
+// -- loadWindowState / saveWindowState (thin fs wrappers) ---------------------
+
+describe('loadWindowState / saveWindowState', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'window-state-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('round-trips a saved state through the documented file name', () => {
+    const state = { bounds: { x: -100, y: 20, width: 1400, height: 900 }, maximized: true };
+    saveWindowState(dir, state);
+    expect(fs.existsSync(windowStateFilePath(dir))).toBe(true);
+    expect(loadWindowState(dir)).toEqual(state);
+  });
+
+  it('returns null for a missing file (first run)', () => {
+    expect(loadWindowState(dir)).toBeNull();
+  });
+
+  it('returns null for corrupt JSON', () => {
+    fs.writeFileSync(windowStateFilePath(dir), '{not json', 'utf8');
+    expect(loadWindowState(dir)).toBeNull();
+  });
+
+  it('returns null for a wrong-shape blob', () => {
+    fs.writeFileSync(windowStateFilePath(dir), JSON.stringify({ bounds: { width: 3 } }), 'utf8');
+    expect(loadWindowState(dir)).toBeNull();
+  });
+
+  it('never throws when the target directory does not exist (log-and-continue)', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() =>
+      saveWindowState(
+        path.join(dir, 'missing'),
+        { bounds: { x: 0, y: 0, width: 1000, height: 700 }, maximized: false },
+      ),
+    ).not.toThrow();
+    expect(errSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/main/src/utils/__tests__/windowState.test.ts
+++ b/main/src/utils/__tests__/windowState.test.ts
@@ -155,7 +155,9 @@ describe('clampWindowBounds', () => {
   it('shifts a window hanging off any edge back into the 120px visibility band', () => {
     const lt = clampWindowBounds({ x: -1500, y: -1400, width: 960, height: 640 }, WORK_AREA);
     expect(lt.x).toBe(-840);
-    expect(lt.y).toBe(-520);
+    // y is floored at the work area's top rather than banded — see the
+    // title-bar test below.
+    expect(lt.y).toBe(0);
     expect(clampedIsVisible(lt)).toBe(true);
     const rb = clampWindowBounds({ x: 1900, y: 1070, width: 960, height: 640 }, WORK_AREA);
     expect(rb.x).toBe(WORK_AREA.width - 120);
@@ -171,11 +173,22 @@ describe('clampWindowBounds', () => {
     // Right edge exactly at area-width - 120 → preserved; one further → shifted.
     expect(clampWindowBounds({ x: 1800, y: 0, width: 960, height: 640 }, WORK_AREA).x).toBe(1800);
     expect(clampWindowBounds({ x: 1801, y: 0, width: 960, height: 640 }, WORK_AREA).x).toBe(1800);
-    // Same band on the y axis (top edge and bottom edge).
-    expect(clampWindowBounds({ x: 0, y: -520, width: 960, height: 640 }, WORK_AREA).y).toBe(-520);
+    // The bottom band applies on y too.
+    expect(clampWindowBounds({ x: 0, y: 960, width: 960, height: 640 }, WORK_AREA).y).toBe(960);
     expect(clampWindowBounds({ x: 0, y: 961, width: 960, height: 640 }, WORK_AREA).y).toBe(960);
-    // One pixel past the top band edge → shifted back in.
-    expect(clampWindowBounds({ x: 0, y: -521, width: 960, height: 640 }, WORK_AREA).y).toBe(-520);
+  });
+
+  it('never places the title bar above the work area', () => {
+    // A window whose top edge is off screen cannot be dragged back, so y is
+    // floored at the work area's top instead of being banded like x. Reachable
+    // whenever a saved position refers to a display that is no longer attached.
+    expect(clampWindowBounds({ x: 0, y: -1, width: 960, height: 640 }, WORK_AREA).y).toBe(0);
+    expect(clampWindowBounds({ x: 0, y: -520, width: 960, height: 640 }, WORK_AREA).y).toBe(0);
+    expect(clampWindowBounds({ x: 0, y: -5000, width: 960, height: 640 }, WORK_AREA).y).toBe(0);
+
+    // Same floor on a work area that does not start at the origin.
+    const area: WindowRect = { x: -1920, y: -1080, width: 1920, height: 1080 };
+    expect(clampWindowBounds({ x: -1000, y: -2000, width: 960, height: 640 }, area).y).toBe(-1080);
   });
 
   it('pins a window larger than the work area to the work-area origin', () => {

--- a/main/src/utils/windowState.ts
+++ b/main/src/utils/windowState.ts
@@ -1,0 +1,180 @@
+/**
+ * windowState — persist the main window's bounds across launches, with a
+ * display-aware first-run default. A fixed, unpersisted size forgets every
+ * manual resize, cramps the fixed-width UI columns on large monitors, and can
+ * overflow the work area on small or scaled displays.
+ *
+ * The bounds live in a JSON file under userData — deliberately NOT localStorage:
+ * the window is created by the main process before any renderer exists. The
+ * geometry math is pure and unit-tested; nothing here imports electron —
+ * index.ts hands the work area in as plain arguments, so the math stays
+ * testable in host-Node vitest.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** A pixel rectangle, structurally Electron's `Rectangle`. */
+export interface WindowRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface SavedWindowState {
+  bounds: WindowRect;
+  maximized: boolean;
+}
+
+/** Floor for a restored window — small enough for a 1280×720 netbook work area. */
+export const MIN_WINDOW_WIDTH = 960;
+export const MIN_WINDOW_HEIGHT = 640;
+
+/** First-run size: clamped proportions of the work area (see defaultWindowBounds). */
+export const FIRST_RUN_MAX_WIDTH = 1600;
+export const FIRST_RUN_MAX_HEIGHT = 1000;
+
+/** How much of a restored window must overlap the work area to count as on-screen. */
+const MIN_VISIBLE_PX = 120;
+
+/**
+ * Validation floor for a SAVED width/height — below this the file is corrupt
+ * (first-run display sizing does a better job than trusting a sliver rect).
+ * Distinct from MIN_WINDOW_WIDTH/HEIGHT, which are the restore-time clamp.
+ */
+const MIN_SANE_DIMENSION = 200;
+/** A saved dimension beyond this is corruption, not a real window. */
+const MAX_SANE_DIMENSION = 100_000;
+/**
+ * Coordinates may be negative (multi-monitor layouts place displays left of /
+ * above the origin), but beyond this magnitude the file is corrupt, not a real
+ * display position.
+ */
+const MAX_SANE_COORDINATE = 100_000;
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isSaneDimension(value: unknown): boolean {
+  return isFiniteNumber(value) && value >= MIN_SANE_DIMENSION && value <= MAX_SANE_DIMENSION;
+}
+
+function isSaneCoordinate(value: unknown): boolean {
+  return isFiniteNumber(value) && Math.abs(value) <= MAX_SANE_COORDINATE;
+}
+
+function isSaneRect(value: unknown): value is WindowRect {
+  if (typeof value !== 'object' || value === null) return false;
+  const r = value as Record<string, unknown>;
+  return (
+    isSaneDimension(r.width) &&
+    isSaneDimension(r.height) &&
+    isSaneCoordinate(r.x) &&
+    isSaneCoordinate(r.y)
+  );
+}
+
+/**
+ * Validate a parsed JSON blob into a usable SavedWindowState, or null when
+ * anything is off (wrong shape, non-finite numbers, sliver dims, absurd
+ * coordinates). A null result means "treat as first run", never a crash.
+ */
+export function sanitizeWindowState(raw: unknown): SavedWindowState | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const candidate = raw as { bounds?: unknown; maximized?: unknown };
+  if (!isSaneRect(candidate.bounds)) return null;
+  return {
+    bounds: {
+      x: Math.round(candidate.bounds.x),
+      y: Math.round(candidate.bounds.y),
+      width: Math.round(candidate.bounds.width),
+      height: Math.round(candidate.bounds.height),
+    },
+    maximized: candidate.maximized === true,
+  };
+}
+
+/**
+ * First-run sizing: 80% of the given work area clamped to
+ * [MIN_WINDOW_WIDTH×MIN_WINDOW_HEIGHT, FIRST_RUN_MAX_WIDTH×FIRST_RUN_MAX_HEIGHT],
+ * centered in that work area. On a 3440×1440 display that yields 1600×1000
+ * (the clamp ceiling); on a 1366×768 laptop the 80% figure already fits and
+ * the minimum keeps the window usable.
+ */
+export function defaultWindowBounds(workArea: WindowRect): WindowRect {
+  const width = Math.round(
+    Math.min(FIRST_RUN_MAX_WIDTH, Math.max(MIN_WINDOW_WIDTH, workArea.width * 0.8)),
+  );
+  const height = Math.round(
+    Math.min(FIRST_RUN_MAX_HEIGHT, Math.max(MIN_WINDOW_HEIGHT, workArea.height * 0.8)),
+  );
+  return {
+    x: Math.round(workArea.x + (workArea.width - width) / 2),
+    y: Math.round(workArea.y + (workArea.height - height) / 2),
+    width,
+    height,
+  };
+}
+
+/**
+ * Force a window rect onto a work area: dimensions at least the minimums, and
+ * at least MIN_VISIBLE_PX of the window overlapping the work area at every
+ * edge (shift x/y into range; a window larger than the work area on an axis
+ * can't keep the visibility band on both edges, so it is pinned to the work
+ * area's origin). Pure integer math — safe to feed straight to BrowserWindow.
+ */
+export function clampWindowBounds(bounds: WindowRect, workArea: WindowRect): WindowRect {
+  const width = Math.max(MIN_WINDOW_WIDTH, Math.round(bounds.width));
+  const height = Math.max(MIN_WINDOW_HEIGHT, Math.round(bounds.height));
+
+  // One axis of the pin-and-band rule: keep at least MIN_VISIBLE_PX of the
+  // window past the area's leading edge AND MIN_VISIBLE_PX short of its far
+  // edge. A window larger than the area on this axis can't do both — pin to
+  // the area's origin instead.
+  const clampAxis = (pos: number, size: number, areaPos: number, areaSize: number): number => {
+    if (size > areaSize) return areaPos;
+    const min = areaPos + MIN_VISIBLE_PX - size;
+    const max = areaPos + areaSize - MIN_VISIBLE_PX;
+    return Math.max(min, Math.min(Math.round(pos), max));
+  };
+
+  return {
+    x: clampAxis(bounds.x, width, workArea.x, workArea.width),
+    y: clampAxis(bounds.y, height, workArea.y, workArea.height),
+    width,
+    height,
+  };
+}
+
+/** Where the state lives inside a userData directory. */
+export function windowStateFilePath(userDataDir: string): string {
+  return path.join(userDataDir, 'window-state.json');
+}
+
+/**
+ * Read + sanitize the persisted state. ANY failure — missing file (first run),
+ * unreadable, invalid JSON, wrong shape — returns null, which the caller must
+ * treat as "size for the display", never a crash.
+ */
+export function loadWindowState(userDataDir: string): SavedWindowState | null {
+  try {
+    const raw = fs.readFileSync(windowStateFilePath(userDataDir), 'utf8');
+    return sanitizeWindowState(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist the state. Best-effort: a read-only dir, full disk, or AV lock on
+ * the file must never take the app down over a window rect — log and continue.
+ * A small file, so a direct writeFileSync is atomic enough in practice.
+ */
+export function saveWindowState(userDataDir: string, state: SavedWindowState): void {
+  try {
+    fs.writeFileSync(windowStateFilePath(userDataDir), JSON.stringify(state), 'utf8');
+  } catch (err) {
+    console.error('[windowState] failed to persist window state:', err);
+  }
+}

--- a/main/src/utils/windowState.ts
+++ b/main/src/utils/windowState.ts
@@ -119,29 +119,40 @@ export function defaultWindowBounds(workArea: WindowRect): WindowRect {
 
 /**
  * Force a window rect onto a work area: dimensions at least the minimums, and
- * at least MIN_VISIBLE_PX of the window overlapping the work area at every
- * edge (shift x/y into range; a window larger than the work area on an axis
- * can't keep the visibility band on both edges, so it is pinned to the work
- * area's origin). Pure integer math — safe to feed straight to BrowserWindow.
+ * at least MIN_VISIBLE_PX of the window overlapping the work area (shift x/y
+ * into range; a window larger than the work area on an axis can't keep the
+ * visibility band on both edges, so it is pinned to the work area's origin).
+ * Pure integer math — safe to feed straight to BrowserWindow.
+ *
+ * The two axes are not symmetric. x may sit either side of the area, but a
+ * negative y offset puts the title bar above the work area, and a window whose
+ * title bar is off screen cannot be dragged back.
  */
 export function clampWindowBounds(bounds: WindowRect, workArea: WindowRect): WindowRect {
   const width = Math.max(MIN_WINDOW_WIDTH, Math.round(bounds.width));
   const height = Math.max(MIN_WINDOW_HEIGHT, Math.round(bounds.height));
 
-  // One axis of the pin-and-band rule: keep at least MIN_VISIBLE_PX of the
-  // window past the area's leading edge AND MIN_VISIBLE_PX short of its far
-  // edge. A window larger than the area on this axis can't do both — pin to
-  // the area's origin instead.
-  const clampAxis = (pos: number, size: number, areaPos: number, areaSize: number): number => {
+  // Horizontal: keep at least MIN_VISIBLE_PX of the window past the area's
+  // leading edge AND MIN_VISIBLE_PX short of its far edge. A window wider than
+  // the area can't do both — pin to the area's origin instead.
+  const clampX = (pos: number, size: number, areaPos: number, areaSize: number): number => {
     if (size > areaSize) return areaPos;
     const min = areaPos + MIN_VISIBLE_PX - size;
     const max = areaPos + areaSize - MIN_VISIBLE_PX;
     return Math.max(min, Math.min(Math.round(pos), max));
   };
 
+  // Vertical: the far-edge band is the same, but the near edge is a floor at
+  // the top of the work area, not a band.
+  const clampY = (pos: number, size: number, areaPos: number, areaSize: number): number => {
+    if (size > areaSize) return areaPos;
+    const max = areaPos + areaSize - MIN_VISIBLE_PX;
+    return Math.max(areaPos, Math.min(Math.round(pos), max));
+  };
+
   return {
-    x: clampAxis(bounds.x, width, workArea.x, workArea.width),
-    y: clampAxis(bounds.y, height, workArea.y, workArea.height),
+    x: clampX(bounds.x, width, workArea.x, workArea.width),
+    y: clampY(bounds.y, height, workArea.y, workArea.height),
     width,
     height,
   };


### PR DESCRIPTION
## What this PR does

The app used to open at a fixed 1400×900 on every launch: it forgot any resize, could overflow smaller screens entirely, and its first-run right-hand columns were narrower than their own headers — the "Agent thread" / "INTERACTIVE" strip clipped inside the rail until you manually resized.

After this PR the window opens sized to your display (80% of the work area, clamped to 960×640…1600×1000, centered), remembers size, position, and maximized state across launches, and the columns are wide enough on first run.

## How it works

- New `main/src/utils/windowState.ts` — pure, unit-tested helpers: a first-run default sized to the display, a restore path that treats garbage in the saved file as first-run (never a crash), and a clamp that keeps every restored window at least 120px inside the work area — so a monitor unplug can never resurrect an off-screen window.
- `createWindow()` restores the saved bounds (re-maximizing when saved maximized; the file stores the *normal* geometry, so un-maximizing lands where the user left it) and persists on resize/move (500ms debounce) and on close.
- The window is maximized inside the `ready-to-show` handler rather than before it. Electron's documentation says maximizing a hidden window also shows it, so doing it earlier revealed the window before it had drawn anything — which is the blank frame the hidden-until-ready logic exists to avoid. Anyone who quit while maximized saw it on every launch.
- The clamp treats the two axes differently on purpose. Horizontally a window may hang off either edge as long as 120px stays on screen. Vertically it may not go above the top of the screen at all, because a window whose title bar is off the top cannot be dragged back.
- Renderer: the two right-hand columns now start at 360px wide instead of 296 and 320.

  Raising that number was not enough on its own. Both columns saved their width to browser storage every time they appeared on screen, not only when someone dragged them. So every install that had ever opened the app already had the old width saved, and a new default would have reached nobody. Two changes fix that: the width is saved only when someone actually resizes it, and a saved width that exactly equals the old default is treated as "never chosen" and replaced by the new one. A width someone picked themselves is kept.

## Tests

38 unit cases covering the geometry and the saved-state file: every way the file can be invalid, the clamp boundaries, the rule that a window can never sit above the top of the screen (checked on a normal display and on a second monitor placed above the first), and the case where saving fails (log it and carry on, never break the launch). Each column also gets cases for not saving on appearance, for replacing the old default, and for keeping a width someone chose.

Run on Windows 11 at commit `97fd62a6`: the geometry tests pass 38 of 38, and the renderer suite passes 319 files and 5,026 tests. The main process suite does not run cleanly on a Windows host on this branch, because the work that makes it Windows-compatible lives in the Windows PR; nothing in this branch depends on it. Not run on macOS.

## Notes

- On very small displays the window now fits the screen (the old fixed size overflowed it), leaving less room for the center column there — the layout's own clamps decide what gives way.
- One cost worth knowing: if someone deliberately dragged a column to exactly 296 or 320 pixels, they get 360 once and have to drag it back. A saved width does not record whether a person chose it or the old code wrote it.
- This PR is independent of the other open PRs and can land in any order.

