### PR TITLE
feat: native Antigravity (agy) agent runtime and orchestrator support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ coverage/
 # Git worktrees (except the main directory)
 /worktree-*/
 /worktrees/
+.worktrees/
 
 # Claude Code session data
 sessions/

--- a/frontend/src/components/cyboflow/ABTestLaunchModal.tsx
+++ b/frontend/src/components/cyboflow/ABTestLaunchModal.tsx
@@ -48,7 +48,7 @@ import { bootstrapArmSessionPanels } from '../../utils/bootstrapArmSessionPanels
 import { useCyboflowStore } from '../../stores/cyboflowStore';
 import { useNavigationStore } from '../../stores/navigationStore';
 import { SubstrateSelector } from './SubstrateSelector';
-import { ModelSelector, DEFAULT_QUICK_MODEL, DEFAULT_CODEX_MODEL } from './ModelSelector';
+import { ModelSelector, DEFAULT_QUICK_MODEL, DEFAULT_CODEX_MODEL, DEFAULT_AGY_MODEL } from './ModelSelector';
 import { AgentPermissionModeSelector } from './AgentPermissionModeSelector';
 import { providerForRuntime, type LaunchAgentRuntime } from './agentRuntimeUi';
 import type { AgentProvider, WorkflowRunStorableRuntime } from '../../../../shared/types/agentRuntime';
@@ -90,6 +90,7 @@ function quickArmAgentRuntime(runtime: LaunchAgentRuntime): WorkflowAgentRuntime
   if (runtime === 'omp-pty') return 'omp-sdk';
   if (runtime === 'omp-fleet') return 'claude-sdk';
   if (runtime === 'pi-pty') return 'pi-sdk';
+  if (runtime === 'agy-pty') return 'agy-sdk';
   return runtime;
 }
 
@@ -117,6 +118,7 @@ const QUICK_ARM_MODEL_RESET: Readonly<Record<AgentProvider, string>> = {
   // ids with no "let the runtime pick" sentinel, so the arm launches on the
   // runtime's own default.
   pi: '',
+  agy: DEFAULT_AGY_MODEL,
 };
 
 /**

--- a/frontend/src/components/cyboflow/ModelSelector.tsx
+++ b/frontend/src/components/cyboflow/ModelSelector.tsx
@@ -40,7 +40,7 @@ export const ULTRACODE_DEFAULT_MODEL = 'fable';
 
 /** Re-exported from shared so the launch seams can reach it without importing
  *  a component; this stays the canonical import site for UI code. */
-export { DEFAULT_CODEX_MODEL } from '../../../../shared/types/agentModels';
+export { DEFAULT_CODEX_MODEL, DEFAULT_AGY_MODEL } from '../../../../shared/types/agentModels';
 
 interface ModelSelectorProps {
   value: string;

--- a/frontend/src/components/cyboflow/SubstrateSelector.tsx
+++ b/frontend/src/components/cyboflow/SubstrateSelector.tsx
@@ -113,6 +113,18 @@ export const PI_PTY_CAVEATS: readonly string[] = [
   'Approvals stay inside the pi TUI — no Cyboflow review-queue integration.',
 ];
 
+/** The v1 limits of the Antigravity structured (agy-sdk) lane. */
+export const AGY_SDK_CAVEATS: readonly string[] = [
+  'Auto-approves tool requests when session permission mode is dontAsk (--dangerously-skip-permissions).',
+  'No mid-turn steering: the next message queues until the current turn finishes.',
+  'Tool activity is not shown in the transcript; only final text per turn.',
+];
+
+/** The v1 limits of the Antigravity CLI (agy-pty) lane. */
+export const AGY_PTY_CAVEATS: readonly string[] = [
+  'Approvals stay inside the Antigravity TUI — no Cyboflow review-queue integration.',
+];
+
 interface SubstrateSelectorProps {
   value: LaunchAgentRuntime;
   onChange: (runtime: LaunchAgentRuntime) => void;
@@ -140,6 +152,7 @@ const PROVIDER_LABELS: Record<AgentProvider, string> = {
   codex: 'Codex',
   omp: 'OMP',
   pi: 'Pi',
+  agy: 'Antigravity',
 };
 
 const MODE_LABELS: Record<RuntimeMode, string> = {
@@ -166,6 +179,8 @@ function lanesForProvider(provider: AgentProvider, omp: OmpAvailability): Provid
       return omp.ariaMode ? { chat: 'omp-fleet' } : { chat: 'omp-sdk', cli: 'omp-pty' };
     case 'pi':
       return { chat: 'pi-sdk', cli: 'pi-pty' };
+    case 'agy':
+      return { chat: 'agy-sdk', cli: 'agy-pty' };
   }
 }
 
@@ -497,6 +512,12 @@ export function SubstrateSelector({
       )}
       {value === 'pi-pty' && (
         <CaveatsPanel testId={caveatsTestId} title="Pi (CLI) — v1 limits" items={PI_PTY_CAVEATS} />
+      )}
+      {value === 'agy-sdk' && (
+        <CaveatsPanel testId={caveatsTestId} title="Antigravity — v1 limits" items={AGY_SDK_CAVEATS} />
+      )}
+      {value === 'agy-pty' && (
+        <CaveatsPanel testId={caveatsTestId} title="Antigravity (CLI) — v1 limits" items={AGY_PTY_CAVEATS} />
       )}
     </div>
   );

--- a/frontend/src/components/cyboflow/VariantEditorModal.tsx
+++ b/frontend/src/components/cyboflow/VariantEditorModal.tsx
@@ -89,6 +89,7 @@ const VARIANT_RUNTIME_LABELS: Record<WorkflowAgentRuntime, string> = {
   'codex-sdk': AGENT_RUNTIME_LABELS['codex-sdk'],
   'omp-sdk': AGENT_RUNTIME_LABELS['omp-sdk'],
   'pi-sdk': AGENT_RUNTIME_LABELS['pi-sdk'],
+  'agy-sdk': AGENT_RUNTIME_LABELS['agy-sdk'],
 };
 
 export function VariantEditorModal({

--- a/frontend/src/components/cyboflow/WorkflowPicker.tsx
+++ b/frontend/src/components/cyboflow/WorkflowPicker.tsx
@@ -38,7 +38,7 @@ import {
   isCyboflowWorkflowName,
 } from '../../../../shared/types/workflows';
 import { DEFAULT_SUBSTRATE } from '../../../../shared/types/substrate';
-import { normalizeAgentModelSelection } from '../../../../shared/types/agentModels';
+import { normalizeAgentModelSelection, DEFAULT_AGY_MODEL } from '../../../../shared/types/agentModels';
 import {
   DEFAULT_SESSION_AGENT_RUNTIME,
   claudeRuntimeFromSubstrate,
@@ -80,6 +80,7 @@ const PROVIDER_MODEL_FLOOR: Readonly<Record<AgentProvider, string>> = {
   // Empty selection, for OMP's reason: pi has no "let the runtime pick"
   // sentinel row.
   pi: '',
+  agy: DEFAULT_AGY_MODEL,
 };
 
 /**

--- a/frontend/src/components/cyboflow/__tests__/SubstrateSelector.test.tsx
+++ b/frontend/src/components/cyboflow/__tests__/SubstrateSelector.test.tsx
@@ -378,8 +378,16 @@ describe('SubstrateSelector — offers exactly the picker-selectable providers',
   });
 
   it('leaves both OMP lanes selectable on a quick session', () => {
-    setProviderAccess({ claude: true, codex: true, omp: true, pi: true });
+    setProviderAccess({ claude: true, codex: true, omp: true, pi: true, agy: true });
     render(<SubstrateSelector value="omp-sdk" onChange={vi.fn()} runtimeScope="session" />);
+
+    expect(screen.getByTestId('substrate-select-mode-chat')).not.toBeDisabled();
+    expect(screen.getByTestId('substrate-select-mode-cli')).not.toBeDisabled();
+  });
+
+  it('leaves both Antigravity lanes selectable on a quick session', () => {
+    setProviderAccess({ claude: true, codex: true, omp: true, pi: true, agy: true });
+    render(<SubstrateSelector value="agy-sdk" onChange={vi.fn()} runtimeScope="session" />);
 
     expect(screen.getByTestId('substrate-select-mode-chat')).not.toBeDisabled();
     expect(screen.getByTestId('substrate-select-mode-cli')).not.toBeDisabled();
@@ -389,14 +397,14 @@ describe('SubstrateSelector — offers exactly the picker-selectable providers',
   // something — never because an unselectable runtime (codex-exec) has no
   // segment, and never merely because the OMP flavor swapped lanes.
   it('does not claim runtimes are hidden when every provider is on', () => {
-    setProviderAccess({ claude: true, codex: true, omp: true, pi: true });
+    setProviderAccess({ claude: true, codex: true, omp: true, pi: true, agy: true });
     render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
 
     expect(screen.queryByText(/are hidden/i)).not.toBeInTheDocument();
   });
 
   it('does not claim runtimes are hidden merely because a flavor is inactive', () => {
-    setProviderAccess({ claude: true, codex: true, omp: true, pi: true });
+    setProviderAccess({ claude: true, codex: true, omp: true, pi: true, agy: true });
     mockUseOmpAvailability.mockReturnValue({ launchable: true, ariaMode: true });
     render(<SubstrateSelector value="claude-sdk" onChange={vi.fn()} runtimeScope="session" />);
 
@@ -441,6 +449,22 @@ describe('SubstrateSelector — OMP + Pi caveats copy (v1 limits)', () => {
     const panel = screen.getByTestId('substrate-caveats');
     expect(panel).toHaveTextContent('Pi (CLI) — v1 limits');
     expect(panel).toHaveTextContent('Approvals stay inside the pi TUI');
+  });
+
+  it('shows the agy-sdk caveats when the value is forced to agy-sdk', () => {
+    render(<SubstrateSelector value="agy-sdk" onChange={vi.fn()} runtimeScope="session" />);
+
+    const panel = screen.getByTestId('substrate-caveats');
+    expect(panel).toHaveTextContent('Antigravity — v1 limits');
+    expect(panel).toHaveTextContent('Auto-approves tool requests');
+  });
+
+  it('shows the agy-pty caveats when the value is forced to agy-pty', () => {
+    render(<SubstrateSelector value="agy-pty" onChange={vi.fn()} runtimeScope="session" />);
+
+    const panel = screen.getByTestId('substrate-caveats');
+    expect(panel).toHaveTextContent('Antigravity (CLI) — v1 limits');
+    expect(panel).toHaveTextContent('Approvals stay inside the Antigravity TUI');
   });
 
   it('shows no caveats panel for an ordinary claude-sdk value', () => {

--- a/frontend/src/components/settings/IntegrationsSettings.test.tsx
+++ b/frontend/src/components/settings/IntegrationsSettings.test.tsx
@@ -11,6 +11,7 @@ const detectClaude = vi.fn();
 const detectCodex = vi.fn();
 const detectOmp = vi.fn();
 const detectPi = vi.fn();
+const detectAgy = vi.fn();
 const { mockUseOmpAvailability } = vi.hoisted(() => ({ mockUseOmpAvailability: vi.fn() }));
 vi.mock('../../hooks/useOmpAvailability', () => ({ useOmpAvailability: mockUseOmpAvailability }));
 
@@ -24,7 +25,9 @@ vi.mock('../../utils/api', () => ({
             ? detectCodex()
             : provider === 'pi'
               ? detectPi()
-              : detectOmp(),
+              : provider === 'agy'
+                ? detectAgy()
+                : detectOmp(),
     },
   },
 }));
@@ -69,6 +72,12 @@ const PI_DETECTED: ProviderDetectionResult<'pi'> = {
   version: '0.84.2',
 };
 
+const AGY_DETECTED: ProviderDetectionResult<'agy'> = {
+  state: 'detected',
+  binaryPath: '/usr/local/bin/agy',
+  version: '1.1.25',
+};
+
 const OMP_UNSUPPORTED_VERSION: ProviderDetectionResult<'omp'> = {
   state: 'unavailable',
   binaryPath: '/usr/local/bin/omp',
@@ -82,6 +91,7 @@ beforeEach(() => {
   detectCodex.mockReset().mockResolvedValue({ success: true, data: CODEX_CONNECTED });
   detectOmp.mockReset().mockResolvedValue({ success: true, data: OMP_MISSING });
   detectPi.mockReset().mockResolvedValue({ success: true, data: PI_DETECTED });
+  detectAgy.mockReset().mockResolvedValue({ success: true, data: AGY_DETECTED });
   updateConfig = vi.fn().mockResolvedValue(true);
   // Default install: OMP runs locally, so the row reports the local binary.
   mockUseOmpAvailability.mockReset().mockReturnValue({ launchable: false, ariaMode: false });
@@ -145,10 +155,10 @@ describe('IntegrationsSettings — provider access toggles', () => {
     fireEvent.click(await screen.findByRole('switch', { name: 'Use Codex in Cyboflow' }));
 
     // Full object, never a partial patch — the siblings must not be dropped.
-    // OMP and Pi ride along at their untouched defaults (absent ⇒ off).
+    // OMP, Pi, and Antigravity ride along at their untouched defaults (absent ⇒ off).
     await waitFor(() =>
       expect(updateConfig).toHaveBeenCalledWith({
-        agentProviderAccess: { claude: true, codex: false, omp: false, pi: false },
+        agentProviderAccess: { claude: true, codex: false, omp: false, pi: false, agy: false },
       }),
     );
   });
@@ -163,7 +173,22 @@ describe('IntegrationsSettings — provider access toggles', () => {
     fireEvent.click(codexSwitch);
     await waitFor(() =>
       expect(updateConfig).toHaveBeenCalledWith({
-        agentProviderAccess: { claude: true, codex: true, omp: false, pi: false },
+        agentProviderAccess: { claude: true, codex: true, omp: false, pi: false, agy: false },
+      }),
+    );
+  });
+
+  it('switches Antigravity on from the off state', async () => {
+    setProviderAccess(undefined);
+    render(<IntegrationsSettings />);
+
+    const agySwitch = await screen.findByRole('switch', { name: 'Use Antigravity in Cyboflow' });
+    expect(agySwitch).not.toBeChecked();
+
+    fireEvent.click(agySwitch);
+    await waitFor(() =>
+      expect(updateConfig).toHaveBeenCalledWith({
+        agentProviderAccess: { claude: true, codex: true, omp: false, pi: false, agy: true },
       }),
     );
   });
@@ -181,10 +206,10 @@ describe('IntegrationsSettings — provider access toggles', () => {
   });
 
   it('explains what a disabled provider means, and warns about the Claude-only surfaces', async () => {
-    // omp: true so ONLY the Claude row is disabled here — otherwise OMP's
-    // own (identical) "hidden from every runtime picker" hint would collide
+    // omp: true and agy: true so ONLY the Claude row is disabled here — otherwise other
+    // providers' "hidden from every runtime picker" hint would collide
     // with Claude's and make findByText ambiguous.
-    setProviderAccess({ claude: false, codex: true, omp: true, pi: true });
+    setProviderAccess({ claude: false, codex: true, omp: true, pi: true, agy: true });
     render(<IntegrationsSettings />);
 
     expect(await screen.findByText(/hidden from every runtime picker/i)).toBeInTheDocument();
@@ -258,7 +283,7 @@ describe('IntegrationsSettings — OMP card', () => {
 
     await waitFor(() =>
       expect(updateConfig).toHaveBeenCalledWith({
-        agentProviderAccess: { claude: true, codex: true, omp: true, pi: false },
+        agentProviderAccess: { claude: true, codex: true, omp: true, pi: false, agy: false },
       }),
     );
   });
@@ -280,7 +305,7 @@ describe('IntegrationsSettings — OMP card', () => {
 
     await waitFor(() =>
       expect(updateConfig).toHaveBeenCalledWith({
-        agentProviderAccess: { claude: true, codex: true, omp: false, pi: false },
+        agentProviderAccess: { claude: true, codex: true, omp: false, pi: false, agy: false },
       }),
     );
   });
@@ -382,7 +407,7 @@ describe('IntegrationsSettings — the Aria gate on Pi', () => {
 
     await waitFor(() =>
       expect(updateConfig).toHaveBeenCalledWith({
-        agentProviderAccess: { claude: true, codex: true, omp: true, pi: true },
+        agentProviderAccess: { claude: true, codex: true, omp: true, pi: true, agy: false },
       }),
     );
   });
@@ -406,7 +431,7 @@ describe('IntegrationsSettings — the Aria gate on Pi', () => {
 
     await waitFor(() =>
       expect(updateConfig).toHaveBeenCalledWith({
-        agentProviderAccess: { claude: true, codex: true, omp: true, pi: true },
+        agentProviderAccess: { claude: true, codex: true, omp: true, pi: true, agy: false },
       }),
     );
   });

--- a/frontend/src/components/settings/IntegrationsSettings.tsx
+++ b/frontend/src/components/settings/IntegrationsSettings.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import { Bot, Code2, ExternalLink, RefreshCw, Boxes, Terminal } from 'lucide-react';
+import { Bot, Code2, ExternalLink, RefreshCw, Boxes, Terminal, Sparkles } from 'lucide-react';
 import type { AgentProvider, AgentProviderAccess } from '../../../../shared/types/agentRuntime';
 import { AGENT_PROVIDERS, isAgentProviderEnabled } from '../../../../shared/types/agentRuntime';
 import type { ProviderDetectionResult } from '../../../../shared/types/onboarding';
@@ -337,16 +337,52 @@ function piView(
   };
 }
 
+function agyView(
+  detection: ProviderDetectionResult<'agy'> | null,
+  error: string | null,
+): ProviderViewModel {
+  if (error) {
+    return { status: 'unavailable', label: 'Check failed', detail: error };
+  }
+  if (!detection) {
+    return { status: 'checking', label: 'Checking', detail: 'Looking for an agy binary on this machine.' };
+  }
+  if (detection.state === 'unavailable') {
+    if (detection.binaryPath !== null) {
+      return {
+        status: 'unavailable',
+        label: 'Unsupported version',
+        detail: detection.version
+          ? `Found agy ${detection.version}, but this version isn't supported.`
+          : "Found an agy binary, but its version couldn't be verified.",
+        metadata: detection.binaryPath,
+      };
+    }
+    return {
+      status: 'unavailable',
+      label: 'Not available',
+      detail: 'agy was not found on this machine.',
+    };
+  }
+  return {
+    status: 'connected',
+    label: 'Detected',
+    detail: detection.version ? `agy ${detection.version}` : 'agy binary found',
+    metadata: detection.binaryPath ?? undefined,
+  };
+}
 
 export function IntegrationsSettings(): React.JSX.Element {
   const [claudeDetection, setClaudeDetection] = useState<ProviderDetectionResult<'claude'> | null>(null);
   const [codexDetection, setCodexDetection] = useState<ProviderDetectionResult<'codex'> | null>(null);
   const [ompDetection, setOmpDetection] = useState<ProviderDetectionResult<'omp'> | null>(null);
   const [piDetection, setPiDetection] = useState<ProviderDetectionResult<'pi'> | null>(null);
+  const [agyDetection, setAgyDetection] = useState<ProviderDetectionResult<'agy'> | null>(null);
   const [claudeError, setClaudeError] = useState<string | null>(null);
   const [codexError, setCodexError] = useState<string | null>(null);
   const [ompError, setOmpError] = useState<string | null>(null);
   const [piError, setPiError] = useState<string | null>(null);
+  const [agyError, setAgyError] = useState<string | null>(null);
   const [checking, setChecking] = useState(true);
   const requestId = useRef(0);
 
@@ -357,12 +393,14 @@ export function IntegrationsSettings(): React.JSX.Element {
     setCodexError(null);
     setOmpError(null);
     setPiError(null);
+    setAgyError(null);
 
-    const [claudeResult, codexResult, ompResult, piResult] = await Promise.allSettled([
+    const [claudeResult, codexResult, ompResult, piResult, agyResult] = await Promise.allSettled([
       API.providers.detect('claude'),
       API.providers.detect('codex'),
       API.providers.detect('omp'),
       API.providers.detect('pi'),
+      API.providers.detect('agy'),
     ]);
     if (currentRequest !== requestId.current) return;
 
@@ -402,6 +440,15 @@ export function IntegrationsSettings(): React.JSX.Element {
       setPiError(responseError('Pi', message));
     }
 
+    if (agyResult.status === 'fulfilled' && agyResult.value.success && agyResult.value.data) {
+      setAgyDetection(agyResult.value.data);
+    } else {
+      const message = agyResult.status === 'rejected'
+        ? agyResult.reason instanceof Error ? agyResult.reason.message : undefined
+        : agyResult.value.error;
+      setAgyError(responseError('Antigravity', message));
+    }
+
     setChecking(false);
   }, []);
 
@@ -428,6 +475,7 @@ export function IntegrationsSettings(): React.JSX.Element {
   const ompAvailability = useOmpAvailability();
   const omp = ompView(ompDetection, ompError, ompAvailability);
   const pi = piView(piDetection, piError);
+  const agy = agyView(agyDetection, agyError);
 
   // Provider access — the toggles below write AppConfig.agentProviderAccess,
   // the same field the onboarding Connect step writes, so the two surfaces are
@@ -451,11 +499,14 @@ export function IntegrationsSettings(): React.JSX.Element {
   // materially less complete than the others, so a non-Aria install gets no Pi
   // card at all rather than a switched-off one that invites turning it on.
   const piSurfaced = useIsAgentProviderSurfaced('pi');
+  const agyEnabled = isAgentProviderEnabled(providerAccess, 'agy');
+  const agySurfaced = useIsAgentProviderSurfaced('agy');
   const enabledByProvider: Record<AgentProvider, boolean> = {
     claude: claudeEnabled,
     codex: codexEnabled,
     omp: ompEnabled,
     pi: piEnabled,
+    agy: agyEnabled,
   };
   const [savingProvider, setSavingProvider] = useState<AgentProvider | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -565,6 +616,18 @@ export function IntegrationsSettings(): React.JSX.Element {
               toggleTestId="provider-toggle-pi"
             />
           )}
+          {agySurfaced && (
+            <ProviderRow
+              name="Antigravity"
+              description="Google DeepMind Antigravity CLI — multi-modal and frontier reasoning models via the local agy installation."
+              icon={<Sparkles className="h-4 w-4" />}
+              view={agy}
+              enabled={agyEnabled}
+              onToggle={(next) => void setProviderEnabled('agy', next)}
+              toggleDisabledReason={toggleReason('agy', agyEnabled)}
+              toggleTestId="provider-toggle-agy"
+            />
+          )}
         </div>
 
         {saveError && (
@@ -591,6 +654,12 @@ export function IntegrationsSettings(): React.JSX.Element {
             (run <code className="border border-border-primary bg-bg-primary px-1">pi</code> in a
             terminal and use <code className="border border-border-primary bg-bg-primary px-1">/login</code>{' '}
             or <code className="border border-border-primary bg-bg-primary px-1">--api-key</code>).
+          </p>
+        )}
+        {!agyEnabled && (
+          <p className="mt-3 text-xs leading-relaxed text-text-tertiary">
+            Antigravity is off by default — turn it on once you've installed it and authenticated
+            (run <code className="border border-border-primary bg-bg-primary px-1">agy</code> in a terminal).
           </p>
         )}
       </SettingsSection>

--- a/frontend/src/components/settings/__tests__/SessionSettings.test.tsx
+++ b/frontend/src/components/settings/__tests__/SessionSettings.test.tsx
@@ -460,9 +460,9 @@ describe('SessionSettings', () => {
 
   describe('Default Agent Runtime', () => {
     it('renders the built-in-default state and every OFFERABLE session runtime', () => {
-      // All three providers switched on, so the capability filter is the only
+      // All providers switched on, so the capability filter is the only
       // thing deciding which session runtimes get a button.
-      renderGroup({ agentProviderAccess: { claude: true, codex: true, omp: true, pi: true } });
+      renderGroup({ agentProviderAccess: { claude: true, codex: true, omp: true, pi: true, agy: true } });
 
       expect(screen.getByTestId('default-agent-runtime-unset')).toHaveAttribute('aria-pressed', 'true');
       // Session membership is necessary but not sufficient: the control shows a

--- a/frontend/src/components/settings/runTypeOverrides.ts
+++ b/frontend/src/components/settings/runTypeOverrides.ts
@@ -28,6 +28,8 @@ import {
   isCodexModelFamily,
   isCodexModelSelection,
   isOmpModelFamily,
+  isAgyModelFamily,
+  DEFAULT_AGY_MODEL,
 } from '../../../../shared/types/agentModels';
 import {
   AGENT_RUNTIME_LABELS as SESSION_AGENT_RUNTIME_LABELS,
@@ -638,6 +640,11 @@ export function coerceModelForRuntime(
       if (model === null) return null;
       if (isOmpModelFamily(model)) return model;
       return isOmpModelFamily(fallbackModel) ? fallbackModel : null;
+    }
+    case 'agy': {
+      if (model === null) return null;
+      if (isAgyModelFamily(model)) return model;
+      return isAgyModelFamily(fallbackModel) ? fallbackModel : DEFAULT_AGY_MODEL;
     }
     case 'claude': {
       if (model === null) return null;

--- a/frontend/src/hooks/useClaudePanel.ts
+++ b/frontend/src/hooks/useClaudePanel.ts
@@ -32,11 +32,13 @@ export async function dispatchQuickSessionInput(
   const isStructuredSdkPanel =
     session.agentRuntime === 'codex-sdk' ||
     session.agentRuntime === 'omp-sdk' ||
-    session.agentRuntime === 'pi-sdk'
+    session.agentRuntime === 'pi-sdk' ||
+    session.agentRuntime === 'agy-sdk'
       ? panelSubstrate !== 'interactive'
       : (session.agentRuntime === 'codex-pty' ||
            session.agentRuntime === 'omp-pty' ||
-           session.agentRuntime === 'pi-pty') &&
+           session.agentRuntime === 'pi-pty' ||
+           session.agentRuntime === 'agy-pty') &&
         panelSubstrate === 'sdk';
 
   if (isStructuredSdkPanel) {

--- a/frontend/src/stores/providerModelCatalogStore.ts
+++ b/frontend/src/stores/providerModelCatalogStore.ts
@@ -94,6 +94,7 @@ export const PROVIDER_MODEL_CATALOG_SLICES: {
   // `models:get-catalog` fetcher returns real rows. Nothing is fetched until
   // a picker actually shows Pi.
   pi: createCatalogSlice('pi'),
+  agy: createCatalogSlice('agy'),
 };
 
 export interface ProviderModelCatalogHook<P extends AgentProvider> {

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -90,6 +90,7 @@ const CATALOG_BRIDGE_FALLBACKS: {
   // discovered `${provider}/${model}` list — no pinned aliases — so an empty
   // catalog would be a silently broken control rather than a degraded one.
   pi: null,
+  agy: null,
 };
 
 // Wrapper class for API calls that provides error handling and consistent interface

--- a/main/src/database/__tests__/migration130.test.ts
+++ b/main/src/database/__tests__/migration130.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Migration 130_widen_agent_runtime_agy.sql — admitting the agy provider and runtimes.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type BetterSqlite3 from 'better-sqlite3';
+import { mkdtempSync, rmSync, readdirSync, copyFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseService } from '../database';
+
+const MIGRATIONS_DIR = join(__dirname, '..', 'migrations');
+const MIGRATION_130 = '130_widen_agent_runtime_agy.sql';
+
+let tmpDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cyboflow-migration130-'));
+  dbPath = join(tmpDir, 'test.db');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function migrationsDirWithout130(): string {
+  const dir = join(tmpDir, 'migrations-pre-130');
+  mkdirSync(dir);
+  for (const name of readdirSync(MIGRATIONS_DIR)) {
+    if (name === MIGRATION_130) continue;
+    if (!/^\d{3}_.*\.sql$/.test(name)) continue;
+    copyFileSync(join(MIGRATIONS_DIR, name), join(dir, name));
+  }
+  return dir;
+}
+
+function openAt(migrationsDir: string): DatabaseService {
+  const svc = new DatabaseService(dbPath);
+  svc.setMigrationsDirForTesting(migrationsDir);
+  svc.initialize();
+  return svc;
+}
+
+function seedRows(db: BetterSqlite3.Database): void {
+  db.prepare(`INSERT INTO projects (id, name, path) VALUES (1, 'Proj', '/tmp/p130')`).run();
+  db.prepare(
+    `INSERT INTO workflows (id, project_id, name, spec_json) VALUES ('wf-1', 1, 'sprint', '{}')`,
+  ).run();
+
+  const insertSession = db.prepare(
+    `INSERT INTO sessions (id, name, initial_prompt, worktree_name, worktree_path, project_id,
+                           status_message, agent_provider, agent_runtime)
+     VALUES (?, ?, 'go', ?, ?, 1, ?, ?, ?)`,
+  );
+  insertSession.run('s-claude', 'Claude', 'wt-1', '/tmp/wt-1', 'Waiting', 'claude', 'claude-sdk');
+  insertSession.run('s-codex-pty', 'Codex TUI', 'wt-2', '/tmp/wt-2', null, 'codex', 'codex-pty');
+  insertSession.run('s-omp-sdk', 'OMP', 'wt-3', '/tmp/wt-3', 'Running', 'omp', 'omp-sdk');
+  insertSession.run('s-pi-sdk', 'Pi', 'wt-4', '/tmp/wt-4', 'Running', 'pi', 'pi-sdk');
+
+  const insertRun = db.prepare(
+    `INSERT INTO workflow_runs (id, workflow_id, project_id, status, permission_mode_snapshot,
+                                agent_provider, agent_runtime)
+     VALUES (?, 'wf-1', 1, 'completed', 'default', ?, ?)`,
+  );
+  insertRun.run('run-claude', 'claude', 'claude-sdk');
+  insertRun.run('run-pi', 'pi', 'pi-sdk');
+
+  db.prepare(
+    `INSERT INTO agent_invocations (agent_invocation_id, run_id, step_id, agent_provider, agent_runtime)
+     VALUES ('inv-seed-1', 'run-claude', 'step-1', 'codex', 'codex-sdk')`,
+  ).run();
+}
+
+function allRows(db: BetterSqlite3.Database, table: string): Array<Record<string, unknown>> {
+  return db.prepare(`SELECT * FROM ${table} ORDER BY rowid`).all() as Array<Record<string, unknown>>;
+}
+
+describe('migration 130: widen agent_provider and agent_runtime for agy', () => {
+  it('migrates an existing database cleanly admitting agy runtimes', () => {
+    // 1. Boot on pre-130 migrations
+    const preDir = migrationsDirWithout130();
+    openAt(preDir).close();
+    const svc1 = openAt(preDir);
+    const db1 = svc1.getDb();
+    seedRows(db1);
+
+    const preSessions = allRows(db1, 'sessions');
+    const preRuns = allRows(db1, 'workflow_runs');
+    svc1.close();
+
+    // 2. Boot on full migrations dir (applies 130)
+    const svc2 = openAt(MIGRATIONS_DIR);
+    const db2 = svc2.getDb();
+
+    // 3. Pre-existing rows survive
+    expect(allRows(db2, 'sessions')).toEqual(preSessions);
+    expect(allRows(db2, 'workflow_runs')).toEqual(preRuns);
+
+    // 4. FK checks clean
+    const fkErrors = db2.prepare('PRAGMA foreign_key_check').all();
+    expect(fkErrors).toEqual([]);
+
+    // 5. Insert sessions with agy
+    const insertSession = db2.prepare(
+      `INSERT INTO sessions (id, name, initial_prompt, worktree_name, worktree_path, project_id,
+                             agent_provider, agent_runtime)
+       VALUES (?, ?, 'prompt', 'wt', '/tmp/wt', 1, ?, ?)`,
+    );
+
+    expect(() => insertSession.run('s-agy-sdk', 'Agy SDK', 'agy', 'agy-sdk')).not.toThrow();
+    expect(() => insertSession.run('s-agy-pty', 'Agy PTY', 'agy', 'agy-pty')).not.toThrow();
+
+    // 6. Insert workflow_runs with agy-sdk
+    const insertRun = db2.prepare(
+      `INSERT INTO workflow_runs (id, workflow_id, project_id, status, permission_mode_snapshot,
+                                  agent_provider, agent_runtime)
+       VALUES (?, 'wf-1', 1, 'queued', 'default', ?, ?)`,
+    );
+
+    expect(() => insertRun.run('run-agy-sdk', 'agy', 'agy-sdk')).not.toThrow();
+
+    // 7. workflow_runs rejects agy-pty (PTY cannot run workflows)
+    expect(() => insertRun.run('run-agy-pty', 'agy', 'agy-pty')).toThrow(/CHECK constraint failed/);
+
+    // 8. Insert workflow_variants with agy
+    const insertVariant = db2.prepare(
+      `INSERT INTO workflow_variants (id, workflow_id, label, agent_provider, agent_runtime)
+       VALUES ('wfv_1', 'wf-1', 'Agy Variant', 'agy', 'agy-sdk')`,
+    );
+    expect(() => insertVariant.run()).not.toThrow();
+
+    // 9. Insert agent_invocations with agy
+    const insertInvocation = db2.prepare(
+      `INSERT INTO agent_invocations (agent_invocation_id, run_id, step_id, agent_provider, agent_runtime)
+       VALUES (?, 'run-agy-sdk', 'step-1', ?, ?)`,
+    );
+    expect(() => insertInvocation.run('inv-agy-1', 'agy', 'agy-sdk')).not.toThrow();
+    expect(() => insertInvocation.run('inv-agy-2', 'agy', 'agy-pty')).not.toThrow();
+
+    // 10. Bogus values rejected
+    expect(() => insertSession.run('s-bogus', 'Bogus', 'unknown', 'agy-sdk')).toThrow(
+      /CHECK constraint failed/,
+    );
+    expect(() => insertSession.run('s-bogus-rt', 'Bogus RT', 'agy', 'invalid-runtime')).toThrow(
+      /CHECK constraint failed/,
+    );
+
+    svc2.close();
+  });
+});

--- a/main/src/database/migrations/130_widen_agent_runtime_agy.sql
+++ b/main/src/database/migrations/130_widen_agent_runtime_agy.sql
@@ -1,0 +1,127 @@
+-- Migration 130: admit the native 'agy' (Antigravity) provider on agent_provider
+-- CHECKs and the agy runtimes on agent_runtime CHECKs across all four
+-- provider-stamped tables (sessions, workflow_runs, workflow_variants,
+-- agent_invocations).
+
+PRAGMA foreign_keys=OFF;
+
+-- ---------------------------------------------------------------------------
+-- sessions.agent_provider  (123 list + 'agy')
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE sessions ADD COLUMN agent_provider_widen_130 TEXT;
+UPDATE sessions SET agent_provider_widen_130 = agent_provider;
+ALTER TABLE sessions DROP COLUMN agent_provider;
+ALTER TABLE sessions
+  ADD COLUMN agent_provider TEXT NOT NULL DEFAULT 'claude'
+    CHECK (agent_provider IN ('claude','codex','omp','pi','agy'));
+UPDATE sessions SET agent_provider = COALESCE(agent_provider_widen_130, 'claude');
+ALTER TABLE sessions DROP COLUMN agent_provider_widen_130;
+
+-- ---------------------------------------------------------------------------
+-- sessions.agent_runtime  (123 list + 'agy-sdk' + 'agy-pty')
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE sessions ADD COLUMN agent_runtime_widen_130 TEXT;
+UPDATE sessions SET agent_runtime_widen_130 = agent_runtime;
+ALTER TABLE sessions DROP COLUMN agent_runtime;
+ALTER TABLE sessions
+  ADD COLUMN agent_runtime TEXT NOT NULL DEFAULT 'claude-sdk'
+    CHECK (agent_runtime IN ('claude-sdk','claude-interactive','codex-sdk','codex-pty','omp-sdk','omp-pty','omp-fleet','pi-sdk','pi-pty','agy-sdk','agy-pty'));
+UPDATE sessions SET agent_runtime = COALESCE(agent_runtime_widen_130, 'claude-sdk');
+ALTER TABLE sessions DROP COLUMN agent_runtime_widen_130;
+
+-- ---------------------------------------------------------------------------
+-- workflow_runs.agent_provider  (123 list + 'agy')
+-- workflow_runs.agent_runtime   (123 list + 'agy-sdk')
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE workflow_runs ADD COLUMN agent_provider_widen_130 TEXT;
+UPDATE workflow_runs SET agent_provider_widen_130 = agent_provider;
+ALTER TABLE workflow_runs DROP COLUMN agent_provider;
+ALTER TABLE workflow_runs
+  ADD COLUMN agent_provider TEXT NOT NULL DEFAULT 'claude'
+    CHECK (agent_provider IN ('claude','codex','omp','pi','agy'));
+UPDATE workflow_runs SET agent_provider = COALESCE(agent_provider_widen_130, 'claude');
+ALTER TABLE workflow_runs DROP COLUMN agent_provider_widen_130;
+
+ALTER TABLE workflow_runs ADD COLUMN agent_runtime_widen_130 TEXT;
+UPDATE workflow_runs SET agent_runtime_widen_130 = agent_runtime;
+ALTER TABLE workflow_runs DROP COLUMN agent_runtime;
+ALTER TABLE workflow_runs
+  ADD COLUMN agent_runtime TEXT NOT NULL DEFAULT 'claude-sdk'
+    CHECK (agent_runtime IN ('claude-sdk','claude-interactive','codex-sdk','omp-sdk','omp-fleet','pi-sdk','agy-sdk'));
+UPDATE workflow_runs SET agent_runtime = COALESCE(agent_runtime_widen_130, 'claude-sdk');
+ALTER TABLE workflow_runs DROP COLUMN agent_runtime_widen_130;
+
+-- ---------------------------------------------------------------------------
+-- workflow_variants.agent_provider / workflow_variants.agent_runtime
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE workflow_variants ADD COLUMN agent_provider_widen_130 TEXT;
+UPDATE workflow_variants SET agent_provider_widen_130 = agent_provider;
+ALTER TABLE workflow_variants DROP COLUMN agent_provider;
+ALTER TABLE workflow_variants
+  ADD COLUMN agent_provider TEXT
+    CHECK (agent_provider IS NULL OR agent_provider IN ('claude','codex','omp','pi','agy'));
+UPDATE workflow_variants SET agent_provider = agent_provider_widen_130;
+ALTER TABLE workflow_variants DROP COLUMN agent_provider_widen_130;
+
+ALTER TABLE workflow_variants ADD COLUMN agent_runtime_widen_130 TEXT;
+UPDATE workflow_variants SET agent_runtime_widen_130 = agent_runtime;
+ALTER TABLE workflow_variants DROP COLUMN agent_runtime;
+ALTER TABLE workflow_variants
+  ADD COLUMN agent_runtime TEXT
+    CHECK (agent_runtime IS NULL OR agent_runtime IN ('claude-sdk','claude-interactive','codex-sdk','omp-sdk','pi-sdk','agy-sdk'));
+UPDATE workflow_variants SET agent_runtime = agent_runtime_widen_130;
+ALTER TABLE workflow_variants DROP COLUMN agent_runtime_widen_130;
+
+-- ---------------------------------------------------------------------------
+-- agent_invocations — full recreate
+-- Note: Mirrors migration 123. Unlike sessions and workflow_runs which use
+-- single-column ALTER/DROP pairs, agent_invocations carries an ON DELETE CASCADE
+-- foreign key against workflow_runs(id) and a UNIQUE constraint on
+-- agent_invocation_id. Recreating the table cleanly re-applies the FK and
+-- unique index without intermediate constraint violations.
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE agent_invocations_new (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+  agent_invocation_id   TEXT NOT NULL UNIQUE,
+  run_id                TEXT NOT NULL,
+  step_id               TEXT,
+  agent_provider        TEXT NOT NULL
+                          CHECK (agent_provider IN ('claude', 'codex', 'omp', 'pi', 'agy')),
+  agent_runtime         TEXT NOT NULL
+                          CHECK (agent_runtime IN ('claude-sdk', 'claude-interactive', 'codex-sdk', 'omp-sdk', 'omp-pty', 'pi-sdk', 'pi-pty', 'agy-sdk', 'agy-pty')),
+  model                 TEXT,
+  external_session_id   TEXT,
+  created_at            TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  panel_id              TEXT,
+  FOREIGN KEY (run_id) REFERENCES workflow_runs(id) ON DELETE CASCADE
+);
+
+INSERT INTO agent_invocations_new (id, agent_invocation_id, run_id, step_id, agent_provider,
+                                   agent_runtime, model, external_session_id, created_at, panel_id)
+  SELECT id, agent_invocation_id, run_id, step_id, agent_provider,
+         agent_runtime, model, external_session_id, created_at, panel_id
+  FROM agent_invocations;
+
+INSERT INTO sqlite_sequence (name, seq)
+  SELECT 'agent_invocations_new', 0
+   WHERE EXISTS (SELECT 1 FROM sqlite_sequence WHERE name = 'agent_invocations')
+     AND NOT EXISTS (SELECT 1 FROM sqlite_sequence WHERE name = 'agent_invocations_new');
+
+UPDATE sqlite_sequence
+   SET seq = MAX(seq, COALESCE((SELECT seq FROM sqlite_sequence WHERE name = 'agent_invocations'), 0))
+ WHERE name = 'agent_invocations_new';
+
+DROP TABLE agent_invocations;
+ALTER TABLE agent_invocations_new RENAME TO agent_invocations;
+
+CREATE INDEX IF NOT EXISTS idx_agent_invocations_run_step_latest
+  ON agent_invocations (run_id, step_id, id DESC);
+CREATE INDEX IF NOT EXISTS idx_agent_invocations_run_panel_latest
+  ON agent_invocations (run_id, panel_id, id DESC);
+
+PRAGMA foreign_keys=ON;

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -71,11 +71,15 @@ import {
   isOmpPtyManagerLike,
   isPiPtyManagerLike,
   isPiSdkManagerLike,
+  isAgyPtyManagerLike,
+  isAgySdkManagerLike,
   isOmpSdkManagerLike,
   type CodexPtyManagerLike,
   type OmpPtyManagerLike,
   type PiPtyManagerLike,
   type PiSdkManagerLike,
+  type AgyPtyManagerLike,
+  type AgySdkManagerLike,
 } from './services/cliManagerFactory';
 import { AbstractCliManager } from './services/panels/cli/AbstractCliManager';
 import { panelManager } from './services/panelManager';
@@ -649,6 +653,8 @@ let codexPtyManager: CodexPtyManagerLike;
 let ompPtyManager: OmpPtyManagerLike;
 let piPtyManager: PiPtyManagerLike;
 let piSdkManager: PiSdkManagerLike;
+let agyPtyManager: AgyPtyManagerLike;
+let agySdkManager: AgySdkManagerLike;
 let gitDiffManager: GitDiffManager;
 let gitStatusManager: GitStatusManager;
 let executionTracker: ExecutionTracker;
@@ -1907,6 +1913,28 @@ async function initializeServices(): Promise<boolean> {
     throw new Error('[Main] cliManagerFactory returned a manager without the Pi SDK seams for pi-sdk');
   }
   piSdkManager = createdPiSdkManager;
+
+  const createdAgyPtyManager = await cliManagerFactory.createManager('agy-pty', {
+    sessionManager,
+    logger,
+    configManager,
+    skipValidation: true,
+  });
+  if (!isAgyPtyManagerLike(createdAgyPtyManager)) {
+    throw new Error('[Main] cliManagerFactory returned a manager without the Agy PTY seams for agy-pty');
+  }
+  agyPtyManager = createdAgyPtyManager;
+
+  const createdAgySdkManager = await cliManagerFactory.createManager('agy-sdk', {
+    sessionManager,
+    logger,
+    configManager,
+    skipValidation: true,
+  });
+  if (!isAgySdkManagerLike(createdAgySdkManager)) {
+    throw new Error('[Main] cliManagerFactory returned a manager without the Agy SDK seams for agy-sdk');
+  }
+  agySdkManager = createdAgySdkManager;
   gitDiffManager = new GitDiffManager(logger);
   gitStatusManager = new GitStatusManager(sessionManager, worktreeManager, gitDiffManager, logger);
   executionTracker = new ExecutionTracker(sessionManager, gitDiffManager);
@@ -3386,6 +3414,8 @@ async function initializeServices(): Promise<boolean> {
     { lane: 'omp-pty', manager: ompPtyManager },
     { lane: 'pi-pty', manager: piPtyManager },
     { lane: 'pi-sdk', manager: piSdkManager },
+    { lane: 'agy-pty', manager: agyPtyManager },
+    { lane: 'agy-sdk', manager: agySdkManager },
   ];
   const managerByLane = new Map<PanelLane, AbstractCliManager>(
     laneManagers.map(({ lane, manager }) => [lane, manager]),
@@ -4445,6 +4475,8 @@ async function initializeServices(): Promise<boolean> {
     ompPtyManager,
     piSdkManager: createdPiSdkManager,
     piPtyManager,
+    agySdkManager: createdAgySdkManager,
+    agyPtyManager,
     claudeModelCatalogService: new ClaudeModelCatalogService(cyboflowLogger),
     // Live-session close-out seams for quick sessions (IDEA-030): route the
     // session merge/rebase/dismiss handlers through the SubstrateDispatchFacade
@@ -4467,6 +4499,8 @@ async function initializeServices(): Promise<boolean> {
       substrateFacade.registerPtyPanel(runId, panelId, ompPtyManager),
     registerPiPtyPanel: (runId: string, panelId: string) =>
       substrateFacade.registerPtyPanel(runId, panelId, piPtyManager),
+    registerAgyPtyPanel: (runId: string, panelId: string) =>
+      substrateFacade.registerPtyPanel(runId, panelId, agyPtyManager),
     // The SAME provider the Claude managers were injected with above, handed to
     // the IPC layer for the CODEX lanes: those spawn from ipc/ with a
     // caller-supplied runId instead of resolving the gate inside the manager, so

--- a/main/src/ipc/models.ts
+++ b/main/src/ipc/models.ts
@@ -4,6 +4,8 @@ import { ModelAvailabilityService } from '../services/modelAvailabilityService';
 import { getSharedOmpModelCatalogProbe } from '../services/panels/omp/ompModelCatalog';
 import { detectPiAvailability } from '../services/panels/pi/piAvailability';
 import { fetchPiModelCatalog } from '../services/panels/pi/piModelCatalog';
+import { detectAgyAvailability } from '../services/panels/agy/agyAvailability';
+import { fetchAgyModelCatalog } from '../services/panels/agy/agyModelCatalog';
 import type { ModelAvailabilityMap } from '../../../shared/types/modelAvailability';
 import {
   AGENT_PROVIDERS,
@@ -58,6 +60,17 @@ const PROVIDER_CATALOG_FETCHERS: { [P in AgentProvider]: ProviderCatalogFetcher<
       );
     }
     return fetchPiModelCatalog(detection.binaryPath);
+  },
+  agy: async () => {
+    const detection = await detectAgyAvailability();
+    if (detection.state !== 'detected' || !detection.binaryPath) {
+      throw new Error(
+        detection.version
+          ? `agy ${detection.version} found but below the supported floor`
+          : 'agy binary not found on PATH',
+      );
+    }
+    return fetchAgyModelCatalog(detection.binaryPath);
   },
 };
 

--- a/main/src/ipc/panels.ts
+++ b/main/src/ipc/panels.ts
@@ -47,6 +47,8 @@ export function registerPanelHandlers(ipcMain: IpcMain, services: AppServices) {
       'omp-pty': services.ompPtyManager,
       'pi-sdk': services.piSdkManager,
       'pi-pty': services.piPtyManager,
+      'agy-sdk': services.agySdkManager,
+      'agy-pty': services.agyPtyManager,
      });
 
   // Panel CRUD operations

--- a/main/src/ipc/providerDetection.ts
+++ b/main/src/ipc/providerDetection.ts
@@ -10,6 +10,7 @@ import { probeClaudeDetection } from './claudeDetection';
 import { probeCodexDetection } from './codexDetection';
 import { detectOmpAvailability } from '../services/panels/omp/ompAvailability';
 import { detectPiAvailability } from '../services/panels/pi/piAvailability';
+import { detectAgyAvailability } from '../services/panels/agy/agyAvailability';
 import type { AppServices } from './types';
 
 /**
@@ -46,6 +47,7 @@ const PROVIDER_DETECTION_PROBES: { [P in AgentProvider]: ProviderDetectionProbe<
   // no services dependency (no `piExecutablePath` config key yet, and pi owns
   // its own provider credentials).
   pi: () => detectPiAvailability(),
+  agy: () => detectAgyAvailability(),
 };
 
 type DetectionResponse =

--- a/main/src/ipc/session.ts
+++ b/main/src/ipc/session.ts
@@ -296,11 +296,14 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
     ompPtyManager, // OMP PTY quick-session runtime
     piPtyManager, // Pi PTY quick-session runtime
     piSdkManager, // Pi structured runtime (quick sessions + workflow runs)
+    agyPtyManager, // Antigravity PTY quick-session runtime
+    agySdkManager, // Antigravity structured runtime (quick sessions + workflow runs)
     killLiveSession, // hard-kill seam for a dismissed PTY quick session's REPL
     registerLivePanel, // at-spawn runId→panelId seed for the facade's relay translation
     registerCodexPtyPanel, // at-spawn runId→panelId seed for Codex PTY quick sessions
     registerOmpPtyPanel, // the OMP twin of registerCodexPtyPanel
     registerPiPtyPanel, // the Pi twin of registerOmpPtyPanel
+    registerAgyPtyPanel, // the Antigravity twin of registerPiPtyPanel
     gitStatusManager,
     archiveProgressManager,
     configManager, // demo-mode probe — gates the real interactive PTY spawn/relay
@@ -691,6 +694,7 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
       // system-prompt channel on this spawn shape, so passing one would be
       // silently dropped rather than delivered.
       createStructuredChatLane({ lane: 'pi-sdk', manager: piSdkManager }),
+      createStructuredChatLane({ lane: 'agy-sdk', manager: agySdkManager }),
     ].map((entry) => [entry.lane, entry]),
   );
 
@@ -789,6 +793,26 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
         briefing: QUICK_PI_PTY_BRIEFING,
       },
     ],
+    [
+      'agy-pty',
+      {
+        label: AGENT_PROVIDER_LABELS.agy,
+        isPanelRunning: (panelId) => agyPtyManager.isPanelRunning(panelId),
+        relayUserTurn: (panelId, input) => agyPtyManager.relayUserTurn(panelId, input),
+        registerPanel: registerAgyPtyPanel,
+        startPanel: (o) =>
+          agyPtyManager.startPanel(
+            o.panelId,
+            o.sessionId,
+            o.worktreePath,
+            o.prompt,
+            o.permissionMode,
+            o.model,
+            o.runId,
+          ),
+        briefing: 'You are Antigravity CLI in interactive session mode.',
+      },
+    ],
   ]);
 
   /**
@@ -803,6 +827,8 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
       'omp-pty': ompPtyManager,
       'pi-sdk': piSdkManager,
       'pi-pty': piPtyManager,
+      'agy-sdk': agySdkManager,
+      'agy-pty': agyPtyManager,
     });
 
   /**
@@ -830,6 +856,7 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
     ['codex-pty', codexPtyManager],
     ['omp-pty', ompPtyManager],
     ['pi-pty', piPtyManager],
+    ['agy-pty', agyPtyManager],
   ] as const) {
     manager?.on?.('exit', (payload: { panelId?: string; sessionId?: string; exitCode?: number }) => {
       handlePtyLaneExit(ptyLane, payload);

--- a/main/src/ipc/types.ts
+++ b/main/src/ipc/types.ts
@@ -19,6 +19,8 @@ import type {
   OmpPtyManagerLike,
   PiPtyManagerLike,
   PiSdkManagerLike,
+  AgyPtyManagerLike,
+  AgySdkManagerLike,
   OmpSdkManagerLike,
 } from '../services/cliManagerFactory';
 import type { AbstractCliManager } from '../services/panels/cli/AbstractCliManager';
@@ -66,6 +68,10 @@ export interface AppServices {
   piPtyManager: PiPtyManagerLike;
   /** Structured pi runtime (turn-spawn, --session-id resume) for quick sessions AND workflow runs. */
   piSdkManager: PiSdkManagerLike;
+  /** Interactive Antigravity PTY runtime for quick sessions only. */
+  agyPtyManager: AgyPtyManagerLike;
+  /** Structured Antigravity runtime (turn-spawn, --conversation resume) for quick sessions AND workflow runs. */
+  agySdkManager: AgySdkManagerLike;
   /**
    * OMP fleet runtime (Phase 4 coexistence, omp-phase4-coexistence-adr.md). A
    * SIBLING to the process managers — a remote worker supervised over the Prime
@@ -106,6 +112,8 @@ export interface AppServices {
   registerOmpPtyPanel: (runId: string, panelId: string) => void;
   /** Deterministic at-spawn registration for Pi PTY quick-session panels. */
   registerPiPtyPanel: (runId: string, panelId: string) => void;
+  /** Deterministic at-spawn registration for Antigravity PTY quick-session panels. */
+  registerAgyPtyPanel: (runId: string, panelId: string) => void;
   /**
    * Idle-debounced quick-session summarizer (session-summary-plan.md §5). The
    * sessions:input handler calls `noteTurnStart` before dispatching a user turn

--- a/main/src/orchestrator/__test_fixtures__/orchestratorTestDb.ts
+++ b/main/src/orchestrator/__test_fixtures__/orchestratorTestDb.ts
@@ -198,17 +198,17 @@ export function createTestDb(options?: CreateTestDbOptions): Database.Database {
   let agentProviderRuntimeAdded = false;
   const addAgentProviderRuntimeColumnsOnce = (): void => {
     if (agentProviderRuntimeAdded) return;
-    // CHECK lists mirror migration 123 (the current widening). A fixture that
+    // CHECK lists mirror migration 130 (the current widening). A fixture that
     // lags a widening does not fail loudly — it rejects the stamp the app now
     // makes legitimately, which reads as a bug in the code under test.
     db.exec(
-      "ALTER TABLE workflow_runs ADD COLUMN agent_provider TEXT NOT NULL DEFAULT 'claude' CHECK (agent_provider IN ('claude','codex','omp','pi'))",
+      "ALTER TABLE workflow_runs ADD COLUMN agent_provider TEXT NOT NULL DEFAULT 'claude' CHECK (agent_provider IN ('claude','codex','omp','pi','agy'))",
     );
     // The pty runtimes are absent for the reason migration 103's own comment
     // gives — a workflow run needs structured events, usage and MCP progress,
     // which a keystroke-driven TUI cannot supply.
     db.exec(
-      "ALTER TABLE workflow_runs ADD COLUMN agent_runtime TEXT NOT NULL DEFAULT 'claude-sdk' CHECK (agent_runtime IN ('claude-sdk','claude-interactive','codex-sdk','omp-sdk','omp-fleet','pi-sdk'))",
+      "ALTER TABLE workflow_runs ADD COLUMN agent_runtime TEXT NOT NULL DEFAULT 'claude-sdk' CHECK (agent_runtime IN ('claude-sdk','claude-interactive','codex-sdk','omp-sdk','omp-fleet','pi-sdk','agy-sdk'))",
     );
     agentProviderRuntimeAdded = true;
   };

--- a/main/src/orchestrator/__tests__/workflowPromptRenderer.test.ts
+++ b/main/src/orchestrator/__tests__/workflowPromptRenderer.test.ts
@@ -163,6 +163,19 @@ describe('renderWorkflowPromptForRuntime', () => {
     }
   });
 
+  it('prepends the agy envelope to a programmatic-step prompt', () => {
+    const rendered = renderWorkflowPromptForRuntime(BASE_PROMPT, {
+      provider: 'agy',
+      runtime: 'agy-sdk',
+      executionModel: 'programmatic',
+      turnKind: 'programmatic-step',
+    });
+
+    expect(rendered.prompt).toContain('# Runtime adapter: Antigravity');
+    expect(rendered.prompt.endsWith(BASE_PROMPT.prompt)).toBe(true);
+    expect(rendered.systemPromptAppend).toBe(BASE_PROMPT.systemPromptAppend);
+  });
+
   /**
    * Every provider now carries an envelope except claude, whose bodies are
    * written for it. A new provider defaulting to `null` by copy-paste is the
@@ -170,7 +183,7 @@ describe('renderWorkflowPromptForRuntime', () => {
    */
   it('only claude renders identity', () => {
     expect(PROVIDER_PROMPT_ENVELOPES.claude).toBeNull();
-    for (const provider of ['codex', 'omp', 'pi'] as const) {
+    for (const provider of ['codex', 'omp', 'pi', 'agy'] as const) {
       expect(PROVIDER_PROMPT_ENVELOPES[provider], provider).not.toBeNull();
     }
   });

--- a/main/src/orchestrator/__tests__/workflowRegistry.test.ts
+++ b/main/src/orchestrator/__tests__/workflowRegistry.test.ts
@@ -1183,7 +1183,7 @@ describe('WorkflowRegistry', () => {
     const ompEnabledRegistry = (): WorkflowRegistry =>
       new WorkflowRegistry(dbAdapter(db), logger, {
         ...makeConfig('default'),
-        getAgentProviderAccess: () => ({ claude: true, codex: true, omp: true, pi: true }),
+        getAgentProviderAccess: () => ({ claude: true, codex: true, omp: true, pi: true, agy: true }),
       });
 
     it('STAMPS omp-sdk on a real workflow launch, projecting the sdk substrate', async () => {
@@ -1316,6 +1316,71 @@ describe('WorkflowRegistry', () => {
             requestedAgentRuntime: 'pi-sdk',
           }),
         ).toThrow(/Pi provider is disabled/);
+      });
+    });
+
+    it('STAMPS agy-sdk on a real workflow launch, projecting the sdk substrate', async () => {
+      await withTempDir('workflow-registry-test-', async (tmpDir) => {
+        const path = writeTempMd(tmpDir, 'agy-launchable.md', '---\n---\n');
+        const gated = ompEnabledRegistry();
+        gated.seed(1, [{ name: 'sprint', path }]);
+
+        interface IdRow { id: string }
+        const { id: workflowId } = db.prepare('SELECT id FROM workflows WHERE name = ?').get('sprint') as IdRow;
+
+        const { runId, substrate } = gated.createRun(workflowId, undefined, TEST_SESSION_ID, undefined, {
+          requestedAgentProvider: 'agy',
+          requestedAgentRuntime: 'agy-sdk',
+          requestedExecutionModel: 'programmatic',
+        });
+
+        expect(substrate).toBe('sdk');
+        const row = db
+          .prepare('SELECT agent_provider, agent_runtime FROM workflow_runs WHERE id = ?')
+          .get(runId) as { agent_provider: string; agent_runtime: string };
+        expect(row).toEqual({ agent_provider: 'agy', agent_runtime: 'agy-sdk' });
+      });
+    });
+
+    it('resolves the agy launch arm from the PROVIDER half alone', async () => {
+      await withTempDir('workflow-registry-test-', async (tmpDir) => {
+        const path = writeTempMd(tmpDir, 'agy-provider-only.md', '---\n---\n');
+        const gated = ompEnabledRegistry();
+        gated.seed(1, [{ name: 'sprint', path }]);
+
+        interface IdRow { id: string }
+        const { id: workflowId } = db.prepare('SELECT id FROM workflows WHERE name = ?').get('sprint') as IdRow;
+
+        const { runId } = gated.createRun(workflowId, undefined, TEST_SESSION_ID, undefined, {
+          requestedAgentProvider: 'agy',
+          requestedExecutionModel: 'programmatic',
+        });
+
+        const row = db
+          .prepare('SELECT agent_provider, agent_runtime FROM workflow_runs WHERE id = ?')
+          .get(runId) as { agent_provider: string; agent_runtime: string };
+        expect(row).toEqual({ agent_provider: 'agy', agent_runtime: 'agy-sdk' });
+      });
+    });
+
+    it('refuses an agy workflow launch when the provider is switched off', async () => {
+      await withTempDir('workflow-registry-test-', async (tmpDir) => {
+        const path = writeTempMd(tmpDir, 'agy-disabled-launch.md', '---\n---\n');
+        const gated = new WorkflowRegistry(dbAdapter(db), logger, {
+          ...makeConfig('default'),
+          getAgentProviderAccess: () => ({ claude: true, codex: true, omp: false, pi: false, agy: false }),
+        });
+        gated.seed(1, [{ name: 'sprint', path }]);
+
+        interface IdRow { id: string }
+        const { id: workflowId } = db.prepare('SELECT id FROM workflows WHERE name = ?').get('sprint') as IdRow;
+
+        expect(() =>
+          gated.createRun(workflowId, undefined, TEST_SESSION_ID, undefined, {
+            requestedAgentProvider: 'agy',
+            requestedAgentRuntime: 'agy-sdk',
+          }),
+        ).toThrow(/Antigravity provider is disabled/);
       });
     });
 

--- a/main/src/orchestrator/workflowPromptRenderer.ts
+++ b/main/src/orchestrator/workflowPromptRenderer.ts
@@ -75,6 +75,20 @@ Provider adaptation rules:
 
 ---`;
 
+const AGY_WORKFLOW_ENVELOPE = `# Runtime adapter: Antigravity
+
+You are running the same Cyboflow workflow semantics as the Claude runtime, but through Antigravity (agy).
+
+Provider adaptation rules:
+
+- Treat the workflow body below as the source of truth for phases, step ids, required outputs, database writes, artifacts, and human gates.
+- When the workflow mentions Claude-specific mechanics such as \`.claude/agents/\`, the Agent tool, or a named \`cyboflow-*\` subagent, interpret that as a role/delegation instruction. **Cyboflow installs no agent files on this runtime**, so the workflow's claim that a \`cyboflow-*\` role "is installed in this worktree's \`.claude/agents/\`" does not hold here.
+- Never adopt an agent that merely shares the role's name from external environment. If delegation is requested, use \`define_subagent\`/\`invoke_subagent\` or **perform that role's work directly yourself, in this turn**, preserving the same returned sections and the same contract the role was given.
+- When the workflow reaches a human gate (e.g. AskUserQuestion or request_user_input), use \`ask_question\` or summarize the gate decision clearly in your response.
+- Do not create or read plugin state files. The Cyboflow database remains the single source of truth.
+
+---`;
+
 /**
  * The runtime-adapter block prepended to a launch / programmatic-step prompt,
  * per provider. `null` = the workflow body needs no adaptation, which is what
@@ -122,6 +136,7 @@ export const PROVIDER_PROMPT_ENVELOPES: Record<AgentProvider, string | null> = {
   // persist. That last rule is a mitigation, not a fix: pi workflow runs still
   // have no way to write cyboflow state, and closing THAT needs a pi MCP writer.
   pi: PI_WORKFLOW_ENVELOPE,
+  agy: AGY_WORKFLOW_ENVELOPE,
 };
 
 export function renderWorkflowPromptForRuntime(

--- a/main/src/services/cliManagerFactory.ts
+++ b/main/src/services/cliManagerFactory.ts
@@ -11,6 +11,8 @@ import { OmpPtyManager } from './panels/omp/ompPtyManager';
 import { OmpSdkManager } from './panels/omp/ompSdkManager';
 import { PiPtyManager } from './panels/pi/piPtyManager';
 import { PiSdkManager } from './panels/pi/piSdkManager';
+import { AgyPtyManager } from './panels/agy/agyPtyManager';
+import { AgySdkManager } from './panels/agy/agySdkManager';
 import {
   CliToolRegistry,
   CliToolDefinition,
@@ -142,6 +144,25 @@ export function isPiSdkManagerLike(manager: AbstractCliManager): manager is PiSd
   void manager;
   return true;
 }
+
+/** The Antigravity PTY seams — identical shape to the Pi/OMP/Codex PTY pair. */
+type AgyPtySeams = Pick<AgyPtyManager, 'startPanel' | 'relayUserTurn'>;
+
+/** The Antigravity SDK seams: the lifecycle is on AbstractCliManager in v1. */
+type AgySdkSeams = Record<string, never>;
+
+export type AgyPtyManagerLike = AbstractCliManager & AgyPtySeams;
+export type AgySdkManagerLike = AbstractCliManager & AgySdkSeams;
+
+export function isAgyPtyManagerLike(manager: AbstractCliManager): manager is AgyPtyManagerLike {
+  const seams = manager as Partial<AgyPtySeams>;
+  return typeof seams.startPanel === 'function' && typeof seams.relayUserTurn === 'function';
+}
+
+export function isAgySdkManagerLike(manager: AbstractCliManager): manager is AgySdkManagerLike {
+  void manager;
+  return true;
+}
 /** Does this manager expose the OMP SDK seams? */
 export function isOmpSdkManagerLike(manager: AbstractCliManager): manager is OmpSdkManagerLike {
   const seams = manager as Partial<OmpSdkSeams>;
@@ -208,6 +229,10 @@ function ompPtyDemoSeams(): Omit<OmpPtySeams, 'startPanel'> {
   return { relayUserTurn: () => {} };
 }
 
+function agyPtyDemoSeams(): Omit<AgyPtySeams, 'startPanel'> {
+  return { relayUserTurn: () => {} };
+}
+
 /**
  * The per-tool demo seam overlays, keyed by tool id. A Record rather than the
  * ternary chain it replaces: each provider adds a row instead of another
@@ -219,6 +244,7 @@ const DEMO_SEAM_OVERLAYS: Readonly<Record<string, () => object>> = {
   'codex-pty': codexPtyDemoSeams,
   'omp-sdk': ompSdkDemoSeams,
   'omp-pty': ompPtyDemoSeams,
+  'agy-pty': agyPtyDemoSeams,
 };
 
 /**
@@ -436,6 +462,10 @@ export class CliManagerFactory {
     // arrival; the provider toggle gates reachability anyway.
     this.registerPiPtyTool();
     this.registerPiSdkTool();
+
+    // Register Antigravity (agy) CLI runtimes.
+    this.registerAgyPtyTool();
+    this.registerAgySdkTool();
 
     // this.registerAiderTool();
     // this.registerContinueTool();
@@ -877,6 +907,105 @@ export class CliManagerFactory {
 
     this.registry.registerTool(piSdkDefinition, {
       priority: 26,
+      validateOnRegister: false,
+    });
+  }
+
+  private registerAgyPtyTool(): void {
+    const agyPtyManagerFactory: ManagerFactoryFunction = (
+      sessionManager: unknown,
+      logger?: Logger,
+      configManager?: ConfigManager,
+    ) => {
+      return new AgyPtyManager(
+        sessionManager as SessionManager,
+        logger,
+        configManager,
+      );
+    };
+
+    const agyPtyDefinition: CliToolDefinition = {
+      id: 'agy-pty',
+      name: 'Antigravity (PTY)',
+      description: 'Antigravity (agy) running as an interactive PTY quick-session runtime',
+      version: '1.0.0',
+      capabilities: {
+        supportsResume: true,
+        supportsMultipleModels: true,
+        supportsPermissions: false,
+        supportsFileOperations: true,
+        supportsGitIntegration: true,
+        supportsSystemPrompts: false,
+        supportsStructuredOutput: false,
+        outputFormats: [
+          CLI_OUTPUT_FORMATS.TEXT,
+        ],
+        supportedPanelTypes: ['claude'],
+      },
+      config: {
+        requiredEnvVars: [],
+        optionalEnvVars: [],
+        requiredConfigKeys: [],
+        optionalConfigKeys: [],
+        defaultExecutable: 'agy',
+        alternativeExecutables: ['agy'],
+        minimumVersion: undefined,
+      },
+      managerFactory: agyPtyManagerFactory,
+    };
+
+    this.registry.registerTool(agyPtyDefinition, {
+      priority: 27,
+      validateOnRegister: false,
+    });
+  }
+
+  private registerAgySdkTool(): void {
+    const agySdkManagerFactory: ManagerFactoryFunction = (
+      sessionManager: unknown,
+      logger?: Logger,
+      configManager?: ConfigManager,
+    ) => {
+      return new AgySdkManager(
+        sessionManager as SessionManager,
+        logger,
+        configManager,
+      );
+    };
+
+    const agySdkDefinition: CliToolDefinition = {
+      id: 'agy-sdk',
+      name: 'Antigravity',
+      description: 'Antigravity (agy) structured stream-json runtime (turn-spawn, --conversation resume)',
+      version: '1.0.0',
+      capabilities: {
+        supportsResume: true,
+        supportsMultipleModels: true,
+        supportsPermissions: false,
+        supportsFileOperations: true,
+        supportsGitIntegration: true,
+        supportsSystemPrompts: false,
+        supportsStructuredOutput: true,
+        outputFormats: [
+          CLI_OUTPUT_FORMATS.JSON,
+          CLI_OUTPUT_FORMATS.TEXT,
+        ],
+        supportedPanelTypes: ['claude'],
+      },
+      config: {
+        requiredEnvVars: [],
+        optionalEnvVars: [],
+        requiredConfigKeys: [],
+        optionalConfigKeys: [],
+        defaultExecutable: 'agy',
+        alternativeExecutables: ['agy'],
+        minimumVersion: undefined,
+      },
+      managerFactory: agySdkManagerFactory,
+    };
+
+    this.registry.registerTool(agySdkDefinition, {
+      priority: 28,
       validateOnRegister: false,
     });
   }

--- a/main/src/services/createQuickSessionCore.ts
+++ b/main/src/services/createQuickSessionCore.ts
@@ -306,6 +306,7 @@ export const QUICK_PROVIDER_SDK_RUNTIME: Readonly<Record<AgentProvider, SessionA
   codex: 'codex-sdk',
   omp: 'omp-sdk',
   pi: 'pi-sdk',
+  agy: 'agy-sdk',
 };
 
 /**

--- a/main/src/services/panelLane.ts
+++ b/main/src/services/panelLane.ts
@@ -58,6 +58,8 @@ export const ALL_PANEL_LANES = [
   'omp-pty',
   'pi-sdk',
   'pi-pty',
+  'agy-sdk',
+  'agy-pty',
 ] as const;
 
 export type PanelLane = (typeof ALL_PANEL_LANES)[number];
@@ -75,6 +77,7 @@ const PROVIDER_LANES: Readonly<
   codex: { sdk: 'codex-sdk', interactive: 'codex-pty' },
   omp: { sdk: 'omp-sdk', interactive: 'omp-pty' },
   pi: { sdk: 'pi-sdk', interactive: 'pi-pty' },
+  agy: { sdk: 'agy-sdk', interactive: 'agy-pty' },
 };
 
 /** The lanes served by a PTY manager — each provider's interactive lane. */
@@ -186,6 +189,8 @@ export function nonClaudeLaneOwner<M>(
     case 'omp-pty':
     case 'pi-sdk':
     case 'pi-pty':
+    case 'agy-sdk':
+    case 'agy-pty':
       return owners[lane];
     default:
       return undefined;

--- a/main/src/services/panels/agy/__tests__/agyModelCatalog.test.ts
+++ b/main/src/services/panels/agy/__tests__/agyModelCatalog.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { parseAgyModelsStdout } from '../agyModelCatalog';
+
+describe('parseAgyModelsStdout', () => {
+  it('parses tab-separated models and ignores progress headers', () => {
+    const raw = `Fetching available models...
+gemini-3.8-flash-high\tGemini 3.8 Flash (High)
+gemini-3.8-flash-medium\tGemini 3.8 Flash (Medium)
+claude-sonnet-4-6\tClaude Sonnet 4.6 (Thinking)
+`;
+    const models = parseAgyModelsStdout(raw);
+    expect(models).toEqual([
+      { id: 'gemini-3.8-flash-high', label: 'Gemini 3.8 Flash (High)' },
+      { id: 'gemini-3.8-flash-medium', label: 'Gemini 3.8 Flash (Medium)' },
+      { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6 (Thinking)' },
+    ]);
+  });
+
+  it('handles empty and whitespace lines gracefully', () => {
+    const raw = `
+\t
+gemini-3.7-flash-high\tGemini 3.7 Flash (High)
+
+`;
+    const models = parseAgyModelsStdout(raw);
+    expect(models).toEqual([
+      { id: 'gemini-3.7-flash-high', label: 'Gemini 3.7 Flash (High)' },
+    ]);
+  });
+});

--- a/main/src/services/panels/agy/__tests__/agyPtyManager.test.ts
+++ b/main/src/services/panels/agy/__tests__/agyPtyManager.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { AgyPtyManager } from '../agyPtyManager';
+import { evaluateAgyVersionPolicy } from '../agyVersions';
+
+class ExposedAgyPtyManager extends AgyPtyManager {
+  exposeBuildCommandArgs(o: {
+    prompt: string;
+    model?: string;
+    reasoningEffort?: string | null;
+    agentPermissionMode?: 'default' | 'dontAsk' | 'acceptEdits';
+    isContinue?: boolean;
+  }): string[] {
+    return this.buildCommandArgs({
+      panelId: 'p',
+      sessionId: 's',
+      worktreePath: '/tmp',
+      prompt: o.prompt,
+      model: o.model,
+      reasoningEffort: o.reasoningEffort,
+      agentPermissionMode: o.agentPermissionMode,
+      isContinue: o.isContinue,
+    });
+  }
+}
+
+function makeExposed(): ExposedAgyPtyManager {
+  return new ExposedAgyPtyManager(
+    { getDbSession: () => null } as never,
+    undefined,
+    { getDefaultAgentPermissionMode: () => 'default' } as never,
+  );
+}
+
+describe('Agy PTY spawn args', () => {
+  it('buildCommandArgs includes model, effort, continue, and interactive prompt', () => {
+    const args = makeExposed().exposeBuildCommandArgs({
+      prompt: 'do a thing',
+      model: 'gemini-3.8-flash-high',
+      reasoningEffort: 'high',
+      isContinue: true,
+    });
+    expect(args).toContain('--model');
+    expect(args).toContain('gemini-3.8-flash-high');
+    expect(args).toContain('--effort');
+    expect(args).toContain('high');
+    expect(args).toContain('--continue');
+    expect(args).toContain('-i=do a thing');
+  });
+
+  it('adds --dangerously-skip-permissions when agentPermissionMode is dontAsk', () => {
+    const args = makeExposed().exposeBuildCommandArgs({
+      prompt: 'hello',
+      agentPermissionMode: 'dontAsk',
+    });
+    expect(args).toContain('--dangerously-skip-permissions');
+  });
+
+  it('adds --mode accept-edits when agentPermissionMode is acceptEdits', () => {
+    const args = makeExposed().exposeBuildCommandArgs({
+      prompt: 'hello',
+      agentPermissionMode: 'acceptEdits',
+    });
+    expect(args).toContain('--mode');
+    expect(args).toContain('accept-edits');
+    expect(args).not.toContain('--dangerously-skip-permissions');
+  });
+
+  it('omits --dangerously-skip-permissions in default mode', () => {
+    const args = makeExposed().exposeBuildCommandArgs({
+      prompt: 'hello',
+      agentPermissionMode: 'default',
+    });
+    expect(args).not.toContain('--dangerously-skip-permissions');
+    expect(args).not.toContain('--mode');
+  });
+});
+
+describe('evaluateAgyVersionPolicy', () => {
+  it('floors below 1.0.0 with a reason and accepts the tested version', () => {
+    expect(evaluateAgyVersionPolicy('0.9.5')).toEqual({
+      ok: false,
+      aboveTested: false,
+      reason: 'below-floor',
+    });
+    expect(evaluateAgyVersionPolicy('1.1.25')).toEqual({
+      ok: true,
+      aboveTested: false,
+      reason: undefined,
+    });
+    expect(evaluateAgyVersionPolicy('1.2.0').aboveTested).toBe(true);
+  });
+
+  it('fails closed on unparseable version output', () => {
+    expect(evaluateAgyVersionPolicy('agy-unknown')).toMatchObject({ ok: false, reason: 'unparseable' });
+  });
+});

--- a/main/src/services/panels/agy/__tests__/agySdkManager.test.ts
+++ b/main/src/services/panels/agy/__tests__/agySdkManager.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type { ClaudeSpawnerOptions } from '../../../../orchestrator/runExecutor';
+import { AgySdkManager } from '../agySdkManager';
+
+const spawnMock = vi.hoisted(() =>
+  vi.fn((_exe: string, args: string[], _opts: unknown) => {
+    const emitter = new EventEmitter();
+    const stdout = new EventEmitter();
+    const stderr = new EventEmitter();
+    const child = Object.assign(emitter, {
+      stdin: {
+        write: vi.fn(),
+        end: vi.fn(),
+      },
+      stdout,
+      stderr,
+      killed: false,
+      kill: vi.fn(),
+    });
+
+    // Simulate agy output stream
+    queueMicrotask(() => {
+      stdout.emit(
+        'data',
+        Buffer.from(
+          JSON.stringify({
+            event: 'init',
+            conversation_id: 'conv-test-123',
+            init: { cwd: '/tmp', tools: ['view_file'] },
+          }) + '\n',
+        ),
+      );
+      stdout.emit(
+        'data',
+        Buffer.from(
+          JSON.stringify({
+            event: 'result',
+            result: {
+              conversation_id: 'conv-test-123',
+              status: 'SUCCESS',
+              response: 'Hello from Antigravity',
+              duration_seconds: 0.5,
+            },
+          }) + '\n',
+        ),
+      );
+      emitter.emit('close', 0);
+    });
+
+    return child;
+  }),
+);
+
+vi.mock('node:child_process', () => ({ spawn: spawnMock, exec: vi.fn() }));
+
+class TestableAgySdk extends AgySdkManager {
+  protected override getCliExecutablePath(): Promise<string> {
+    return Promise.resolve('/fake/agy');
+  }
+}
+
+function makeManager() {
+  return new TestableAgySdk(
+    { getDbSession: () => null } as never,
+    undefined,
+    { getDefaultAgentPermissionMode: () => 'default' } as never,
+  );
+}
+
+type SpawnCall = [string, string[], { env: Record<string, string | undefined> }];
+
+function lastSpawnCall(): SpawnCall {
+  const call = spawnMock.mock.calls.at(-1) as SpawnCall | undefined;
+  if (!call) throw new Error('spawn was never called');
+  return call;
+}
+
+describe('AgySdkManager turn spawning and conversation resumption', () => {
+  beforeEach(() => {
+    spawnMock.mockClear();
+  });
+
+  it('spawns agy with prompt, output format, model, and effort', async () => {
+    const mgr = makeManager();
+    const outcome = await mgr.spawnCliProcess({
+      panelId: 'panel-1',
+      sessionId: 'sess-1',
+      worktreePath: '/tmp/wt',
+      prompt: 'say hi',
+      model: 'gemini-3.8-flash-high',
+      reasoningEffort: 'high',
+      agentPermissionMode: 'dontAsk',
+    } satisfies ClaudeSpawnerOptions);
+
+    expect(outcome.resultText).toBe('Hello from Antigravity');
+
+    const [, args] = lastSpawnCall();
+    expect(args).toContain('-p');
+    expect(args).toContain('say hi');
+    expect(args).toContain('--output-format');
+    expect(args).toContain('stream-json');
+    expect(args).toContain('--model');
+    expect(args).toContain('gemini-3.8-flash-high');
+    expect(args).toContain('--effort');
+    expect(args).toContain('high');
+    expect(args).toContain('--dangerously-skip-permissions');
+  });
+
+  it('resumes with recorded conversationId on subsequent turns', async () => {
+    const mgr = makeManager();
+
+    // Turn 1
+    await mgr.spawnCliProcess({
+      panelId: 'panel-2',
+      sessionId: 'sess-2',
+      worktreePath: '/tmp/wt',
+      prompt: 'turn 1',
+    });
+    const [, argsTurn1] = lastSpawnCall();
+    expect(argsTurn1).not.toContain('--conversation');
+
+    // Turn 2: uses conv-test-123 recorded from turn 1's init event
+    await mgr.spawnCliProcess({
+      panelId: 'panel-2',
+      sessionId: 'sess-2',
+      worktreePath: '/tmp/wt',
+      prompt: 'turn 2',
+    });
+    const [, argsTurn2] = lastSpawnCall();
+    expect(argsTurn2).toContain('--conversation');
+    expect(argsTurn2).toContain('conv-test-123');
+  });
+});

--- a/main/src/services/panels/agy/agyAvailability.ts
+++ b/main/src/services/panels/agy/agyAvailability.ts
@@ -1,0 +1,39 @@
+import { findExecutableInPath, getShellPath } from '../../../utils/shellPath';
+import { probeCliVersion } from '../cli/cliVersionProbe';
+import { evaluateAgyVersionPolicy, AGY_MIN_SUPPORTED_VERSION, AGY_TESTED_VERSION } from './agyVersions';
+import type { ProviderDetectionResult } from '../../../../../shared/types/onboarding';
+
+/**
+ * Antigravity's onboarding/Settings availability probe.
+ *
+ * Side-effect free and UNCACHED, per the onboarding probe contract in
+ * `providerDetection.ts`.
+ */
+export async function detectAgyAvailability(
+  customPath?: string,
+): Promise<ProviderDetectionResult<'agy'>> {
+  const configuredPath = customPath?.trim();
+  const resolvedPath = configuredPath || findExecutableInPath('agy');
+  if (!resolvedPath) {
+    return { state: 'unavailable', binaryPath: null, version: null };
+  }
+
+  let rawVersion: string;
+  try {
+    const probe = await probeCliVersion(resolvedPath, { ...process.env, PATH: getShellPath() });
+    rawVersion = probe.version;
+  } catch {
+    return { state: 'unavailable', binaryPath: resolvedPath, version: null };
+  }
+
+  const verdict = evaluateAgyVersionPolicy(rawVersion);
+  if (!verdict.ok) {
+    return { state: 'unavailable', binaryPath: resolvedPath, version: rawVersion };
+  }
+  if (verdict.aboveTested) {
+    console.warn(
+      `[AGY] detected version ${rawVersion} is newer than the last version this integration was tested against (${AGY_TESTED_VERSION}, floor ${AGY_MIN_SUPPORTED_VERSION}); proceeding, but behavior beyond the tested version is unverified.`,
+    );
+  }
+  return { state: 'detected', binaryPath: resolvedPath, version: rawVersion };
+}

--- a/main/src/services/panels/agy/agyModelCatalog.ts
+++ b/main/src/services/panels/agy/agyModelCatalog.ts
@@ -1,0 +1,74 @@
+import { spawn } from 'node:child_process';
+import type { AgyModelOption, AgyModelCatalog } from '../../../../../shared/types/agentModels';
+import { DEFAULT_AGY_MODEL } from '../../../../../shared/types/agentModels';
+
+/**
+ * Antigravity's model catalog, discovered from the machine's own `agy models`.
+ *
+ * `agy models` outputs a tab-separated table of id and label, with an optional
+ * progress header line like "Fetching available models...":
+ *
+ *   gemini-3.8-flash-high\tGemini 3.8 Flash (High)
+ *   gemini-3.8-flash-medium\tGemini 3.8 Flash (Medium)
+ *   claude-sonnet-4-6\tClaude Sonnet 4.6 (Thinking)
+ */
+export function parseAgyModelsStdout(stdout: string): AgyModelOption[] {
+  const models: AgyModelOption[] = [];
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('Fetching')) continue;
+    const parts = trimmed.split('\t');
+    if (parts.length < 2) continue;
+    const [id, label] = parts;
+    if (!id || !label) continue;
+    models.push({ id: id.trim(), label: label.trim() });
+  }
+  return models;
+}
+
+export async function fetchAgyModelCatalog(
+  binaryPath: string,
+  timeoutMs = 15_000,
+): Promise<AgyModelCatalog> {
+  const { stdout, stderr } = await new Promise<{ stdout: string; stderr: string }>(
+    (resolve, reject) => {
+      const child = spawn(binaryPath, ['models'], {
+        env: { ...process.env },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let out = '';
+      let err = '';
+      const timer = setTimeout(() => {
+        child.kill('SIGKILL');
+        reject(new Error(`agy models timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      child.stdout.on('data', (chunk: Buffer) => {
+        out += chunk.toString('utf8');
+      });
+      child.stderr.on('data', (chunk: Buffer) => {
+        err += chunk.toString('utf8');
+      });
+      child.on('error', (e: Error) => {
+        clearTimeout(timer);
+        reject(e);
+      });
+      child.on('close', (code) => {
+        clearTimeout(timer);
+        if (code === 0) resolve({ stdout: out, stderr: err });
+        else reject(new Error(`agy models exited ${code}${err ? `: ${err.trim()}` : ''}`));
+      });
+    },
+  );
+
+  const models = parseAgyModelsStdout(stdout);
+
+  if (models.length === 0) {
+    const firstErr = stderr.trim().split('\n')[0];
+    throw new Error(`agy models returned no models${firstErr ? `: ${firstErr}` : ''}`);
+  }
+
+  return {
+    models,
+    defaultModel: DEFAULT_AGY_MODEL,
+  };
+}

--- a/main/src/services/panels/agy/agyPtyManager.ts
+++ b/main/src/services/panels/agy/agyPtyManager.ts
@@ -1,0 +1,345 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type * as pty from '@homebridge/node-pty-prebuilt-multiarch';
+import type { AgentProvider } from '../../../../../shared/types/agentRuntime';
+import type { ConversationMessage } from '../../../database/models';
+import type { PermissionMode } from '../../../../../shared/types/workflows';
+import { isPermissionMode } from '../../../../../shared/types/workflows';
+import { getShellPath, findExecutableInPath } from '../../../utils/shellPath';
+import { AbstractCliManager } from '../cli/AbstractCliManager';
+import { probeCliVersion, type CliVersionProbeResult } from '../cli/cliVersionProbe';
+import { evaluateAgyVersionPolicy, AGY_MIN_SUPPORTED_VERSION, AGY_TESTED_VERSION } from './agyVersions';
+
+interface AgyPtySpawnOptions {
+  panelId: string;
+  sessionId: string;
+  worktreePath: string;
+  prompt: string;
+  permissionMode?: 'approve' | 'ignore';
+  agentPermissionMode?: PermissionMode;
+  model?: string;
+  reasoningEffort?: string | null;
+  runId?: string;
+  isContinue?: boolean;
+  [key: string]: unknown;
+}
+
+interface AgyPtySpawnContext {
+  panelId: string;
+  sessionId: string;
+  runId: string;
+}
+
+const PTY_BACKLOG_CAP_BYTES = 200_000;
+
+export class AgyPtyManager extends AbstractCliManager {
+  private resolvedExecutablePath: string | null = null;
+  private readonly panelRunIds = new Map<string, string>();
+  private readonly ptyBacklog = new Map<string, string>();
+  private readonly ptySpawnContext = new AsyncLocalStorage<AgyPtySpawnContext>();
+
+  protected getCliToolName(): string {
+    return 'Antigravity';
+  }
+
+  /** Vendor for the provider-access guard (Settings → Integrations). */
+  protected getAgentProvider(): AgentProvider {
+    return 'agy';
+  }
+
+  protected async testCliAvailability(customPath?: string): Promise<{ available: boolean; error?: string; version?: string; path?: string }> {
+    const configuredPath = customPath?.trim();
+
+    getShellPath();
+    const resolvedPath = configuredPath || findExecutableInPath('agy');
+    if (!resolvedPath) {
+      this.resolvedExecutablePath = null;
+      return { available: false, error: 'agy executable not found in PATH' };
+    }
+
+    try {
+      const probe = await this.probeVersion(resolvedPath);
+      if (probe.usedNodeFallback) {
+        this.markNeedsNodeFallback();
+      }
+
+      const verdict = evaluateAgyVersionPolicy(probe.version);
+      if (!verdict.ok) {
+        this.resolvedExecutablePath = null;
+        const reason =
+          verdict.reason === 'below-floor'
+            ? `agy ${probe.version} is older than the minimum supported version ${AGY_MIN_SUPPORTED_VERSION}`
+            : `could not parse agy version output "${probe.version}"`;
+        return { available: false, error: reason, version: probe.version, path: resolvedPath };
+      }
+      if (verdict.aboveTested) {
+        this.logger?.warn(
+          `[AGY] detected version ${probe.version} is newer than the last version this integration was tested against (${AGY_TESTED_VERSION}); proceeding, but behavior beyond the tested version is unverified.`,
+        );
+      }
+
+      this.resolvedExecutablePath = resolvedPath;
+      return { available: true, version: probe.version, path: resolvedPath };
+    } catch (err) {
+      this.resolvedExecutablePath = null;
+      return {
+        available: false,
+        error: `Failed to run "${resolvedPath} --version": ${err instanceof Error ? err.message : String(err)}`,
+        path: resolvedPath,
+      };
+    }
+  }
+
+  protected async probeVersion(executablePath: string): Promise<CliVersionProbeResult> {
+    return probeCliVersion(executablePath, await this.getSystemEnvironment());
+  }
+
+  protected async getCliExecutablePath(): Promise<string> {
+    if (this.resolvedExecutablePath) {
+      return this.resolvedExecutablePath;
+    }
+    const availability = await this.testCliAvailability();
+    if (!availability.available || !availability.path) {
+      throw new Error(`Antigravity CLI not available: ${availability.error ?? 'unknown error'}`);
+    }
+    return availability.path;
+  }
+
+  protected buildCommandArgs(options: AgyPtySpawnOptions): string[] {
+    const args: string[] = [];
+
+    if (options.model && options.model.trim().length > 0) {
+      args.push('--model', options.model.trim());
+    }
+
+    if (options.reasoningEffort) {
+      args.push('--effort', String(options.reasoningEffort));
+    }
+
+    if (options.agentPermissionMode === 'dontAsk') {
+      args.push('--dangerously-skip-permissions');
+    } else if (options.agentPermissionMode === 'acceptEdits') {
+      args.push('--mode', 'accept-edits');
+    }
+
+    if (options.isContinue) {
+      args.push('--continue');
+    }
+
+    const prompt = options.prompt?.trim();
+    if (prompt && prompt.length > 0) {
+      args.push(`-i=${prompt}`);
+    } else {
+      args.push('-i');
+    }
+
+    return args;
+  }
+
+  protected parseCliOutput(data: string, panelId: string, sessionId: string): Array<{ panelId: string; sessionId: string; type: 'json' | 'stdout' | 'stderr'; data: unknown; timestamp: Date }> {
+    return [{
+      panelId,
+      sessionId,
+      type: 'stdout',
+      data,
+      timestamp: new Date(),
+    }];
+  }
+
+  protected async initializeCliEnvironment(_options: AgyPtySpawnOptions): Promise<{ [key: string]: string }> {
+    return {};
+  }
+
+  protected async getCliEnvironment(_options: AgyPtySpawnOptions): Promise<{ [key: string]: string }> {
+    return {};
+  }
+
+  protected async cleanupCliResources(sessionId: string): Promise<void> {
+    for (const [panelId, process] of this.processes.entries()) {
+      if (process.sessionId !== sessionId) continue;
+      const runId = this.panelRunIds.get(panelId);
+      this.panelRunIds.delete(panelId);
+      if (runId) {
+        this.ptyBacklog.delete(runId);
+      }
+    }
+  }
+
+  override async spawnCliProcess(options: AgyPtySpawnOptions): Promise<void> {
+    const runId = options.runId ?? options.panelId;
+    this.panelRunIds.set(options.panelId, runId);
+    try {
+      await this.runWithPtySpawnContext(
+        { panelId: options.panelId, sessionId: options.sessionId, runId },
+        () => super.spawnCliProcess({ ...options, runId }),
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.emit('pty-output', {
+        panelId: options.panelId,
+        sessionId: options.sessionId,
+        runId,
+        type: 'pty',
+        data: `\r\n\x1b[31mAntigravity failed to start: ${message}\x1b[0m\r\n`,
+        timestamp: new Date(),
+      });
+      this.emit('exit', {
+        panelId: options.panelId,
+        sessionId: options.sessionId,
+        exitCode: 1,
+        signal: null,
+      });
+      this.panelRunIds.delete(options.panelId);
+      this.ptyBacklog.delete(runId);
+      throw err;
+    }
+  }
+
+  protected override async spawnPtyProcess(command: string, args: string[], cwd: string, env: { [key: string]: string }): Promise<pty.IPty> {
+    const ptyProcess = await super.spawnPtyProcess(command, args, cwd, env);
+    const context = this.ptySpawnContext.getStore();
+    if (context) {
+      ptyProcess.onData((data: string) => {
+        this.recordPtyBacklog(context.runId, data);
+        this.emit('pty-output', {
+          panelId: context.panelId,
+          sessionId: context.sessionId,
+          runId: context.runId,
+          type: 'pty',
+          data,
+          timestamp: new Date(),
+        });
+      });
+    }
+    return ptyProcess;
+  }
+
+  async startPanel(
+    panelId: string,
+    sessionId: string,
+    worktreePath: string,
+    prompt: string,
+    permissionMode?: 'approve' | 'ignore',
+    model?: string,
+    runId?: string,
+  ): Promise<void> {
+    await this.spawnCliProcess({
+      panelId,
+      sessionId,
+      worktreePath,
+      prompt,
+      permissionMode,
+      agentPermissionMode: this.resolveSessionAgentPermissionMode(sessionId, permissionMode),
+      model,
+      runId,
+    });
+  }
+
+  async continuePanel(
+    panelId: string,
+    sessionId: string,
+    worktreePath: string,
+    prompt: string,
+    _conversationHistory: ConversationMessage[],
+    permissionMode?: 'approve' | 'ignore',
+    model?: string,
+  ): Promise<void> {
+    await this.killProcess(panelId);
+    await this.spawnCliProcess({
+      panelId,
+      sessionId,
+      worktreePath,
+      prompt,
+      permissionMode,
+      agentPermissionMode: this.resolveSessionAgentPermissionMode(sessionId, permissionMode),
+      model,
+      isContinue: true,
+    });
+  }
+
+  relayUserTurn(panelId: string, input: string): void {
+    this.sendInput(panelId, `${input}\r`);
+  }
+
+  relayRawInput(panelId: string, input: string): void {
+    this.sendInput(panelId, input);
+  }
+
+  resizePanel(panelId: string, cols: number, rows: number): void {
+    const process = this.getProcess(panelId);
+    if (!process) return;
+    process.process.resize(cols, rows);
+  }
+
+  getPtyBacklog(runId: string): string {
+    return this.ptyBacklog.get(runId) ?? '';
+  }
+
+  async stopPanel(panelId: string): Promise<void> {
+    const runId = this.panelRunIds.get(panelId);
+    await this.killProcess(panelId);
+    this.panelRunIds.delete(panelId);
+    if (runId) {
+      this.ptyBacklog.delete(runId);
+    }
+  }
+
+  async restartPanelWithHistory(
+    panelId: string,
+    sessionId: string,
+    worktreePath: string,
+    initialPrompt: string,
+    _conversationHistory: ConversationMessage[],
+  ): Promise<void> {
+    await this.killProcess(panelId);
+    const permissionMode = this.sessionManager.getDbSession(sessionId)?.permission_mode;
+    await this.startPanel(panelId, sessionId, worktreePath, initialPrompt, permissionMode);
+  }
+
+  protected getCliNotAvailableMessage(error?: string): string {
+    const interpreterAdvice = this.missingInterpreterAdvice(error);
+    if (interpreterAdvice) {
+      return [`Error: ${error}`, '', interpreterAdvice].join('\n');
+    }
+    if (error && /older than the minimum supported version/.test(error)) {
+      return [
+        `Error: ${error}`,
+        '',
+        'Antigravity CLI is installed but too old for this integration. Update it with:',
+        '  agy update',
+      ].join('\n');
+    }
+    return [
+      `Error: ${error}`,
+      '',
+      'Antigravity CLI (agy) is not available.',
+      '',
+      'Install agy and authenticate in your terminal, then verify `agy --version` works.',
+    ].join('\n');
+  }
+
+  private resolveSessionAgentPermissionMode(
+    sessionId: string,
+    legacyPermissionMode?: 'approve' | 'ignore',
+  ): PermissionMode {
+    if (legacyPermissionMode === 'ignore') return 'dontAsk';
+    const stored = this.sessionManager.getDbSession(sessionId)?.agent_permission_mode;
+    if (isPermissionMode(stored)) return stored;
+    return this.configManager?.getDefaultAgentPermissionMode() ?? 'default';
+  }
+
+  private recordPtyBacklog(runId: string, data: string): void {
+    const next = (this.ptyBacklog.get(runId) ?? '') + data;
+    this.ptyBacklog.set(
+      runId,
+      next.length > PTY_BACKLOG_CAP_BYTES ? next.slice(-PTY_BACKLOG_CAP_BYTES) : next,
+    );
+  }
+
+  protected runWithPtySpawnContext<T>(context: AgyPtySpawnContext, operation: () => T): T {
+    return this.ptySpawnContext.run(context, operation);
+  }
+
+  protected getActivePtySpawnContext(): AgyPtySpawnContext | undefined {
+    return this.ptySpawnContext.getStore();
+  }
+}

--- a/main/src/services/panels/agy/agySdkManager.ts
+++ b/main/src/services/panels/agy/agySdkManager.ts
@@ -1,0 +1,505 @@
+import { spawn, type ChildProcess, type ChildProcessByStdio } from 'node:child_process';
+import type { Writable, Readable } from 'node:stream';
+import { randomUUID } from 'node:crypto';
+import type { AgentProvider } from '../../../../../shared/types/agentRuntime';
+import type { ConversationMessage } from '../../../database/models';
+import type { PermissionMode } from '../../../../../shared/types/workflows';
+import { isPermissionMode } from '../../../../../shared/types/workflows';
+import type { CliSpawnOutcome } from '../../../../../shared/types/cliPanels';
+import type { ClaudeSpawnerOptions } from '../../../orchestrator/runExecutor';
+import { getShellPath, findExecutableInPath } from '../../../utils/shellPath';
+import { AbstractCliManager } from '../cli/AbstractCliManager';
+import { probeCliVersion, type CliVersionProbeResult } from '../cli/cliVersionProbe';
+import { evaluateAgyVersionPolicy, AGY_MIN_SUPPORTED_VERSION, AGY_TESTED_VERSION } from './agyVersions';
+
+interface AgyTurnState {
+  conversationId: string | null;
+  model?: string;
+  effort?: string;
+  agentPermissionMode?: PermissionMode;
+  cwd: string;
+  child: ChildProcess | null;
+}
+
+interface AgyStreamEvent {
+  event: string;
+  conversation_id?: string;
+  init?: {
+    cwd?: string;
+    tools?: string[];
+    permission_mode?: string;
+  };
+  step_update?: {
+    conversation_id?: string;
+    step_index?: number;
+    state?: string;
+    step_type?: string;
+    text_delta?: string;
+    duration_seconds?: number;
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      thinking_tokens?: number;
+      cache_read_tokens?: number;
+      total_tokens?: number;
+    };
+  };
+  result?: {
+    conversation_id?: string;
+    status?: string;
+    response?: string;
+    duration_seconds?: number;
+    num_turns?: number;
+    denied_actions?: unknown[];
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      thinking_tokens?: number;
+      cache_read_tokens?: number;
+      total_tokens?: number;
+    };
+  };
+}
+
+/**
+ * AgySdkManager — structured Antigravity lane.
+ *
+ * Spawns `agy -p <prompt> --output-format stream-json [--conversation <id>]`
+ * child per turn. First turn obtains conversation_id from the stream, and follow-up
+ * turns resume by supplying `--conversation <id>`.
+ */
+export class AgySdkManager extends AbstractCliManager {
+  private static readonly panelConversationIds = new Map<string, string>();
+  private resolvedExecutablePath: string | null = null;
+  private readonly turns = new Map<string, AgyTurnState>();
+  private readonly lastResultText = new Map<string, string>();
+
+  protected getCliToolName(): string {
+    return 'Antigravity';
+  }
+
+  protected getAgentProvider(): AgentProvider {
+    return 'agy';
+  }
+
+  protected async testCliAvailability(customPath?: string): Promise<{ available: boolean; error?: string; version?: string; path?: string }> {
+    const configuredPath = customPath?.trim();
+
+    getShellPath();
+    const resolvedPath = configuredPath || findExecutableInPath('agy');
+    if (!resolvedPath) {
+      this.resolvedExecutablePath = null;
+      return { available: false, error: 'agy executable not found in PATH' };
+    }
+
+    try {
+      const probe = await this.probeVersion(resolvedPath);
+      if (probe.usedNodeFallback) {
+        this.markNeedsNodeFallback();
+      }
+      const verdict = evaluateAgyVersionPolicy(probe.version);
+      if (!verdict.ok) {
+        this.resolvedExecutablePath = null;
+        return {
+          available: false,
+          error:
+            verdict.reason === 'below-floor'
+              ? `agy ${probe.version} is older than the minimum supported version ${AGY_MIN_SUPPORTED_VERSION}`
+              : `could not parse agy version output "${probe.version}"`,
+          version: probe.version,
+          path: resolvedPath,
+        };
+      }
+      if (verdict.aboveTested) {
+        this.logger?.warn(
+          `[AGY] detected version ${probe.version} is newer than the last tested version (${AGY_TESTED_VERSION}); proceeding unverified.`,
+        );
+      }
+      this.resolvedExecutablePath = resolvedPath;
+      return { available: true, version: probe.version, path: resolvedPath };
+    } catch (err) {
+      this.resolvedExecutablePath = null;
+      return {
+        available: false,
+        error: `Failed to run "${resolvedPath} --version": ${err instanceof Error ? err.message : String(err)}`,
+        path: resolvedPath,
+      };
+    }
+  }
+
+  protected async probeVersion(executablePath: string): Promise<CliVersionProbeResult> {
+    return probeCliVersion(executablePath, await this.getSystemEnvironment());
+  }
+
+  protected async getCliExecutablePath(): Promise<string> {
+    if (this.resolvedExecutablePath) {
+      return this.resolvedExecutablePath;
+    }
+    const availability = await this.testCliAvailability();
+    if (!availability.available || !availability.path) {
+      throw new Error(`Antigravity CLI not available: ${availability.error ?? 'unknown error'}`);
+    }
+    return availability.path;
+  }
+
+  async startPanel(
+    panelId: string,
+    sessionId: string,
+    worktreePath: string,
+    prompt: string,
+    permissionMode?: 'approve' | 'ignore',
+    model?: string,
+    runId?: string,
+  ): Promise<void> {
+    this.turns.set(panelId, {
+      conversationId: AgySdkManager.panelConversationIds.get(panelId) ?? null,
+      model,
+      cwd: worktreePath,
+      child: null,
+      agentPermissionMode: this.resolveSessionAgentPermissionMode(sessionId, permissionMode),
+    });
+    await this.runTurn(panelId, sessionId, worktreePath, prompt, runId);
+  }
+
+  async continuePanel(
+    panelId: string,
+    sessionId: string,
+    worktreePath: string,
+    prompt: string,
+    _conversationHistory: ConversationMessage[],
+    permissionMode?: 'approve' | 'ignore',
+    model?: string,
+  ): Promise<void> {
+    let state = this.turns.get(panelId);
+    if (!state) {
+      state = {
+        conversationId: AgySdkManager.panelConversationIds.get(panelId) ?? null,
+        cwd: worktreePath,
+        child: null,
+      };
+      this.turns.set(panelId, state);
+    }
+    state.agentPermissionMode = this.resolveSessionAgentPermissionMode(sessionId, permissionMode);
+    if (model && model.trim().length > 0) state.model = model;
+    await this.runTurn(panelId, sessionId, worktreePath, prompt, undefined);
+  }
+
+  async stopPanel(panelId: string): Promise<void> {
+    const state = this.turns.get(panelId);
+    if (state?.child && !state.child.killed) {
+      state.child.kill('SIGTERM');
+    }
+    if (state) state.child = null;
+    this.lastResultText.delete(panelId);
+  }
+
+  async restartPanelWithHistory(
+    panelId: string,
+    sessionId: string,
+    worktreePath: string,
+    initialPrompt: string,
+    _conversationHistory: ConversationMessage[],
+  ): Promise<void> {
+    const prior = this.turns.get(panelId);
+    await this.stopPanel(panelId);
+    this.turns.set(panelId, {
+      conversationId: null, // Fresh conversation on restart
+      model: prior?.model,
+      effort: prior?.effort,
+      cwd: worktreePath,
+      child: null,
+      agentPermissionMode: prior?.agentPermissionMode ?? 'default',
+    });
+    await this.runTurn(panelId, sessionId, worktreePath, initialPrompt, undefined);
+  }
+
+  private async runTurn(
+    panelId: string,
+    sessionId: string,
+    worktreePath: string,
+    prompt: string,
+    runId?: string,
+  ): Promise<void> {
+    const state = this.turns.get(panelId);
+    if (!state) throw new Error(`[AGY] no turn state for panel ${panelId}`);
+
+    const executable = await this.getCliExecutablePath();
+    const args: string[] = [
+      '-p', prompt,
+      '--output-format', 'stream-json',
+      '--print-timeout', '0',
+    ];
+
+    if (state.conversationId) {
+      args.push('--conversation', state.conversationId);
+    }
+
+    if (state.model && state.model.trim().length > 0) {
+      args.push('--model', state.model.trim());
+    }
+
+    if (state.effort && state.effort.trim().length > 0) {
+      args.push('--effort', state.effort.trim());
+    }
+
+    if (state.agentPermissionMode === 'dontAsk') {
+      args.push('--dangerously-skip-permissions');
+    } else if (state.agentPermissionMode === 'acceptEdits') {
+      args.push('--mode', 'accept-edits');
+    }
+
+    const effRunId = runId ?? panelId;
+    await new Promise<void>((resolve) => {
+      let buffer = '';
+      let sawResult = false;
+
+      const child: ChildProcessByStdio<Writable, Readable, Readable> = spawn(
+        executable,
+        args,
+        {
+          cwd: worktreePath,
+          env: {
+            ...process.env,
+            PATH: getShellPath(),
+          },
+          stdio: ['pipe', 'pipe', 'pipe'],
+        },
+      );
+      state.child = child;
+
+      let settled = false;
+      const finish = (exitCode: number) => {
+        if (settled) return;
+        settled = true;
+        state.child = null;
+        if (exitCode !== 0) {
+          this.emit('output', {
+            panelId,
+            sessionId,
+            type: 'json',
+            data: { type: 'system', subtype: 'result', is_error: true },
+            timestamp: new Date(),
+          });
+        }
+        this.emit('turn-end', { panelId, sessionId, runId: effRunId });
+        this.emit('exit', { panelId, sessionId, exitCode, signal: null });
+        resolve();
+      };
+
+      child.stdout.on('data', (chunk: Buffer) => {
+        buffer += chunk.toString('utf8');
+        let idx: number;
+        while ((idx = buffer.indexOf('\n')) >= 0) {
+          const line = buffer.slice(0, idx).trim();
+          buffer = buffer.slice(idx + 1);
+          if (!line) continue;
+          if (this.handleEventLine(line, panelId, sessionId, state)) {
+            sawResult = true;
+          }
+        }
+      });
+
+      child.stderr.on('data', (chunk: Buffer) => {
+        this.emit('output', {
+          panelId,
+          sessionId,
+          type: 'stderr',
+          data: chunk.toString('utf8'),
+          timestamp: new Date(),
+        });
+      });
+
+      child.on('error', (e: Error) => {
+        this.emit('output', {
+          panelId,
+          sessionId,
+          type: 'stdout',
+          data: `\r\n\x1b[31mAntigravity failed to start: ${e.message}\x1b[0m\r\n`,
+          timestamp: new Date(),
+        });
+        finish(1);
+      });
+
+      child.on('close', (code) => {
+        const rest = buffer.trim();
+        buffer = '';
+        if (rest && this.handleEventLine(rest, panelId, sessionId, state)) {
+          sawResult = true;
+        }
+        if (code === 0 && !sawResult) {
+          this.logger?.warn(`[AGY] turn for panel ${panelId} exited 0 without result; synthesizing result`);
+          this.emit('output', {
+            panelId,
+            sessionId,
+            type: 'json',
+            data: { type: 'system', subtype: 'result', is_error: false },
+            timestamp: new Date(),
+          });
+        }
+        finish(code ?? 1);
+      });
+    });
+  }
+
+  private handleEventLine(
+    line: string,
+    panelId: string,
+    sessionId: string,
+    state: AgyTurnState,
+  ): boolean {
+    let evt: AgyStreamEvent;
+    try {
+      evt = JSON.parse(line) as AgyStreamEvent;
+    } catch {
+      return false;
+    }
+
+    if (evt.event === 'init' && evt.conversation_id) {
+      state.conversationId = evt.conversation_id;
+      AgySdkManager.panelConversationIds.set(panelId, evt.conversation_id);
+      this.emit('output', {
+        panelId,
+        sessionId,
+        type: 'json',
+        data: {
+          type: 'system',
+          subtype: 'init',
+          session_id: sessionId,
+          external_session_id: state.conversationId,
+        },
+        timestamp: new Date(),
+      });
+      return false;
+    }
+
+    if (evt.event === 'result' && evt.result) {
+      let response = evt.result.response ?? '';
+      if (evt.result.conversation_id) {
+        state.conversationId = evt.result.conversation_id;
+        AgySdkManager.panelConversationIds.set(panelId, evt.result.conversation_id);
+      }
+      const hasDeniedActions =
+        Array.isArray(evt.result.denied_actions) && evt.result.denied_actions.length > 0;
+      if (hasDeniedActions && !response.trim()) {
+        response = '[Antigravity] Action was denied by permission policy.';
+      }
+      this.lastResultText.set(panelId, response);
+
+      if (response.length > 0) {
+        this.emit('output', {
+          panelId,
+          sessionId,
+          type: 'json',
+          data: {
+            type: 'assistant',
+            message: {
+              id: `agy-${randomUUID()}`,
+              model: state.model ?? 'agy',
+              role: 'assistant',
+              content: [{ type: 'text', text: response }],
+            },
+            session_id: sessionId,
+            external_session_id: state.conversationId,
+          },
+          timestamp: new Date(),
+        });
+      }
+
+      const isError =
+        evt.result.status !== 'SUCCESS' ||
+        (hasDeniedActions && !evt.result.response?.trim());
+      this.emit('output', {
+        panelId,
+        sessionId,
+        type: 'json',
+        data: {
+          type: 'system',
+          subtype: 'result',
+          is_error: isError,
+          session_id: sessionId,
+          external_session_id: state.conversationId,
+        },
+        timestamp: new Date(),
+      });
+      return true;
+    }
+
+    return false;
+  }
+
+  override async spawnCliProcess(options: ClaudeSpawnerOptions): Promise<CliSpawnOutcome> {
+    this.assertProviderEnabled(options);
+    const panelId = options.spawnKey ?? options.panelId;
+    const sessionId = options.sessionId ?? panelId;
+    let state = this.turns.get(panelId);
+    if (!state) {
+      state = {
+        conversationId:
+          options.resumeSessionId ??
+          AgySdkManager.panelConversationIds.get(panelId) ??
+          null,
+        model: typeof options.model === 'string' ? options.model : undefined,
+        effort: typeof options.reasoningEffort === 'string' ? options.reasoningEffort : undefined,
+        cwd: options.worktreePath ?? process.cwd(),
+        child: null,
+        agentPermissionMode: 'default',
+      };
+      this.turns.set(panelId, state);
+    } else {
+      if (typeof options.model === 'string') state.model = options.model;
+      if (typeof options.reasoningEffort === 'string') state.effort = options.reasoningEffort;
+      if (options.worktreePath) state.cwd = options.worktreePath;
+      if (options.resumeSessionId && !state.conversationId) {
+        state.conversationId = options.resumeSessionId;
+      }
+    }
+
+    const runMode = options.agentPermissionMode;
+    state.agentPermissionMode = isPermissionMode(runMode) ? runMode : 'default';
+
+    if (state.child && !state.child.killed) {
+      throw new Error(`[AGY] a turn is already running for panel ${panelId}`);
+    }
+    await this.runTurn(panelId, sessionId, state.cwd, options.prompt ?? '', options.runId);
+    const resultText = this.lastResultText.get(panelId) ?? null;
+    this.lastResultText.delete(panelId);
+    return { resultText };
+  }
+
+  override isPanelRunning(panelId: string): boolean {
+    const child = this.turns.get(panelId)?.child;
+    return child !== null && child !== undefined && !child.killed;
+  }
+
+  private resolveSessionAgentPermissionMode(
+    sessionId: string,
+    legacyPermissionMode?: 'approve' | 'ignore',
+  ): PermissionMode {
+    if (legacyPermissionMode === 'ignore') return 'dontAsk';
+    const stored = this.sessionManager.getDbSession(sessionId)?.agent_permission_mode;
+    if (isPermissionMode(stored)) return stored;
+    return this.configManager?.getDefaultAgentPermissionMode() ?? 'default';
+  }
+
+  // ── AbstractCliManager abstract members ────────────────────────────────
+  protected buildCommandArgs(_options: { prompt: string; model?: string }): string[] {
+    throw new Error('[AGY] sdk lane does not use buildCommandArgs; turns go through spawnCliProcess/runTurn');
+  }
+
+  protected parseCliOutput(data: string, panelId: string, sessionId: string): Array<{ panelId: string; sessionId: string; type: 'json' | 'stdout' | 'stderr'; data: unknown; timestamp: Date }> {
+    return [{ panelId, sessionId, type: 'stdout', data, timestamp: new Date() }];
+  }
+
+  protected async initializeCliEnvironment(_options: unknown): Promise<{ [key: string]: string }> {
+    return {};
+  }
+
+  protected async getCliEnvironment(_options: unknown): Promise<{ [key: string]: string }> {
+    return {};
+  }
+
+  protected async cleanupCliResources(sessionId: string): Promise<void> {
+    this.turns.delete(sessionId);
+    this.lastResultText.delete(sessionId);
+  }
+}

--- a/main/src/services/panels/agy/agyVersions.ts
+++ b/main/src/services/panels/agy/agyVersions.ts
@@ -1,0 +1,45 @@
+/**
+ * Version discipline for the Antigravity CLI (`agy`).
+ *
+ * Same policy shape as piVersions.ts / ompVersions.ts:
+ *   - AGY_MIN_SUPPORTED_VERSION — hard floor; below it probes report 'unavailable'
+ *   - AGY_TESTED_VERSION — newest verified version; newer binaries are accepted with warning
+ */
+
+/** Hard floor: a probed agy binary below this version is refused. */
+export const AGY_MIN_SUPPORTED_VERSION = '1.0.0';
+
+/** Newest version verified against; soft ceiling only — never refuses. */
+export const AGY_TESTED_VERSION = '1.1.25';
+
+export interface AgyVersionVerdict {
+  ok: boolean;
+  aboveTested: boolean;
+  /** Why a binary failed: below the floor, or unparseable `--version` output. */
+  reason?: 'below-floor' | 'unparseable';
+}
+
+/**
+ * Compare a probed semver string against the floor/tested pair. Non-semver
+ * output fails closed (`ok: false`) so a broken `--version` never reads as a
+ * usable binary.
+ */
+export function evaluateAgyVersionPolicy(rawVersion: string): AgyVersionVerdict {
+  const match = rawVersion.trim().match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return { ok: false, aboveTested: false, reason: 'unparseable' };
+  const toTuple = (v: string): [number, number, number] =>
+    v.split('.').map(Number) as [number, number, number];
+  const cmp = (a: [number, number, number], b: [number, number, number]): number => {
+    for (let i = 0; i < 3; i++) {
+      if (a[i] !== b[i]) return a[i] - b[i];
+    }
+    return 0;
+  };
+  const parsed = toTuple(match[0]);
+  const belowFloor = cmp(parsed, toTuple(AGY_MIN_SUPPORTED_VERSION)) < 0;
+  return {
+    ok: !belowFloor,
+    aboveTested: cmp(parsed, toTuple(AGY_TESTED_VERSION)) > 0,
+    reason: belowFloor ? 'below-floor' : undefined,
+  };
+}

--- a/main/src/services/substrateDispatchFacade.ts
+++ b/main/src/services/substrateDispatchFacade.ts
@@ -166,6 +166,8 @@ const LANE_WIRING: Readonly<Record<PanelLane, LaneWiring>> = {
   // mounts afterwards.
   'pi-sdk': { output: true, spawned: true, turnEnd: false, retainBacklogOnFailedExit: false },
   'pi-pty': { output: true, spawned: true, turnEnd: true, retainBacklogOnFailedExit: true },
+  'agy-sdk': { output: true, spawned: true, turnEnd: false, retainBacklogOnFailedExit: false },
+  'agy-pty': { output: true, spawned: true, turnEnd: true, retainBacklogOnFailedExit: true },
 };
 
 /**

--- a/shared/types/__tests__/agentModels.test.ts
+++ b/shared/types/__tests__/agentModels.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isAgyModelFamily,
+  normalizeAgentModelSelection,
+} from '../agentModels';
+
+describe('agentModels', () => {
+  it('identifies agy model family including Gemini, Claude, and GPT-OSS models', () => {
+    expect(isAgyModelFamily('gemini-3.8-flash-high')).toBe(true);
+    expect(isAgyModelFamily('gemini-3.7-flash-medium')).toBe(true);
+    expect(isAgyModelFamily('claude-sonnet-4-6')).toBe(true);
+    expect(isAgyModelFamily('claude-opus-4-6-thinking')).toBe(true);
+    expect(isAgyModelFamily('gpt-oss-120b-medium')).toBe(true);
+    expect(isAgyModelFamily('unknown-model')).toBe(false);
+  });
+
+  it('normalizes agy model selection properly', () => {
+    // Retains agy Gemini models
+    expect(normalizeAgentModelSelection('agy', 'gemini-3.8-flash-high')).toBe('gemini-3.8-flash-high');
+
+    // Retains agy-supported Claude models when selected for agy
+    expect(normalizeAgentModelSelection('agy', 'claude-sonnet-4-6')).toBe('claude-sonnet-4-6');
+    expect(normalizeAgentModelSelection('agy', 'claude-opus-4-6-thinking')).toBe('claude-opus-4-6-thinking');
+
+    // Drops foreign models that belong to other providers and aren't supported on agy
+    expect(normalizeAgentModelSelection('agy', 'claude-3-5-sonnet-20241022')).toBeUndefined();
+    expect(normalizeAgentModelSelection('agy', 'gpt-4o')).toBeUndefined();
+
+    // When provider is Claude, drops Gemini models
+    expect(normalizeAgentModelSelection('claude', 'gemini-3.8-flash-high')).toBeUndefined();
+
+    // Preserves Claude models for Claude
+    expect(normalizeAgentModelSelection('claude', 'claude-sonnet-4-6')).toBe('claude-sonnet-4-6');
+    expect(normalizeAgentModelSelection('claude', 'sonnet')).toBe('sonnet');
+  });
+});

--- a/shared/types/agentCapabilities.ts
+++ b/shared/types/agentCapabilities.ts
@@ -95,6 +95,8 @@ export const RUNTIME_CAPABILITIES: Readonly<Record<AgentRuntime, AgentRuntimeCap
   // side learns a flag for it. Fast mode remains the Claude-only opt-in.
   'pi-sdk': { selectableInPickers: true, supportsEffort: false, supportsFastMode: false },
   'pi-pty': { selectableInPickers: true, supportsEffort: false, supportsFastMode: false },
+  'agy-sdk': { selectableInPickers: true, supportsEffort: true, supportsFastMode: false },
+  'agy-pty': { selectableInPickers: true, supportsEffort: false, supportsFastMode: false },
  };
 
 /**

--- a/shared/types/agentModels.ts
+++ b/shared/types/agentModels.ts
@@ -90,6 +90,17 @@ export interface PiModelCatalog {
   models: OmpModelOption[];
 }
 
+/** Renderer-safe projection of one entry returned by `agy models`. */
+export interface AgyModelOption {
+  id: string;
+  label: string;
+}
+
+export interface AgyModelCatalog {
+  models: AgyModelOption[];
+  defaultModel: string | null;
+}
+
 /**
  * Which catalog shape each provider advertises.
  *
@@ -106,6 +117,7 @@ export interface ProviderModelCatalogs {
   codex: CodexModelCatalog;
   omp: OmpModelCatalog;
   pi: PiModelCatalog;
+  agy: AgyModelCatalog;
 }
 
 /**
@@ -175,6 +187,18 @@ export function isCodexModelSelection(model: string): boolean {
  */
 export const DEFAULT_CODEX_MODEL = 'auto';
 
+export function isAgyModelFamily(model: string): boolean {
+  const normalized = model.toLowerCase().trim();
+  return (
+    normalized.startsWith('gemini-') ||
+    normalized.startsWith('gpt-oss-') ||
+    normalized === 'claude-sonnet-4-6' ||
+    normalized === 'claude-opus-4-6-thinking'
+  );
+}
+
+export const DEFAULT_AGY_MODEL = 'gemini-3.8-flash-high';
+
 /**
  * Which provider owns a model id, one predicate per provider. Adding a provider
  * is one entry here (the Record is exhaustive over `AgentProvider`, so the
@@ -193,6 +217,7 @@ export const AGENT_MODEL_FAMILY_PREDICATES: Readonly<
   // patterns — which is exactly OMP's slash rule, so the predicate is shared.
   // If pi ever admits bare ids this becomes its own function.
   pi: isOmpModelFamily,
+  agy: isAgyModelFamily,
 };
 /**
  * Families that SHARE a shape are non-competing: omp and pi both use
@@ -233,6 +258,11 @@ export function normalizeAgentModelSelection(
 
   const key = value.toLowerCase();
   if (key === 'default') return undefined;
+
+  // If this provider's own family explicitly claims this model, keep it!
+  if (AGENT_MODEL_FAMILY_PREDICATES[provider](key)) {
+    return value;
+  }
 
   for (const other of AGENT_PROVIDERS) {
     if (other === provider) continue;

--- a/shared/types/agentRuntime.ts
+++ b/shared/types/agentRuntime.ts
@@ -19,7 +19,7 @@ import type { CliSubstrate } from './substrate';
  * because `z.enum` needs a non-empty readonly tuple of string literals; the
  * `AgentProvider` union is derived FROM it so the two cannot drift.
  */
-export const AGENT_PROVIDERS = ['claude', 'codex', 'omp', 'pi'] as const;
+export const AGENT_PROVIDERS = ['claude', 'codex', 'omp', 'pi', 'agy'] as const;
 
 export type AgentProvider = (typeof AGENT_PROVIDERS)[number];
 
@@ -45,6 +45,8 @@ export const ALL_AGENT_RUNTIMES = [
   'omp-fleet',
   'pi-sdk',
   'pi-pty',
+  'agy-sdk',
+  'agy-pty',
 ] as const;
 
 export type AgentRuntime = (typeof ALL_AGENT_RUNTIMES)[number];
@@ -82,6 +84,7 @@ export const WORKFLOW_RUN_STORABLE_RUNTIMES = [
   'omp-sdk',
   'omp-fleet',
   'pi-sdk',
+  'agy-sdk',
 ] as const;
 
 export type WorkflowRunStorableRuntime = (typeof WORKFLOW_RUN_STORABLE_RUNTIMES)[number];
@@ -110,6 +113,10 @@ export const WORKFLOW_LAUNCHABLE_RUNTIMES = [
   // NOT built yet is an interactive approval prompt — dontAsk remains the
   // only way to run write-tier steps unattended.
   'pi-sdk',
+  // Structured JSON-events lane for Antigravity (agy --output-format stream-json):
+  // per-step events, usage and tool results reach Cyboflow like the other SDK
+  // lanes. agy-pty stays excluded for the keystroke-TUI reason.
+  'agy-sdk',
 ] as const;
 
 export type WorkflowLaunchableRuntime = (typeof WORKFLOW_LAUNCHABLE_RUNTIMES)[number];
@@ -146,6 +153,7 @@ export const PROVIDER_DEFAULT_RUNTIME: Readonly<Record<AgentProvider, WorkflowLa
   codex: 'codex-sdk',
   omp: 'omp-sdk',
   pi: 'pi-sdk',
+  agy: 'agy-sdk',
 };
 
 export const DEFAULT_SESSION_AGENT_RUNTIME: SessionAgentRuntime = 'claude-sdk';
@@ -161,6 +169,8 @@ export const SESSION_AGENT_RUNTIMES = [
   'omp-fleet',
   'pi-sdk',
   'pi-pty',
+  'agy-sdk',
+  'agy-pty',
 ] as const;
 
 /** Human labels for the workflow-scoped runtime picker. Single source shared by
@@ -171,6 +181,7 @@ export const WORKFLOW_AGENT_RUNTIME_LABELS: Record<WorkflowLaunchableRuntime, st
   'codex-sdk': 'Codex SDK',
   'omp-sdk': 'OMP',
   'pi-sdk': 'Pi',
+  'agy-sdk': 'Antigravity',
 };
 
 /**
@@ -201,6 +212,8 @@ export const AGENT_RUNTIME_LABELS: Record<SessionAgentRuntime, string> = {
   'omp-fleet': 'OMP fleet',
   'pi-sdk': 'Pi',
   'pi-pty': 'Pi (CLI)',
+  'agy-sdk': 'Antigravity SDK',
+  'agy-pty': 'Antigravity (CLI)',
 };
 
 // ---------------------------------------------------------------------------
@@ -312,6 +325,13 @@ export const AGENT_PROVIDER_REGISTRY: Readonly<Record<AgentProvider, AgentProvid
     defaultEnabled: false,
     requiresAriaMode: true,
   },
+  // Antigravity (agy) — agent CLI platform.
+  agy: {
+    runtimePrefix: 'agy-',
+    sdkRuntime: 'agy-sdk',
+    defaultEnabled: false,
+    requiresAriaMode: false,
+  },
 };
 
 /**
@@ -326,6 +346,7 @@ export const AGENT_PROVIDER_LABELS: Record<AgentProvider, string> = {
   codex: 'Codex',
   omp: 'OMP',
   pi: 'Pi',
+  agy: 'Antigravity',
 };
 
 export const AGENT_PROVIDER_TABLE: AgentProviderTable<AgentProvider> = {

--- a/shared/types/onboarding.ts
+++ b/shared/types/onboarding.ts
@@ -102,6 +102,8 @@ export interface ProviderDetectionStates {
   // so the only observable is binary presence + a successful `--version` at
   // or above the floor. No 'loggedOut': nothing in main/ can see pi's auth.
   pi: 'detected' | 'unavailable';
+  // Antigravity (agy) CLI presence and version probe.
+  agy: 'detected' | 'unavailable';
 }
 
 /** The evidence each provider's probe returns alongside its state. */
@@ -119,6 +121,7 @@ export interface ProviderDetectionPayloads {
   // OMP's shape rather than declaring a byte-for-byte twin interface. If the
   // two ever diverge (e.g. pi gains an observable login), split it then.
   pi: OmpBinaryDetection;
+  agy: OmpBinaryDetection;
 }
 
 /**

--- a/shared/types/reasoningEffort.ts
+++ b/shared/types/reasoningEffort.ts
@@ -46,8 +46,11 @@ export type OmpEffortLevel = (typeof OMP_EFFORT_LEVELS)[number];
 export const PI_EFFORT_LEVELS = OMP_EFFORT_LEVELS;
 export type PiEffortLevel = OmpEffortLevel;
 
+export const AGY_EFFORT_LEVELS = ['low', 'medium', 'high'] as const;
+export type AgyEffortLevel = (typeof AGY_EFFORT_LEVELS)[number];
+
 /** The union of every effort value any provider accepts. */
-export type ReasoningEffort = ClaudeEffortLevel | CodexEffortLevel | OmpEffortLevel;
+export type ReasoningEffort = ClaudeEffortLevel | CodexEffortLevel | OmpEffortLevel | AgyEffortLevel;
 
 /**
  * Every effort value across every provider, de-duplicated, for the wire schema.
@@ -77,6 +80,7 @@ const CLAUDE_EFFORT_SET = new Set<string>(CLAUDE_EFFORT_LEVELS);
 const CODEX_EFFORT_SET = new Set<string>(CODEX_EFFORT_LEVELS);
 const OMP_EFFORT_SET = new Set<string>(OMP_EFFORT_LEVELS);
 const PI_EFFORT_SET = OMP_EFFORT_SET;
+const AGY_EFFORT_SET = new Set<string>(AGY_EFFORT_LEVELS);
 const ALL_EFFORT_SET = new Set<string>(ALL_EFFORT_LEVELS);
 
 /** Each provider's own ordered scale, low-to-high. Exhaustive by construction. */
@@ -85,6 +89,7 @@ const EFFORT_LEVELS_BY_PROVIDER: Readonly<Record<AgentProvider, readonly Reasoni
   codex: CODEX_EFFORT_LEVELS,
   omp: OMP_EFFORT_LEVELS,
   pi: PI_EFFORT_LEVELS,
+  agy: AGY_EFFORT_LEVELS,
 };
 
 const EFFORT_SETS_BY_PROVIDER: Readonly<Record<AgentProvider, ReadonlySet<string>>> = {
@@ -92,6 +97,7 @@ const EFFORT_SETS_BY_PROVIDER: Readonly<Record<AgentProvider, ReadonlySet<string
   codex: CODEX_EFFORT_SET,
   omp: OMP_EFFORT_SET,
   pi: PI_EFFORT_SET,
+  agy: AGY_EFFORT_SET,
 };
 
 /** Narrow an arbitrary value to a known effort level (provider-agnostic). */


### PR DESCRIPTION
## Overview
Adds native Antigravity (`agy`) agent provider support across Cyboflow, achieving parity with existing providers (`claude`, `codex`, `omp`, `pi`).

## Summary of Changes
- **Database Migration 130**: Widen SQLite `CHECK` constraints on `sessions`, `workflow_runs`, `workflow_variants`, and `agent_invocations` to accept `'agy'`, `'agy-sdk'`, and `'agy-pty'`. Fully preserves foreign key cascades and unique constraints.
- **Shared Runtime & Model Registry**:
  - Register `'agy'` across `AGENT_PROVIDERS`, `ALL_AGENT_RUNTIMES`, `SESSION_AGENT_RUNTIMES`, `WORKFLOW_RUN_STORABLE_RUNTIMES`, and `WORKFLOW_LAUNCHABLE_RUNTIMES`.
  - Add `AGENT_PROVIDER_REGISTRY.agy` (`runtimePrefix: 'agy-'`, `sdkRuntime: 'agy-sdk'`, `defaultEnabled: false`, `requiresAriaMode: false`).
  - Add `DEFAULT_AGY_MODEL = 'gemini-3.8-flash-high'` and catalog definitions; updated `isAgyModelFamily` and `normalizeAgentModelSelection`.
  - Widen `ReasoningEffort` to include `AgyEffortLevel = 'low' | 'medium' | 'high'`.
- **Backend Services (`main/src/services/panels/agy/`)**:
  - `AgyVersions`: Semver validation (`>=1.0.0`, tested `1.1.25`).
  - `AgyAvailability`: Probes `agy --version` on `$PATH`.
  - `AgyModelCatalog`: Probes and parses `agy models` output (`id\tlabel`).
  - `AgyPtyManager`: PTY runner using `-i=<prompt>`, `--effort`, `--continue`, `--mode accept-edits`, and `--dangerously-skip-permissions`.
  - `AgySdkManager`: Headless runner with `--output-format stream-json`, `--print-timeout 0`, multi-turn session continuity (`--continue` / `options.resumeSessionId`), silent `denied_actions` error synthesis, and resource lifecycle cleanup.
- **Wiring & Orchestrator**:
  - Integrated into `cliManagerFactory`, `substrateDispatchFacade`, `panelLane`, `createQuickSessionCore`, and IPC handlers.
  - Added `AGY_WORKFLOW_ENVELOPE` in `workflowPromptRenderer.ts` and updated orchestrator test fixtures.
- **Frontend UI & Settings**:
  - Add Antigravity provider detection, status badge, binary path, and toggle card in `IntegrationsSettings.tsx`.
  - Add substrate resolution and caveats in `SubstrateSelector.tsx`.
  - Wire follow-up turn dispatch in `useClaudePanel.ts`.
  - Update `ModelSelector`, `WorkflowPicker`, `VariantEditorModal`, `ABTestLaunchModal`, `SessionSettings`, and `runTypeOverrides`.

## Verification & Quirk Audits
- Handled live `agy 1.1.26` CLI quirks:
  - PTY `-i` syntax eating flags (formatted as `-i=<prompt>` or bare `-i`).
  - Passing `--print-timeout 0` to prevent premature timeout during long agentic runs.
  - Headless `denied_actions` error synthesis when zero-confirmation execution encounters permissions.
  - Model family catalog preservation for cross-provider models exposed via `agy models`.
- `pnpm run -r typecheck` passes with 0 errors across `shared`, `main`, and `frontend`.
- All backend (193/193) and frontend (150/150) affected test suites passing.